### PR TITLE
Handle missing Supabase token in browser auth helper

### DIFF
--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -16,5 +16,11 @@ export const supabaseBrowser = createClient<Database>(url, anon, {
 
 export const authHeaders = async (extra: Record<string, string> = {}) => {
   const { data: { session } } = await supabaseBrowser.auth.getSession();
-  return { ...extra, Authorization: `Bearer ${session?.access_token}` };
+  const accessToken = session?.access_token;
+
+  if (!accessToken) {
+    return { ...extra };
+  }
+
+  return { ...extra, Authorization: `Bearer ${accessToken}` };
 };

--- a/tests/lib/supabaseBrowser.test.ts
+++ b/tests/lib/supabaseBrowser.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { authHeaders, supabaseBrowser } from '@/lib/supabaseBrowser';
+
+test('authHeaders omits Authorization when no session access token', async () => {
+  const originalGetSession = supabaseBrowser.auth.getSession;
+
+  (supabaseBrowser.auth.getSession as typeof originalGetSession) = async () =>
+    ({
+      data: { session: null },
+      error: null,
+    } as any);
+
+  try {
+    const headers = await authHeaders({ 'X-Test': '1' });
+    assert.deepStrictEqual(headers, { 'X-Test': '1' });
+  } finally {
+    (supabaseBrowser.auth.getSession as typeof originalGetSession) = originalGetSession;
+  }
+});
+
+test('authHeaders includes Authorization when access token is present', async () => {
+  const originalGetSession = supabaseBrowser.auth.getSession;
+
+  (supabaseBrowser.auth.getSession as typeof originalGetSession) = async () =>
+    ({
+      data: { session: { access_token: 'token-123' } },
+      error: null,
+    } as any);
+
+  try {
+    const headers = await authHeaders({ Accept: 'application/json' });
+    assert.deepStrictEqual(headers, {
+      Accept: 'application/json',
+      Authorization: 'Bearer token-123',
+    });
+  } finally {
+    (supabaseBrowser.auth.getSession as typeof originalGetSession) = originalGetSession;
+  }
+});


### PR DESCRIPTION
## Summary
- avoid attaching a Bearer token when the Supabase session has no access token while still merging caller-provided headers
- add node:test coverage to confirm the helper includes or omits Authorization based on session state

## Testing
- npm test *(fails: existing tests in tests/api/auth/login-event.test.ts expect login telemetry to be enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68daf550d1ec83219dc6c58ee1f311b4