### PR TITLE
Fix locale helper imports for language settings

### DIFF
--- a/components/common/LocaleSwitcher.tsx
+++ b/components/common/LocaleSwitcher.tsx
@@ -1,6 +1,6 @@
 // components/common/LocaleSwitcher.tsx
 import React from 'react';
-import { persistLocale as setLocale, getLocale, type Locale } from '@/lib/locale';
+import { setLocale, getLocale, type Locale } from '@/lib/locale';
 import { loadTranslations } from "@/lib/i18n";
 
 type Props = {

--- a/pages/settings/language.tsx
+++ b/pages/settings/language.tsx
@@ -3,13 +3,13 @@ import * as React from "react";
 import Head from "next/head";
 import { Container } from "@/components/design-system/Container";
 import LocaleSwitcher from "@/components/common/LocaleSwitcher";
-import { _detectLocale as detectLocale, persistLocale as setLocale } from "@/lib/locale";
+import { detectLocale, setLocale } from "@/lib/locale";
 import { loadTranslations, t, getLocale } from "@/lib/i18n";
 import type { SupportedLocale } from "@/lib/i18n/config";
 import { supabaseBrowser } from "@/lib/supabaseBrowser";
 
 export default function LanguageSettingsPage() {
-  const [locale, setLocale] = React.useState<SupportedLocale>("en");
+  const [locale, setLocaleState] = React.useState<SupportedLocale>("en");
   const [busy, setBusy] = React.useState(false);
   const [saved, setSaved] = React.useState<null | "ok" | "err">(null);
   const [userId, setUserId] = React.useState<string | null>(null);
@@ -24,7 +24,7 @@ export default function LanguageSettingsPage() {
 
       const initial = safeDetect ? safeDetect() : getLocale();
       await loadTranslations(initial);
-      setLocale(getLocale());
+      setLocaleState(getLocale());
 
       const { data } = await supabaseBrowser.auth.getSession();
       setUserId(data.session?.user?.id ?? null);
@@ -37,7 +37,7 @@ export default function LanguageSettingsPage() {
     try {
       await loadTranslations(next);
       setLocale(next);
-      setLocale(next);
+      setLocaleState(next);
 
       // Persist to profile if logged in
       if (userId) {


### PR DESCRIPTION
## Summary
- use the actual locale storage helper export in the locale switcher component
- update the settings page to import detectLocale/setLocale correctly and avoid state setter collisions

## Testing
- npm run build *(fails: tailwindcss CLI missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daf9c3ac188321b747a0b3f3800157