### PR TITLE
feat: handle report errors

### DIFF
--- a/pages/institutions/[orgId]/reports.tsx
+++ b/pages/institutions/[orgId]/reports.tsx
@@ -34,7 +34,8 @@ export const getServerSideProps: GetServerSideProps<ReportsPageProps> = async (c
   return { props: { ok: true, org, baseline, seedData } }
 }
 
-export default function OrgReportsPage({ ok, error, org, baseline, seedData }: ReportsPageProps){
+export default function OrgReportsPage(props: ReportsPageProps){
+  const { ok, org, baseline, seedData } = props
   const [range, setRange] = React.useState<'8w'|'12w'>('8w')
 
   // Group by week -> pivot per module for charts
@@ -60,12 +61,24 @@ export default function OrgReportsPage({ ok, error, org, baseline, seedData }: R
     }))
   }, [seedData, range, ok, org])
 
-  if (!ok || !org){
+  if (!org){
     return (
       <main className="mx-auto max-w-3xl px-4 py-12">
         <div className="rounded-2xl border border-border bg-card p-8 text-center">
           <h1 className="font-slab text-h2">Organization not found</h1>
           <p className="mt-2 text-mutedText">It may have been removed or you lack access.</p>
+          <Link href="/institutions" className="mt-6 inline-flex rounded-xl bg-primary px-4 py-2 text-primary-foreground">Back to Institutions</Link>
+        </div>
+      </main>
+    )
+  }
+
+  if (!ok){
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-12">
+        <div className="rounded-2xl border border-border bg-card p-8 text-center">
+          <h1 className="font-slab text-h2">Error</h1>
+          <p className="mt-2 text-mutedText">{props.error}</p>
           <Link href="/institutions" className="mt-6 inline-flex rounded-xl bg-primary px-4 py-2 text-primary-foreground">Back to Institutions</Link>
         </div>
       </main>


### PR DESCRIPTION
## Summary
- remove unused `error` param in reports page
- show org-not-found and explicit error messages in reports page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c80f22550c8321b9010c999d77f299