### PR TITLE
Harden Supabase session bridge fallback

### DIFF
--- a/pages/api/auth/set-session.ts
+++ b/pages/api/auth/set-session.ts
@@ -2,6 +2,104 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
 
+type SupabaseSession = {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  expires_at?: number;
+};
+
+type CookieOptions = {
+  httpOnly?: boolean;
+  sameSite?: 'lax' | 'strict' | 'none';
+  secure?: boolean;
+  path?: string;
+  maxAge?: number;
+  expires?: Date;
+};
+
+function serializeCookie(name: string, value: string, options: CookieOptions = {}) {
+  const segments = [`${name}=${encodeURIComponent(value)}`];
+  if (options.path) segments.push(`Path=${options.path}`);
+  if (typeof options.maxAge === 'number') segments.push(`Max-Age=${Math.floor(options.maxAge)}`);
+  if (options.expires) segments.push(`Expires=${options.expires.toUTCString()}`);
+  if (options.httpOnly) segments.push('HttpOnly');
+  if (options.secure) segments.push('Secure');
+  if (options.sameSite) {
+    const normalized = options.sameSite.charAt(0).toUpperCase() + options.sameSite.slice(1);
+    segments.push(`SameSite=${normalized}`);
+  }
+  return segments.join('; ');
+}
+
+function appendSetCookie(res: NextApiResponse, value: string) {
+  const existing = res.getHeader('Set-Cookie');
+  if (!existing) {
+    res.setHeader('Set-Cookie', value);
+    return;
+  }
+
+  if (Array.isArray(existing)) {
+    res.setHeader('Set-Cookie', [...existing, value]);
+    return;
+  }
+
+  res.setHeader('Set-Cookie', [existing as string, value]);
+}
+
+function writeSessionCookies(res: NextApiResponse, session: SupabaseSession | null | undefined) {
+  if (!session || !session.access_token) return false;
+
+  const secure = process.env.NODE_ENV === 'production';
+  const baseOptions = {
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    secure,
+    path: '/',
+  };
+
+  const maxAge = typeof session.expires_in === 'number' ? session.expires_in : undefined;
+  appendSetCookie(
+    res,
+    serializeCookie('sb-access-token', session.access_token, {
+      ...baseOptions,
+      ...(typeof maxAge === 'number' ? { maxAge } : {}),
+      ...(session.expires_at ? { expires: new Date(session.expires_at * 1000) } : {}),
+    }),
+  );
+
+  if (session.refresh_token) {
+    appendSetCookie(
+      res,
+      serializeCookie('sb-refresh-token', session.refresh_token, {
+        ...baseOptions,
+        // refresh tokens are typically long-lived; fall back to 30 days if no expiry provided
+        maxAge: session.expires_in ?? 60 * 60 * 24 * 30,
+      }),
+    );
+  }
+
+  return true;
+}
+
+function clearSessionCookies(res: NextApiResponse) {
+  const secure = process.env.NODE_ENV === 'production';
+  const cookieNames = ['sb-access-token', 'sb-refresh-token', 'sb:token', 'supabase-auth-token'];
+
+  cookieNames.forEach((name) => {
+    appendSetCookie(
+      res,
+      serializeCookie(name, '', {
+        path: '/',
+        maxAge: 0,
+        httpOnly: true,
+        sameSite: 'lax',
+        secure,
+      }),
+    );
+  });
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');
 
@@ -13,18 +111,50 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(503).json({ ok: false, error: 'service_unavailable' });
   }
 
-  const { event, session } = req.body as { event: string; session: any };
+  const { event, session } = req.body as { event: string; session: SupabaseSession | null };
 
   try {
     if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED' || event === 'INITIAL_SESSION') {
-      // writes sb-access-token / sb-refresh-token cookies
-      await supabase.auth.setSession(session);
+      let needsFallback = true;
+
+      if (typeof supabase.auth.setSession === 'function') {
+        try {
+          await supabase.auth.setSession(session as any);
+          needsFallback = false;
+        } catch (error) {
+          console.warn('Set-session API - setSession helper failed, using fallback cookies:', error);
+        }
+      }
+
+      if (needsFallback) {
+        const wroteCookies = writeSessionCookies(res, session);
+        if (!wroteCookies) {
+          clearSessionCookies(res);
+        }
+      }
+
       return res.status(200).json({ ok: true });
     }
