### PR TITLE
Fix Supabase client usage during sign out

### DIFF
--- a/lib/auth/signOut.ts
+++ b/lib/auth/signOut.ts
@@ -2,7 +2,7 @@
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 
 export async function signOutAndRedirect(router?: { replace: (p: string) => any }) {
-  const supabase = supabaseBrowser();
+  const supabase = supabaseBrowser;
   // Clear client session first (local)
   try { await supabase.auth.signOut({ scope: 'local' } as any); } catch {}
   // Clear server cookie (Next.js auth helpers) if present


### PR DESCRIPTION
## Summary
- reuse the shared Supabase browser client instance during sign out to avoid invoking it like a factory

## Testing
- `npx tsc --noEmit` *(fails: existing repository-wide type errors referencing missing Node types and exports)*
- `npx tsc --noEmit -p tsconfig.app.json` *(fails: existing repository-wide type errors referencing missing React/Next types and component props)*

------
https://chatgpt.com/codex/tasks/task_e_68daf54a336883219c5e46ad90bfe5a3