### PR TITLE
Revamp header navigation styling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,33 +67,37 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
     <header
       role="banner"
       className={[
-        'relative z-50 transition-all duration-300',
-        solidHeader ? 'bg-background/95 border-b border-border shadow-sm' : 'header-glass',
+        'relative sticky top-0 z-50 w-full border-b transition-[background,box-shadow,border-color] duration-300',
+        'supports-[backdrop-filter]:backdrop-blur-xl supports-[backdrop-filter]:bg-background/70',
+        solidHeader
+          ? 'bg-background/95 border-border shadow-[0_16px_45px_-30px_rgba(67,97,238,0.55)] dark:shadow-[0_16px_45px_-30px_rgba(128,255,219,0.35)]'
+          : 'header-glass border-border/40 dark:border-vibrantPurple/30',
         'before:content-[""] before:absolute before:inset-x-0 before:bottom-0 before:h-[2px]',
-        'before:bg-gradient-to-r before:from-vibrantPurple/70 before:via-electricBlue/70 before:to-neonGreen/70',
-        solidHeader ? 'shadow-glow' : '',
+        'before:bg-gradient-to-r before:from-vibrantPurple/60 before:via-electricBlue/60 before:to-neonGreen/60',
       ].join(' ')}
     >
       <Container>
-        <div className="relative flex items-center justify-between py-3 md:py-4">
+        <div className="relative flex items-center justify-between py-2.5 md:py-3.5">
           {/* Brand */}
           <Link
             href={user?.id ? '/dashboard' : '/'}
-            className="flex items-center gap-3 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-ds"
+            className="group flex items-center gap-3 rounded-ds focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             aria-label="Go to home"
           >
-            <span className="relative inline-flex items-center justify-center rounded-xl bg-card p-1.5 shadow-sm ring-1 ring-border">
-              <Image
-                src="/brand/logo.png"
-                alt="GramorX logo"
-                width="44"
-                height="44"
-                className="h-10 w-10 md:h-11 md:w-11 rounded-lg object-contain"
-                priority
-              />
-              <span className="absolute -right-1 -bottom-1 h-2.5 w-2.5 rounded-full bg-accent/90 ring-2 ring-card" />
+            <span className="relative inline-flex items-center justify-center rounded-xl bg-card/90 shadow-sm ring-1 ring-border transition group-hover:ring-primary/40 dark:bg-dark/70">
+              <span className="relative h-9 w-9 overflow-hidden rounded-lg md:h-10 md:w-10">
+                <Image
+                  src="/brand/logo.png"
+                  alt="GramorX logo"
+                  width={44}
+                  height={44}
+                  className="h-full w-full object-contain"
+                  priority
+                />
+              </span>
+              <span aria-hidden className="absolute -right-1 -bottom-1 h-2.5 w-2.5 rounded-full bg-accent/90 ring-2 ring-card" />
             </span>
-            <p className="font-slab font-bold text-h2 md:text-h1 leading-none" role="heading" aria-level={1}>
+            <p className="leading-none font-slab text-h2 font-bold md:text-h1" role="heading" aria-level={1}>
               <span className="text-gradient-primary transition-opacity group-hover:opacity-90">
                 GramorX
               </span>

--- a/components/navigation/DesktopNav.tsx
+++ b/components/navigation/DesktopNav.tsx
@@ -8,7 +8,7 @@ import { NotificationBell } from '@/components/design-system/NotificationBell';
 import { ModuleMenu } from './ModuleMenu';
 import { FireStreak } from './FireStreak';
 import { IconOnlyThemeToggle } from './IconOnlyThemeToggle';
