### PR TITLE
refactor: simplify new item button link

### DIFF
--- a/pages/content/studio/index.tsx
+++ b/pages/content/studio/index.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps: GetServerSideProps<StudioIndexProps> = async (c
 
 export default function StudioIndexPage(props: StudioIndexProps) {
   const [q, setQ] = React.useState('');
-  
+
   const items = props.ok ? props.items : [];
   const filtered = React.useMemo(() => {
     const needle = q.toLowerCase().trim();
@@ -64,11 +64,13 @@ export default function StudioIndexPage(props: StudioIndexProps) {
         <section className="mx-auto max-w-7xl px-4 py-6">
           <div className="flex items-center justify-between gap-3">
             <h1 className="font-slab text-h2 md:text-h1">Content Studio</h1>
-            <Link href="/content/studio/new" className="inline-flex">
-              <Button variant="primary" className="bg-primary text-primary-foreground">
-                New Item
-              </Button>
-            </Link>
+            <Button
+              href="/content/studio/new"
+              variant="primary"
+              className="bg-primary text-primary-foreground"
+            >
+              New Item
+            </Button>
           </div>
           <p className="mt-1 text-small text-mutedText">
             Create and manage IELTS practice content for all modules.
@@ -107,9 +109,7 @@ export default function StudioIndexPage(props: StudioIndexProps) {
                       ? 'bg-goldenYellow/15 text-goldenYellow'
                       : 'bg-sunsetRed/15 text-sunsetRed';
 
-                const when = it.updated_at
-                  ? new Date(it.updated_at).toLocaleString()
-                  : '—';
+                const when = it.updated_at ? new Date(it.updated_at).toLocaleString() : '—';
 
                 return (
                   <Link
@@ -119,7 +119,9 @@ export default function StudioIndexPage(props: StudioIndexProps) {
                   >
                     <div className="flex items-center justify-between gap-3">
                       <div className="line-clamp-1 font-medium">{it.title ?? 'Untitled'}</div>
-                      <span className={cls('rounded-lg px-2 py-1 text-caption', statusClass)}>{it.status}</span>
+                      <span className={cls('rounded-lg px-2 py-1 text-caption', statusClass)}>
+                        {it.status}
+                      </span>
                     </div>
                     <div className="mt-1 text-small text-mutedText">
                       {(it.module ?? '—').toString().toUpperCase()} · Updated {when}


### PR DESCRIPTION
## Summary
- remove outer Link from Content Studio new-item button
- use Button's href prop for navigation

## Testing
- `npm test`
- `npm run lint`
- `npx tsx link-test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c80fa4939c8321bf0ddc7cdbba9ca2