### PR TITLE
Guard recorder auto-start with ref and tidy effect

### DIFF
--- a/components/speaking/Recorder.tsx
+++ b/components/speaking/Recorder.tsx
@@ -4,6 +4,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from 'react';
 import { useRecorder } from '@/hooks/useRecorder';
 
@@ -56,15 +57,15 @@ export const Recorder = forwardRef<RecorderHandle, RecorderProps>(
       reset: () => reset(),
     }));
 
+    const startedRef = useRef(false);
+
     // auto-start for exam flow
     useEffect(() => {
-      let kicked = false;
-      if (autoStart && !kicked && !isRecording && durationSec === 0) {
-        kicked = true;
+      if (autoStart && !startedRef.current && !isRecording && durationSec === 0) {
+        startedRef.current = true;
         start().catch((e) => onError?.(String(e)));
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [autoStart]);
+    }, [autoStart, isRecording, durationSec, start, onError]);
 
     // hard max duration
     useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure speaking recorder auto-start only runs once via `useRef`
- depend on `autoStart`, `isRecording`, and `durationSec` instead of `eslint-disable`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80f2c715883219ef633b75b5ada0a