### PR TITLE
feat: allow overriding locale switcher label

### DIFF
--- a/components/common/LocaleSwitcher.tsx
+++ b/components/common/LocaleSwitcher.tsx
@@ -7,9 +7,10 @@ type Props = {
   value?: Locale;
   onChanged?: (next: Locale) => void;
   options?: { value: Locale; label: string }[];
+  label?: string;
 };
 
-export default function LocaleSwitcher({ value, onChanged, options }: Props) {
+export default function LocaleSwitcher({ value, onChanged, options, label }: Props) {
   const [busy, setBusy] = React.useState(false);
   const [local, setLocal] = React.useState<Locale>(value ?? getLocale('en'));
 
@@ -35,7 +36,7 @@ export default function LocaleSwitcher({ value, onChanged, options }: Props) {
 
   return (
     <label className="inline-flex items-center gap-2 text-small">
-      <span className="text-mutedText">Language</span>
+      <span className="text-mutedText">{label ?? "Language"}</span>
       <select
         className="rounded-ds border border-border bg-card px-3 py-2 text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         value={local}


### PR DESCRIPTION
## Summary
- allow LocaleSwitcher to accept an optional label override
- render the provided label or fall back to the default language text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf9c7f0208321916af37e1c2935d2