-import { NAV } from './constants';
+import { NAV, USER_MENU_LINKS } from './constants';
 
 interface UserInfo {
   id: string | null;
@@ -47,35 +47,38 @@ export function DesktopNav({
   const canSeePartners = role === 'partner' || role === 'admin';
   const canSeeAdmin = role === 'admin' && showAdmin;
 
+  const navItemClass =
+    'nav-pill text-small font-medium text-foreground/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
   return (
     <nav className={className} aria-label="Primary" {...rest}>
       <ul className="relative flex items-center gap-2">
         {user.id && (
           <li>
-            <NavLink href="/dashboard" className="px-3 py-2 rounded-lg hover:bg-muted" label="Dashboard" />
+            <NavLink href="/dashboard" className={navItemClass} label="Dashboard" />
           </li>
         )}
 
         <ModuleMenu open={openModules} setOpen={setOpenModules} modulesRef={modulesRef} />
 
         <li>
-          <NavLink href="/learning" className="px-3 py-2 rounded-lg hover:bg-muted" label="Learning" />
+          <NavLink href="/learning" className={navItemClass} label="Learning" />
         </li>
 
         {NAV.map((n) => (
           <li key={n.href}>
-            <NavLink href={n.href} className="px-3 py-2 rounded-lg hover:bg-muted" label={n.label} />
+            <NavLink href={n.href} className={navItemClass} label={n.label} />
           </li>
         ))}
 
         {canSeePartners && (
           <li>
-            <NavLink href="/partners" className="px-3 py-2 rounded-lg hover:bg-muted" label="Partners" />
+            <NavLink href="/partners" className={navItemClass} label="Partners" />
           </li>
         )}
         {canSeeAdmin && (
           <li>
-            <NavLink href="/admin/partners" className="px-3 py-2 rounded-lg hover:bg-muted" label="Admin" />
+            <NavLink href="/admin/partners" className={navItemClass} label="Admin" />
           </li>
         )}
 
@@ -98,17 +101,11 @@ export function DesktopNav({
                 email={user.email}
                 avatarUrl={user.avatarUrl}
                 onSignOut={signOut}
-                /** FIX: UserMenu expects `items`, not `links` */
-                items={[
-                  {
-                    href: '/account/billing', label: 'Billing',
-                    id: ''
-                  },
-                  {
-                    href: '/account/referrals', label: 'Referrals',
-                    id: ''
-                  },
-                ]}
+                items={USER_MENU_LINKS.map((link) => ({
+                  id: link.id,
+                  label: link.label,
+                  href: link.href,
+                }))}
               />
             ) : (
               <Link

--- a/components/navigation/MobileNav.tsx
+++ b/components/navigation/MobileNav.tsx
@@ -8,7 +8,7 @@ import { NavLink } from '@/components/design-system/NavLink';
 import { NotificationBell } from '@/components/design-system/NotificationBell';
 import { FireStreak } from './FireStreak';
 import { IconOnlyThemeToggle } from './IconOnlyThemeToggle';
-import { MODULE_LINKS, NAV } from './constants';
+import { MODULE_LINKS, NAV, USER_MENU_LINKS } from './constants';
 
 interface UserInfo {
   id: string | null;
@@ -47,6 +47,9 @@ export function MobileNav({
 }: MobileNavProps) {
   const canSeePartners = role === 'partner' || role === 'admin';
   const canSeeAdmin = role === 'admin' && showAdmin;
+  const mobileItemClass = 'block rounded-lg px-3 py-3 hover:bg-muted';
+
+  const closeMenu = React.useCallback(() => setMobileOpen(false), [setMobileOpen]);
 
   const overlay = (
     <div
@@ -101,7 +104,8 @@ export function MobileNav({
               <li>
                 <NavLink
                   href="/dashboard"
-                  className="block rounded-lg px-3 py-3 hover:bg-muted"
+                  className={mobileItemClass}
+                  onClick={closeMenu}
                 >
                   Dashboard
                 </NavLink>
@@ -111,7 +115,8 @@ export function MobileNav({
             <li>
               <NavLink
                 href="/learning"
-                className="block rounded-lg px-3 py-3 hover:bg-muted"
+                className={mobileItemClass}
+                onClick={closeMenu}
               >
                 Learning
               </NavLink>
@@ -144,6 +149,10 @@ export function MobileNav({
                       <NavLink
                         href={m.href}
                         className="block px-4 py-3 hover:bg-muted"
+                        onClick={() => {
+                          setMobileModulesOpen(false);
+                          closeMenu();
+                        }}
                       >
                         {m.label}
                       </NavLink>
@@ -157,7 +166,8 @@ export function MobileNav({
               <li key={n.href}>
                 <NavLink
                   href={n.href}
-                  className="block rounded-lg px-3 py-3 hover:bg-muted"
+                  className={mobileItemClass}
+                  onClick={closeMenu}
                 >
                   {n.label}
                 </NavLink>
@@ -168,7 +178,8 @@ export function MobileNav({
               <li>
                 <NavLink
                   href="/partners"
-                  className="block rounded-lg px-3 py-3 hover:bg-muted"
+                  className={mobileItemClass}
+                  onClick={closeMenu}
                 >
                   Partners
                 </NavLink>
@@ -178,33 +189,22 @@ export function MobileNav({
               <li>
                 <NavLink
                   href="/admin/partners"
-                  className="block rounded-lg px-3 py-3 hover:bg-muted"
+                  className={mobileItemClass}
+                  onClick={closeMenu}
                 >
                   Admin
                 </NavLink>
               </li>
             )}
 
-            {user.id && (
-              <>
-                <li>
-                  <NavLink
-                    href="/account/billing"
-                    className="block rounded-lg px-3 py-3 hover:bg-muted"
-                  >
-                    Billing
+            {user.id &&
+              USER_MENU_LINKS.map((item) => (
+                <li key={item.id}>
+                  <NavLink href={item.href} className={mobileItemClass} onClick={closeMenu}>
+                    {item.label}
                   </NavLink>
                 </li>
-                <li>
-                  <NavLink
-                    href="/account/referrals"
-                    className="block rounded-lg px-3 py-3 hover:bg-muted"
-                  >
-                    Referrals
-                  </NavLink>
-                </li>
-              </>
-            )}
+              ))}
           </ul>
         </nav>
       </Container>

--- a/components/navigation/ModuleMenu.tsx
+++ b/components/navigation/ModuleMenu.tsx
@@ -91,7 +91,7 @@ export function ModuleMenu({ open, setOpen, modulesRef }: ModuleMenuProps) {
         aria-expanded={open}
         aria-haspopup="menu"
         aria-controls={MENU_ID}
-        className="inline-flex items-center gap-2 rounded-lg px-3 py-2 hover:bg-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        className={`nav-pill gap-2 text-small font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 focus-visible:ring-offset-background ${open ? 'is-active' : ''}`}
       >
         <span>Modules</span>
         <svg

--- a/components/navigation/constants.tsx
+++ b/components/navigation/constants.tsx
@@ -33,3 +33,11 @@ export const NAV: ReadonlyArray<{ href: string; label: string }> = [
   { href: '/predictor', label: 'Band Predictor' },
   { href: '/pricing',   label: 'Pricing' },
 ];
+
+export const USER_MENU_LINKS: ReadonlyArray<{ id: string; href: string; label: string }> = [
+  { id: 'account',      href: '/account',           label: 'Account' },
+  { id: 'settings',     href: '/settings',          label: 'Settings' },
+  { id: 'notifications', href: '/notifications',    label: 'Notifications' },
+  { id: 'billing',      href: '/account/billing',   label: 'Billing' },
+  { id: 'referrals',    href: '/account/referrals', label: 'Referrals' },
+];


### PR DESCRIPTION
## Summary
- refine the main header shell with sticky glass styling and a refreshed logo badge
- switch desktop and module navigation triggers to shared nav-pill styling and expose consistent account menu links
- update the mobile navigation to close on selection and surface the same account links as desktop via new constants

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c849be85e88321ac332877af3f1e63