### PR TITLE
Add offline fallback page

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -69,15 +69,18 @@ const baseConfig = {
 };
 
 // --- PWA wrapper (unchanged except for baseConfig.images above) ---
-export default withPWA({
-  dest: 'public',
-  disable: process.env.NODE_ENV === 'development',
-  register: true,
-  skipWaiting: true,
-  buildExcludes: [
-    /.*\.map$/,
-    /middleware-manifest\.json$/,
-    /server\/middleware-manifest\.json$/,
-  ],
-  publicExcludes: ['**/*.map'],
-})(baseConfig);
+  export default withPWA({
+    dest: 'public',
+    disable: process.env.NODE_ENV === 'development',
+    register: true,
+    skipWaiting: true,
+    buildExcludes: [
+      /.*\.map$/,
+      /middleware-manifest\.json$/,
+      /server\/middleware-manifest\.json$/,
+    ],
+    publicExcludes: ['**/*.map'],
+    fallbacks: {
+      document: '/_offline',
+    },
+  })(baseConfig);

--- a/pages/_offline.tsx
+++ b/pages/_offline.tsx
@@ -1,0 +1,10 @@
+export default function Offline() {
+  return (
+    <main className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold">You're offline</h1>
+        <p className="mt-2">Please check your internet connection.</p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add offline fallback page
- configure PWA plugin to use custom offline page

## Testing
- `npm test` *(fails: tsx not found)*
- `npm ci` *(fails: chromedriver download 403)*
- `npm run build` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f594a4408321b6fccd5384460535