### PR TITLE
Add Storybook viewport addon and defaults

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,6 +9,7 @@ const config: StorybookConfig = {
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-actions',
+    '@storybook/addon-viewport',
   ],
   docs: {
     autodocs: true

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 // Load your globals so Tailwind + tokens apply inside SB
 import '../styles/globals.css';
@@ -12,7 +13,11 @@ const preview: Preview = {
         date: /Date$/
       }
     },
-    layout: 'padded'
+    layout: 'padded',
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphone6'
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- register `@storybook/addon-viewport` in Storybook config
- set up default viewport options using Storybook's preset list

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: tsx: not found)*
- `npm run storybook` *(fails: sh: 1: storybook: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f5928f2c8321b14957b94a7d8bcb