### PR TITLE
Cache Supabase browser client globally

### DIFF
--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -5,14 +5,22 @@ import { Database } from '@/types/supabase'; // Adjust if you have typed DB
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-export const supabaseBrowser = createClient<Database>(url, anon, {
-  auth: {
-    flowType: 'pkce', // Better for browser auth
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
-    persistSession: true,
-  },
-});
+const globalForSupabase = globalThis as typeof globalThis & {
+  __supabaseBrowser?: SupabaseClient<Database>;
+};
+
+if (!globalForSupabase.__supabaseBrowser) {
+  globalForSupabase.__supabaseBrowser = createClient<Database>(url, anon, {
+    auth: {
+      flowType: 'pkce', // Better for browser auth
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      persistSession: true,
+    },
+  });
+}
+
+export const supabaseBrowser = globalForSupabase.__supabaseBrowser;
 
 export const authHeaders = async (extra: Record<string, string> = {}) => {
   const { data: { session } } = await supabaseBrowser.auth.getSession();


### PR DESCRIPTION
## Summary
- cache the Supabase browser client on a global singleton so HMR reuse prevents duplicate GoTrue clients
- reuse the cached client instance when building auth headers

## Testing
- npm run lint *(fails: next not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daf54f09f0832193b38b3837c8cf67