### PR TITLE
Handle INITIAL_SESSION event in auth API

### DIFF
--- a/_tests_/set-session.test.ts
+++ b/_tests_/set-session.test.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from 'node:assert';
+
+const calls = {
+  setSession: [] as any[],
+  signOut: 0,
+};
+
+require.cache[require.resolve('@supabase/auth-helpers-nextjs')] = {
+  exports: {
+    createPagesServerClient: () => ({
+      auth: {
+        setSession: async (session: any) => {
+          calls.setSession.push(session);
+        },
+        signOut: async () => {
+          calls.signOut += 1;
+        },
+      },
+    }),
+  },
+};
+
+const handler = require('../pages/api/auth/set-session').default;
+
+function createRes() {
+  return {
+    statusCode: 0,
+    body: undefined as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data: any) {
+      this.body = data;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+}
+
+(async () => {
+  const session = { access_token: 'tok', refresh_token: 'ref' };
+  const resInitial = createRes();
+  await handler(
+    { method: 'POST', body: { event: 'INITIAL_SESSION', session } } as any,
+    resInitial as any,
+  );
+  assert.equal(resInitial.statusCode, 200);
+  assert.equal(resInitial.body.ok, true);
+  assert.equal(calls.setSession.length, 1);
+  assert.equal(calls.setSession[0], session);
+
+  const resSignedOut = createRes();
+  await handler(
+    { method: 'POST', body: { event: 'SIGNED_OUT', session: null } } as any,
+    resSignedOut as any,
+  );
+  assert.equal(resSignedOut.statusCode, 200);
+  assert.equal(resSignedOut.body.ok, true);
+  assert.equal(calls.signOut, 1);
+
+  console.log('set-session events tested');
+})();

--- a/pages/api/auth/set-session.ts
+++ b/pages/api/auth/set-session.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { event, session } = req.body as { event: string; session: any };
 
   try {
-    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION') {
       // writes sb-access-token / sb-refresh-token cookies
       await supabase.auth.setSession(session);
       return res.status(200).json({ ok: true });


### PR DESCRIPTION
## Summary
- call `supabase.auth.setSession` when the auth webhook reports an `INITIAL_SESSION`
- keep the existing signed out behavior and add a regression test covering both paths

## Testing
- npx tsx _tests_/set-session.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68c84cb309608321b40faca018d820ad