### PR TITLE
Handle initial Supabase session event in set-session API

### DIFF
--- a/pages/api/auth/set-session.ts
+++ b/pages/api/auth/set-session.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { event, session } = req.body as { event: string; session: any };
 
   try {
-    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION') {
       // writes sb-access-token / sb-refresh-token cookies
       await supabase.auth.setSession(session);
       return res.status(200).json({ ok: true });


### PR DESCRIPTION
## Summary
- call `supabase.auth.setSession` when the auth webhook notifies of an `INITIAL_SESSION` event
- preserve the existing sign-out handling logic

## Testing
- npm run lint *(fails: `next` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84b3d6c5c8321a8f8fce587889ec4