+
     if (event === 'SIGNED_OUT') {
-      await supabase.auth.signOut();
+      let needsFallback = true;
+
+      if (typeof supabase.auth.signOut === 'function') {
+        try {
+          await supabase.auth.signOut();
+          needsFallback = false;
+        } catch (error) {
+          console.warn('Set-session API - signOut helper failed, clearing cookies manually:', error);
+        }
+      }
+
+      if (needsFallback) {
+        clearSessionCookies(res);
+      }
+
       return res.status(200).json({ ok: true });
     }
+
     // No-op for other events
     return res.status(200).json({ ok: true });
   } catch (e) {

--- a/tests/api/auth/set-session.test.ts
+++ b/tests/api/auth/set-session.test.ts
@@ -1,31 +1,32 @@
 import { strict as assert } from 'node:assert';
 
-const calls = {
-  setSession: [] as any[],
-  signOut: 0,
-};
+function withAuthStub(auth: Record<string, any>) {
+  const helperPath = require.resolve('@supabase/auth-helpers-nextjs');
+  const handlerPath = require.resolve('../../../pages/api/auth/set-session');
 
-require.cache[require.resolve('@supabase/auth-helpers-nextjs')] = {
-  exports: {
-    createPagesServerClient: () => ({
-      auth: {
-        setSession: async (session: any) => {
-          calls.setSession.push(session);
-        },
-        signOut: async () => {
-          calls.signOut += 1;
-        },
-      },
-    }),
-  },
-};
+  delete require.cache[helperPath];
+  delete require.cache[handlerPath];
 
-const handler = require('../../../pages/api/auth/set-session').default;
+  require.cache[helperPath] = {
+    exports: {
+      createPagesServerClient: () => ({ auth }),
+    },
+  } as any;
+
+  return require(handlerPath).default;
+}
 
 function createRes() {
+  const headers: Record<string, string | string[]> = {};
   return {
     statusCode: 0,
     body: undefined as any,
+    getHeader(name: string) {
+      return headers[name];
+    },
+    setHeader(name: string, value: string | string[]) {
+      headers[name] = value;
+    },
     status(code: number) {
       this.statusCode = code;
       return this;
@@ -41,9 +42,20 @@ function createRes() {
 }
 
 (async () => {
+  // Scenario 1: Supabase helpers expose setSession/signOut
+  const calls = { setSession: [] as any[], signOut: 0 };
+  const handlerWithHelpers = withAuthStub({
+    setSession: async (session: any) => {
+      calls.setSession.push(session);
+    },
+    signOut: async () => {
+      calls.signOut += 1;
+    },
+  });
+
   const session = { access_token: 'tok', refresh_token: 'ref' };
   const resInitial = createRes();
-  await handler(
+  await handlerWithHelpers(
     { method: 'POST', body: { event: 'INITIAL_SESSION', session } } as any,
     resInitial as any,
   );
@@ -51,15 +63,104 @@ function createRes() {
   assert.equal(resInitial.body.ok, true);
   assert.equal(calls.setSession.length, 1);
   assert.equal(calls.setSession[0], session);
+  assert.equal(resInitial.getHeader('Set-Cookie'), undefined);
 
   const resSignedOut = createRes();
-  await handler(
+  await handlerWithHelpers(
     { method: 'POST', body: { event: 'SIGNED_OUT', session: null } } as any,
     resSignedOut as any,
   );
   assert.equal(resSignedOut.statusCode, 200);
   assert.equal(resSignedOut.body.ok, true);
   assert.equal(calls.signOut, 1);
+
+  // Scenario 1b: Helpers are present but throw -> fallback should recover
+  const failingHandler = withAuthStub({
+    setSession: async () => {
+      throw new TypeError('setSession not supported');
+    },
+    signOut: async () => {
+      throw new Error('signOut not supported');
+    },
+  });
+
+  const failingRes = createRes();
+  await failingHandler(
+    { method: 'POST', body: { event: 'SIGNED_IN', session } } as any,
+    failingRes as any,
+  );
+  assert.equal(failingRes.statusCode, 200);
+  assert.equal(failingRes.body.ok, true);
+  const failingCookies = failingRes.getHeader('Set-Cookie');
+  assert.ok(Array.isArray(failingCookies));
+  assert.ok(String(failingCookies?.[0]).includes('sb-access-token=tok'));
+
+  const failingSignOutRes = createRes();
+  await failingHandler(
+    { method: 'POST', body: { event: 'SIGNED_OUT', session: null } } as any,
+    failingSignOutRes as any,
+  );
+  assert.equal(failingSignOutRes.statusCode, 200);
+  assert.equal(failingSignOutRes.body.ok, true);
+  const failingCleared = failingSignOutRes.getHeader('Set-Cookie');
+  assert.ok(Array.isArray(failingCleared));
+  ['sb-access-token', 'sb-refresh-token', 'sb:token', 'supabase-auth-token'].forEach((name) => {
+    assert.ok(
+      failingCleared?.some((cookieValue) =>
+        String(cookieValue).includes(`${name}=`) && String(cookieValue).includes('Max-Age=0'),
+      ),
+    );
+  });
+
+  // Scenario 2: Fallback without helper methods
+  const handlerWithFallback = withAuthStub({});
+  const fallbackRes = createRes();
+  await handlerWithFallback(
+    { method: 'POST', body: { event: 'INITIAL_SESSION', session } } as any,
+    fallbackRes as any,
+  );
+  assert.equal(fallbackRes.statusCode, 200);
+  assert.equal(fallbackRes.body.ok, true);
+  const cookies = fallbackRes.getHeader('Set-Cookie');
+  assert.ok(Array.isArray(cookies));
+  assert.equal(cookies?.length, 2);
+  assert.ok(String(cookies?.[0]).includes('sb-access-token=tok'));
+  assert.ok(String(cookies?.[1]).includes('sb-refresh-token=ref'));
+
+  const fallbackInitialNullRes = createRes();
+  await handlerWithFallback(
+    { method: 'POST', body: { event: 'INITIAL_SESSION', session: null } } as any,
+    fallbackInitialNullRes as any,
+  );
+  assert.equal(fallbackInitialNullRes.statusCode, 200);
+  assert.equal(fallbackInitialNullRes.body.ok, true);
+  const initialNullCookies = fallbackInitialNullRes.getHeader('Set-Cookie');
+  assert.ok(Array.isArray(initialNullCookies));
+  assert.equal(initialNullCookies?.length, 4);
+  ['sb-access-token', 'sb-refresh-token', 'sb:token', 'supabase-auth-token'].forEach((name) => {
+    assert.ok(
+      initialNullCookies?.some((cookieValue) =>
+        String(cookieValue).includes(`${name}=`) && String(cookieValue).includes('Max-Age=0'),
+      ),
+    );
+  });
+
+  const fallbackSignOutRes = createRes();
+  await handlerWithFallback(
+    { method: 'POST', body: { event: 'SIGNED_OUT', session: null } } as any,
+    fallbackSignOutRes as any,
+  );
+  assert.equal(fallbackSignOutRes.statusCode, 200);
+  assert.equal(fallbackSignOutRes.body.ok, true);
+  const clearedCookies = fallbackSignOutRes.getHeader('Set-Cookie');
+  assert.ok(Array.isArray(clearedCookies));
+  ['sb-access-token', 'sb-refresh-token', 'sb:token', 'supabase-auth-token'].forEach((name) => {
+    assert.ok(
+      clearedCookies?.some((cookieValue) =>
+        String(cookieValue).includes(`${name}=`) && String(cookieValue).includes('Max-Age=0'),
+      ),
+    );
+  });
 
   console.log('set-session events tested');
 })();


### PR DESCRIPTION
## Summary
- fall back to manual Supabase cookie handling when helper setSession/signOut calls throw
- keep cookie clearing for sign-out events even if helper signOut fails
- cover helper failure scenarios in the set-session API tests

## Testing
- npx --yes tsx tests/api/auth/set-session.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e454728ab88321af474395917acbe6