### PR TITLE
Fix locale switcher supported locale validation

### DIFF
--- a/components/common/LocaleSwitcher.tsx
+++ b/components/common/LocaleSwitcher.tsx
@@ -1,7 +1,18 @@
 // components/common/LocaleSwitcher.tsx
 import React from 'react';
 import { persistLocale as setLocale, getLocale, type Locale } from '@/lib/locale';
-import { loadTranslations } from "@/lib/i18n";
+import { loadTranslations } from '@/lib/i18n';
+import { i18nConfig, type SupportedLocale } from '@/lib/i18n/config';
+
+const supportedLocales = new Set<SupportedLocale>(i18nConfig.locales);
+
+export function toSupportedLocale(locale: Locale): SupportedLocale {
+  if (supportedLocales.has(locale as SupportedLocale)) {
+    return locale as SupportedLocale;
+  }
+
+  return i18nConfig.defaultLocale;
+}
 
 type Props = {
   value?: Locale;
@@ -22,9 +33,10 @@ export default function LocaleSwitcher({ value, onChanged, options }: Props) {
 
   async function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const next = e.target.value as Locale;
+    const supportedLocale = toSupportedLocale(next);
     try {
       setBusy(true);
-      await loadTranslations(toSupported(next));
+      await loadTranslations(supportedLocale);
       setLocale(next);
       setLocal(next);
       onChanged?.(next);

--- a/tests/lib/locale-switcher.test.ts
+++ b/tests/lib/locale-switcher.test.ts
@@ -1,0 +1,12 @@
+import { strict as assert } from 'node:assert';
+
+import { toSupportedLocale } from '../../components/common/LocaleSwitcher';
+
+assert.equal(toSupportedLocale('en'), 'en');
+assert.equal(toSupportedLocale('ur'), 'ur');
+
+// Unsupported locales should fall back to the default supported locale.
+assert.equal(toSupportedLocale('ar'), 'en');
+assert.equal(toSupportedLocale('fr'), 'en');
+
+console.log('Locale switcher helper validates supported locales');


### PR DESCRIPTION
## Summary
- ensure the locale switcher validates selections against the supported i18n locales before loading translations
- add a unit test covering the supported-locale helper fallback behaviour

## Testing
- `npm test -- --runInBand` *(fails: tsx command missing because npm install cannot complete; chromedriver download is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daf9c5b3a08321a863d1f188b2305c