### PR TITLE
Refactor Supabase browser client reuse

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,9 +1,2 @@
-import { env } from "@/lib/env";
-import { createClient } from '@supabase/supabase-js';
-import type { Database } from '@/types/database';
-
-const url = env.NEXT_PUBLIC_SUPABASE_URL;
-const anon = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-// Singleton client for browser context
-export const supabase = createClient<Database>(url, anon);
+export { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+export type { Database } from '@/types/supabase';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -66,3 +66,5 @@ export interface DBSchema {
 
 export type TableName = keyof DBSchema;
 export type RowOf<T extends TableName> = DBSchema[T];
+
+export type Database = DBSchema;


### PR DESCRIPTION
## Summary
- update `lib/supabaseClient` to re-export the singleton browser Supabase client
- expose the shared `Database` type from `types/supabase` so both client modules rely on the same typings

## Testing
- not run (environment only)


------
https://chatgpt.com/codex/tasks/task_e_68daf5ea2e708321a08f26092a62c7af