### PR TITLE
Fix PremiumExamPage default export

### DIFF
--- a/pages/premium/PremiumExamPage.tsx
+++ b/pages/premium/PremiumExamPage.tsx
@@ -4,7 +4,7 @@ import { ExamShell } from '../../premium-ui/exam/ExamShell';
 import { Scratchpad } from '../../premium-ui/exam/Scratchpad';
 import { MediaDock } from '../../premium-ui/exam/MediaDock';
 
-export function PremiumExamPage() {
+export default function PremiumExamPage() {
   const handleAccessGranted = () => {
     // Track analytics, update user state, etc.
     console.log('Premium exam room access granted');


### PR DESCRIPTION
## Summary
- update the premium exam page to use a default export so the route meets Next.js requirements

## Testing
- npm run build *(fails: `tailwindcss: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68daf9c318a88321aa20ca5047c8c0b9