### PR TITLE
Align tokens and supabase types for initial improvements

### DIFF
--- a/components/challenge/Leaderboard.tsx
+++ b/components/challenge/Leaderboard.tsx
@@ -52,7 +52,7 @@ export function Leaderboard({ cohortId, initial = [] }: LeaderboardProps) {
       </div>
 
       {error && (
-        <div className="rounded-md border border-border bg-card px-3 py-2 text-caption text-red-400">
+        <div className="rounded-md border border-border bg-card px-3 py-2 text-caption text-danger">
           {error}
         </div>
       )}

--- a/components/dashboard/SavedItems.tsx
+++ b/components/dashboard/SavedItems.tsx
@@ -62,8 +62,8 @@ export function SavedItems() {
   if (loading) {
     return (
       <Card className="p-6 rounded-ds-2xl">
-        <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded" />
-        <div className="mt-4 animate-pulse h-4 w-64 bg-gray-200 dark:bg-white/10 rounded" />
+        <div className="animate-pulse h-5 w-40 bg-muted dark:bg-white/10 rounded" />
+        <div className="mt-4 animate-pulse h-4 w-64 bg-muted dark:bg-white/10 rounded" />
       </Card>
     );
   }

--- a/components/design-system/Checkbox.tsx
+++ b/components/design-system/Checkbox.tsx
@@ -9,14 +9,22 @@ export type CheckboxProps = Readonly<
     label?: React.ReactNode;
     description?: React.ReactNode;
     error?: string | null;
+    onCheckedChange?: (checked: boolean) => void;
   }
 >;
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ id, name, label, description, error, className, ...props }, ref) => {
+  ({ id, name, label, description, error, className, onCheckedChange, onChange, ...props }, ref) => {
     const inputId = id ?? React.useId();
     const descId = description ? `${inputId}-desc` : undefined;
     const errId = error ? `${inputId}-error` : undefined;
+    const handleChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange?.(event);
+        onCheckedChange?.(event.target.checked);
+      },
+      [onChange, onCheckedChange],
+    );
 
     return (
       <div className={cn("flex items-start gap-3", className)}>
@@ -33,6 +41,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
               error ? "border-sunsetOrange" : "border-border",
               "bg-card"
             )}
+            onChange={handleChange}
             {...props}
           />
           <span className="pointer-events-none absolute h-2.5 w-2.5 rounded-full bg-primary opacity-0 peer-checked:opacity-100" />

--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -11,6 +11,7 @@ export type InputProps = Readonly<
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> & {
     label?: string;
     hint?: string;
+    helperText?: string;
     error?: string | null;
     size?: FieldSize;
     variant?: FieldVariant;
@@ -53,6 +54,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       className,
       label,
       hint,
+      helperText,
       error,
       size = 'md',
       variant = 'solid',
@@ -68,10 +70,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const uid = React.useId();
     const inputId = id ?? uid;
 
-    const hintId = hint ? `${inputId}-hint` : undefined;
+    const resolvedHint = helperText ?? hint;
+    const hintId = resolvedHint ? `${inputId}-hint` : undefined;
     const errorId = error ? `${inputId}-error` : undefined;
     const describedBy =
-      [error ? errorId : null, hint ? hintId : null].filter(Boolean).join(' ') || undefined;
+      [error ? errorId : null, resolvedHint ? hintId : null].filter(Boolean).join(' ') || undefined;
 
     const hasLeft = Boolean(leftSlot);
     const hasRight = Boolean(rightSlot);
@@ -129,9 +132,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             <p id={errorId} className="text-caption text-sunsetOrange">
               {error}
             </p>
-          ) : hint ? (
+          ) : resolvedHint ? (
             <p id={hintId} className="text-caption text-muted-foreground">
-              {hint}
+              {resolvedHint}
             </p>
           ) : null}
         </div>

--- a/components/design-system/Select.tsx
+++ b/components/design-system/Select.tsx
@@ -35,6 +35,14 @@ const variantMap: Record<FieldVariant, string> = {
 };
 
 // Shared props
+type SelectOption =
+  | string
+  | Readonly<{
+      value: string;
+      label: React.ReactNode;
+      disabled?: boolean;
+    }>;
+
 type SelectProps = {
   label?: string;
   hint?: string;
@@ -46,6 +54,7 @@ type SelectProps = {
   required?: boolean;
   className?: string;
   id?: string;
+  options?: ReadonlyArray<SelectOption>;
 } & Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'>;
 
 // Shared field wrapper component
@@ -99,8 +108,9 @@ export const Select = React.memo(
         leftSlot,
         rightSlot,
         disabled,
+        options,
         children,
-        ...props
+      ...props
       },
       ref
     ) => {
@@ -146,7 +156,21 @@ export const Select = React.memo(
               )}
               {...props}
             >
-              {children}
+              {children ??
+                options?.map((option) => {
+                  if (typeof option === 'string') {
+                    return (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    );
+                  }
+                  return (
+                    <option key={option.value} value={option.value} disabled={option.disabled}>
+                      {option.label}
+                    </option>
+                  );
+                })}
             </select>
             {hasRight && (
               <span className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground">

--- a/components/reading/QuestionBlock.tsx
+++ b/components/reading/QuestionBlock.tsx
@@ -69,7 +69,7 @@ export const QuestionBlock: React.FC<{
                     aria-label={`Option ${i + 1}: ${opt}`}
                   />
                   <span>
-                    <kbd className="px-1.5 py-0.5 rounded-ds bg-gray-200/60 dark:bg-white/10 mr-2">
+                    <kbd className="px-1.5 py-0.5 rounded-ds bg-muted/60 dark:bg-white/10 mr-2">
                       {i + 1}
                     </kbd>
                     {opt}
@@ -126,7 +126,7 @@ export const QuestionBlock: React.FC<{
             />
             <p className="text-small text-muted-foreground mt-1">
               Press{' '}
-              <kbd className="px-1 rounded-ds bg-gray-200/60 dark:bg-white/10">
+              <kbd className="px-1 rounded-ds bg-muted/60 dark:bg-white/10">
                 Enter
               </kbd>{' '}
               to jump to next unanswered.

--- a/components/reading/QuestionNav.tsx
+++ b/components/reading/QuestionNav.tsx
@@ -90,7 +90,7 @@ export const QuestionNav: React.FC<{
             ? 'bg-success/15 text-success border-success/30'
             : flagged
               ? 'bg-goldenYellow/15 text-goldenYellow border-goldenYellow/30'
-              : 'bg-gray-200/40 dark:bg-white/10 text-foreground dark:text-white border-lightBorder/60 dark:border-white/10';
+              : 'bg-muted/40 dark:bg-white/10 text-foreground dark:text-white border-lightBorder/60 dark:border-white/10';
 
           return (
             <button

--- a/components/reading/ReadingStatsCard.tsx
+++ b/components/reading/ReadingStatsCard.tsx
@@ -67,8 +67,8 @@ export function ReadingStatsCard() {
   if (loading) {
     return (
       <Card className="p-6">
-        <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded mb-3" />
-        <div className="animate-pulse h-4 w-64 bg-gray-200 dark:bg-white/10 rounded" />
+        <div className="animate-pulse h-5 w-40 bg-muted dark:bg-white/10 rounded mb-3" />
+        <div className="animate-pulse h-4 w-64 bg-muted dark:bg-white/10 rounded" />
       </Card>
     );
   }

--- a/components/sections/Learning/CourseCatalog.tsx
+++ b/components/sections/Learning/CourseCatalog.tsx
@@ -47,7 +47,7 @@ export const CourseCatalog: React.FC = () => {
 
         {loading && (
           <Card className="p-6 rounded-ds-2xl mt-6">
-            <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+            <div className="animate-pulse h-6 w-40 bg-muted dark:bg-white/10 rounded" />
           </Card>
         )}
 

--- a/components/teacher/CohortTable.tsx
+++ b/components/teacher/CohortTable.tsx
@@ -109,7 +109,7 @@ export function CohortTable({ rows, onNudge, onRemove, sortBy = "progress" }: Co
                         <button
                           type="button"
                           onClick={() => onRemove(r.id)}
-                          className="rounded-md border border-border bg-background px-2 py-1 text-caption text-red-400 hover:bg-border/30"
+                          className="rounded-md border border-border bg-background px-2 py-1 text-caption text-danger hover:bg-border/30"
                         >
                           Remove
                         </button>

--- a/components/visa/GapToGoal.tsx
+++ b/components/visa/GapToGoal.tsx
@@ -24,19 +24,21 @@ export const GapToGoal: React.FC = () => {
 
       const [targetRes, profileRes] = await Promise.all([
         supabaseBrowser
-          .from<VisaTarget>('visa_targets')
-          .select('*')
+          .from('visa_targets')
+          .select('user_id, institution, target_band, deadline')
           .eq('user_id', user.id)
-          .maybeSingle(),
+          .maybeSingle()
+          .returns<VisaTarget>(),
         supabaseBrowser
-          .from<Profile>('user_profiles')
+          .from('user_profiles')
           .select('goal_band')
           .eq('user_id', user.id)
-          .maybeSingle(),
+          .maybeSingle()
+          .returns<Pick<Profile, 'goal_band'>>(),
       ]);
 
       if (targetRes.data) setTarget(targetRes.data);
-      if (profileRes.data) setCurrentBand(profileRes.data.goal_band);
+      if (profileRes.data) setCurrentBand(profileRes.data.goal_band ?? null);
     })();
   }, []);
 

--- a/components/visa/TargetScoreForm.tsx
+++ b/components/visa/TargetScoreForm.tsx
@@ -24,10 +24,11 @@ export const TargetScoreForm: React.FC = () => {
       } = await supabaseBrowser.auth.getUser();
       if (!user) return;
       const { data } = await supabaseBrowser
-        .from<VisaTarget>('visa_targets')
-        .select('*')
+        .from('visa_targets')
+        .select('user_id, institution, target_band, deadline')
         .eq('user_id', user.id)
-        .maybeSingle();
+        .maybeSingle()
+        .returns<VisaTarget>();
       if (data) {
         setInstitution(data.institution);
         setTargetBand(data.target_band?.toString() ?? '');

--- a/lib/gamification/index.ts
+++ b/lib/gamification/index.ts
@@ -12,9 +12,10 @@ export type UserBadge = {
  */
 export async function getUserBadges(userId: string): Promise<Badge[]> {
   const { data, error } = await supabase
-    .from<UserBadge>('user_badges')
+    .from('user_badges')
     .select('badge_id')
-    .eq('user_id', userId);
+    .eq('user_id', userId)
+    .returns<Array<Pick<UserBadge, 'badge_id'>>>();
   if (error || !data) return [];
   const all = [...badges.streaks, ...badges.milestones, ...badges.community];
   return all.filter((b) => data.some((d) => d.badge_id === b.id));
@@ -24,5 +25,7 @@ export async function getUserBadges(userId: string): Promise<Badge[]> {
  * Award a badge to a user. Uses upsert to avoid duplicates.
  */
 export async function awardBadge(userId: string, badgeId: string) {
-  return supabase.from<UserBadge>('user_badges').upsert({ user_id: userId, badge_id: badgeId }, { onConflict: 'user_id,badge_id' });
+  return supabase
+    .from('user_badges')
+    .upsert({ user_id: userId, badge_id: badgeId }, { onConflict: 'user_id,badge_id' });
 }

--- a/pages/admin/reviews/[attemptId].tsx
+++ b/pages/admin/reviews/[attemptId].tsx
@@ -165,7 +165,7 @@ export default function ReviewAttemptPage() {
             {/* Left: Attempt summary */}
             <Card className="p-6 md:col-span-2 rounded-ds-2xl">
               {loading ? (
-                <div className="animate-pulse h-5 w-full bg-gray-200 dark:bg-white/10 rounded" />
+                <div className="animate-pulse h-5 w-full bg-muted dark:bg-white/10 rounded" />
               ) : !data ? (
                 <div className="text-grayish">No data.</div>
               ) : (

--- a/pages/admin/reviews/index.tsx
+++ b/pages/admin/reviews/index.tsx
@@ -222,7 +222,7 @@ export default function AdminReviewsIndex() {
                     Array.from({ length: 6 }).map((_, i) => (
                       <tr key={`skeleton-${i}`} className="border-t border-lightBorder/40 dark:border-white/10">
                         <td colSpan={7} className="py-3">
-                          <div className="animate-pulse h-5 w-full bg-gray-200 dark:bg-white/10 rounded" />
+                          <div className="animate-pulse h-5 w-full bg-muted dark:bg-white/10 rounded" />
                         </td>
                       </tr>
                     ))

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -190,7 +190,7 @@ function AdminUsers() {
                 {loading ? (
                   <tr>
                     <td className="px-5 py-4" colSpan={8}>
-                      <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+                      <div className="animate-pulse h-5 w-40 bg-muted dark:bg-white/10 rounded" />
                     </td>
                   </tr>
                 ) : filtered.length === 0 ? (

--- a/pages/cert/[id].tsx
+++ b/pages/cert/[id].tsx
@@ -128,7 +128,7 @@ export default function CertificatePage() {
               Loading certificate…
             </div>
           ) : error ? (
-            <div className="rounded-xl border border-border bg-card p-4 text-small text-red-400">
+            <div className="rounded-xl border border-border bg-card p-4 text-small text-danger">
               {error} — You may need to{" "}
               <Link
                 className="text-primary underline-offset-2 hover:underline"

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -28,10 +28,11 @@ export default function CommunityThreadsPage() {
 
   async function fetchThreads() {
     const { data } = await supabase
-      .from<Thread>('community_threads')
-      .select('*')
-      .order('created_at', { ascending: false });
-    setThreads(data || []);
+      .from('community_threads')
+      .select('id, title, content, flagged, created_at')
+      .order('created_at', { ascending: false })
+      .returns<Thread[]>();
+    setThreads(data ?? []);
   }
 
   async function createThread() {

--- a/pages/community/questions.tsx
+++ b/pages/community/questions.tsx
@@ -23,9 +23,10 @@ export default function QuestionsPage() {
 
   async function fetchQas() {
     const { data } = await supabase
-      .from<QA>('community_questions')
-      .select('*')
-      .order('created_at', { ascending: false });
+      .from('community_questions')
+      .select('id, question, answer, votes')
+      .order('created_at', { ascending: false })
+      .returns<QA[]>();
     setQas(data || []);
   }
 

--- a/pages/community/review/index.tsx
+++ b/pages/community/review/index.tsx
@@ -27,10 +27,11 @@ export default function PeerReviewPage() {
 
   async function fetchReviews() {
     const { data } = await supabase
-      .from<Review>('peer_reviews')
+      .from('peer_reviews')
       .select('id, content, created_at, comments:peer_review_comments(id, content)')
-      .order('created_at', { ascending: false });
-    setReviews((data as any) || []);
+      .order('created_at', { ascending: false })
+      .returns<Review[]>();
+    setReviews(data ?? []);
   }
 
   async function submitReview() {

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -178,7 +178,7 @@ export default function Dashboard() {
             {[...Array(3)].map((_, i) => (
               <Card key={i} className="p-6 rounded-ds-2xl">
                 <div className="animate-pulse h-6 w-40 bg-gray-2 00 dark:bg-white/10 rounded" />
-                <div className="mt-4 animate-pulse h-24 bg-gray-200 dark:bg-white/10 rounded" />
+                <div className="mt-4 animate-pulse h-24 bg-muted dark:bg-white/10 rounded" />
               </Card>
             ))}
           </div>

--- a/pages/learning/[slug].tsx
+++ b/pages/learning/[slug].tsx
@@ -172,19 +172,19 @@ export default function CourseDetailPage() {
         <Container>
           <div className="grid gap-6 lg:grid-cols-[1fr_.8fr]">
             <Card className="p-0 rounded-ds-2xl overflow-hidden">
-              <div className="h-64 w-full bg-gray-200 dark:bg-white/10 animate-pulse" />
+              <div className="h-64 w-full bg-muted dark:bg-white/10 animate-pulse" />
               <div className="p-6 space-y-3">
-                <div className="h-5 w-40 bg-gray-200 dark:bg-white/10 rounded animate-pulse" />
-                <div className="h-10 w-2/3 bg-gray-200 dark:bg-white/10 rounded animate-pulse" />
-                <div className="h-5 w-1/2 bg-gray-200 dark:bg-white/10 rounded animate-pulse" />
+                <div className="h-5 w-40 bg-muted dark:bg-white/10 rounded animate-pulse" />
+                <div className="h-10 w-2/3 bg-muted dark:bg-white/10 rounded animate-pulse" />
+                <div className="h-5 w-1/2 bg-muted dark:bg-white/10 rounded animate-pulse" />
               </div>
             </Card>
             <Card className="p-6 rounded-ds-2xl">
-              <div className="h-6 w-32 bg-gray-200 dark:bg-white/10 rounded animate-pulse" />
+              <div className="h-6 w-32 bg-muted dark:bg-white/10 rounded animate-pulse" />
               <div className="mt-4 space-y-3">
                 {Array.from({ length: 5 }).map((_, i) => (
                   <div key={i} className="p-3.5 rounded-ds border border-lightBorder dark:border-white/10">
-                    <div className="h-4 w-1/2 bg-gray-200 dark:bg-white/10 rounded animate-pulse" />
+                    <div className="h-4 w-1/2 bg-muted dark:bg-white/10 rounded animate-pulse" />
                   </div>
                 ))}
               </div>

--- a/pages/learning/strategies/index.tsx
+++ b/pages/learning/strategies/index.tsx
@@ -323,10 +323,10 @@ export default function Strategies() {
           <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {[...Array(6)].map((_, i) => (
               <Card key={i} className="p-6">
-                <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded mb-3" />
-                <div className="animate-pulse h-4 w-24 bg-gray-200 dark:bg-white/10 rounded mb-1.5" />
-                <div className="animate-pulse h-4 w-20 bg-gray-200 dark:bg-white/10 rounded mb-4" />
-                <div className="animate-pulse h-4 w-full bg-gray-200 dark:bg-white/10 rounded" />
+                <div className="animate-pulse h-6 w-40 bg-muted dark:bg-white/10 rounded mb-3" />
+                <div className="animate-pulse h-4 w-24 bg-muted dark:bg-white/10 rounded mb-1.5" />
+                <div className="animate-pulse h-4 w-20 bg-muted dark:bg-white/10 rounded mb-4" />
+                <div className="animate-pulse h-4 w-full bg-muted dark:bg-white/10 rounded" />
               </Card>
             ))}
           </div>

--- a/pages/listening/[slug].tsx
+++ b/pages/listening/[slug].tsx
@@ -310,7 +310,7 @@ export default function ListeningTestPage() {
       <section className="py-24">
         <Container>
           <Card className="p-6">
-            <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+            <div className="animate-pulse h-6 w-40 bg-muted dark:bg-white/10 rounded" />
           </Card>
         </Container>
       </section>

--- a/pages/reading/[slug].tsx
+++ b/pages/reading/[slug].tsx
@@ -216,14 +216,14 @@ export default function ReadingRunnerPage() {
         <Container>
         {!test ? (
           err ? <Alert variant="warning" title="Error">{err}</Alert> : (
-            <Card className="p-6"><div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" /></Card>
+            <Card className="p-6"><div className="animate-pulse h-6 w-40 bg-muted dark:bg-white/10 rounded" /></Card>
           )
         ) : (
           <>
             {/* Sticky bar */}
             <div className="sticky top-16 z-10 card-surface border border-lightBorder dark:border-white/10 rounded-ds p-3 flex items-center gap-3 flex-wrap">
               <Badge variant="info">Time Left: {mm}:{ss}</Badge>
-              <div className="flex-1 h-2 bg-gray-200/60 dark:bg-white/10 rounded-ds" aria-label="Progress" role="progressbar" aria-valuenow={progressPct} aria-valuemin={0} aria-valuemax={100}>
+              <div className="flex-1 h-2 bg-muted/60 dark:bg-white/10 rounded-ds" aria-label="Progress" role="progressbar" aria-valuenow={progressPct} aria-valuemin={0} aria-valuemax={100}>
                 <div className="h-2 bg-primary rounded-ds" style={{ width: `${progressPct}%` }} />
               </div>
               <Badge variant={progressPct===100 ? 'success' : 'warning'}>{progressPct}%</Badge>

--- a/pages/reading/index.tsx
+++ b/pages/reading/index.tsx
@@ -77,7 +77,7 @@ export default function ReadingListPage() {
         {!items ? (
           <div className="mt-10">
             <Card className="p-6">
-              <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+              <div className="animate-pulse h-6 w-40 bg-muted dark:bg-white/10 rounded" />
             </Card>
           </div>
         ) : (

--- a/pages/reading/review/[attemptId].tsx
+++ b/pages/reading/review/[attemptId].tsx
@@ -67,7 +67,7 @@ export default function ReadingReviewPage() {
       <Container>
         {!data ? (
           err ? <Alert variant="warning" title="Error">{err}</Alert> : (
-            <Card className="p-6"><div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" /></Card>
+            <Card className="p-6"><div className="animate-pulse h-6 w-40 bg-muted dark:bg-white/10 rounded" /></Card>
           )
         ) : (
           <>

--- a/pages/reading/stats.tsx
+++ b/pages/reading/stats.tsx
@@ -17,7 +17,7 @@ export default function ReadingStatsPage() {
         <h1 className="font-slab text-display text-gradient-primary">Reading Stats</h1>
         {!stats ? (
           <Card className="p-6 mt-6">
-            <div className="animate-pulse h-5 w-40 bg-gray-200 dark:bg-white/10 rounded" />
+            <div className="animate-pulse h-5 w-40 bg-muted dark:bg-white/10 rounded" />
           </Card>
         ) : (
           <Card className="p-6 mt-6">

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -176,8 +176,8 @@ export default function Dashboard() {
           <div className="grid gap-6 md:grid-cols-3">
             {[...Array(3)].map((_, i) => (
               <Card key={i} className="p-6 rounded-ds-2xl">
-                <div className="animate-pulse h-6 w-40 bg-gray-200 dark:bg-white/10 rounded" />
-                <div className="mt-4 animate-pulse h-24 bg-gray-200 dark:bg-white/10 rounded" />
+                <div className="animate-pulse h-6 w-40 bg-muted dark:bg-white/10 rounded" />
+                <div className="mt-4 animate-pulse h-24 bg-muted dark:bg-white/10 rounded" />
               </Card>
             ))}
           </div>

--- a/pages/speaking/attempts/index.tsx
+++ b/pages/speaking/attempts/index.tsx
@@ -76,7 +76,7 @@ export default function SpeakingAttemptsPage() {
             </thead>
             <tbody>
               {items.map((a) => (
-                <tr key={a.id} className="border-t border-gray-100 dark:border-white/10">
+                <tr key={a.id} className="border-t border-lightBorder/60 dark:border-white/10">
                   <td className="px-4 py-3">{new Date(a.created_at).toLocaleString()}</td>
                   <td className="px-4 py-3 uppercase">{a.section.replace('part', 'Part ')}</td>
                   <td className="px-4 py-3 font-medium">{a.overall ?? '—'}</td>

--- a/pages/speaking/practice.tsx
+++ b/pages/speaking/practice.tsx
@@ -497,7 +497,7 @@ export default function SpeakingPracticePage() {
                 {stage === 'error' && 'Error'}
               </div>
               {(stage === 'uploading' || stage === 'scoring') && (
-                <div className="mt-3 animate-pulse h-2 rounded bg-gray-200 dark:bg-white/10" />
+                <div className="mt-3 animate-pulse h-2 rounded bg-muted dark:bg-white/10" />
               )}
               {error && <div className="mt-3 text-small text-rose-600 break-words">{error}</div>}
             </div>

--- a/pages/speaking/simulator/part2.tsx
+++ b/pages/speaking/simulator/part2.tsx
@@ -377,7 +377,7 @@ export default function SpeakingPart2() {
               </div>
 
               {(stage === 'uploading' || stage === 'scoring') && (
-                <div className="mt-3 animate-pulse h-2 rounded bg-gray-200 dark:bg-white/10" />
+                <div className="mt-3 animate-pulse h-2 rounded bg-muted dark:bg-white/10" />
               )}
 
               {error && (

--- a/pages/speaking/simulator/part3.tsx
+++ b/pages/speaking/simulator/part3.tsx
@@ -264,7 +264,7 @@ export default function SpeakingPart3() {
                 {stage === 'error' && 'Error'}
               </div>
               {(stage === 'uploading' || stage === 'scoring') && (
-                <div className="mt-3 animate-pulse h-2 rounded bg-gray-200 dark:bg-white/10" />
+                <div className="mt-3 animate-pulse h-2 rounded bg-muted dark:bg-white/10" />
               )}
               {error && <div className="mt-3 text-small text-rose-600 break-words">{error}</div>}
             </div>

--- a/pages/teacher/cohorts/[id].tsx
+++ b/pages/teacher/cohorts/[id].tsx
@@ -143,7 +143,7 @@ export default function CohortDetail() {
               Loading cohort…
             </div>
           ) : error ? (
-            <div className="rounded-xl border border-border bg-card p-4 text-small text-red-400">
+            <div className="rounded-xl border border-border bg-card p-4 text-small text-danger">
               {error}
             </div>
           ) : !cohort ? (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,7 +21,7 @@ body { @apply font-sans text-lightText bg-lightBg overflow-x-hidden relative; }
 }
 
 /* Header / Nav */
-.header-glass { @apply text-lightText bg-white/90 backdrop-blur-md border-b border-gray-200; }
+.header-glass { @apply text-lightText bg-white/90 backdrop-blur-md border-b border-lightBorder; }
 .dark .header-glass { @apply text-white bg-dark/95 border-vibrantPurple/20; }
 
 /* Nav pill */


### PR DESCRIPTION
## Summary
- replace remaining gray skeleton placeholders and error text styles with design-system tokens across learning, reading, and admin screens
- extend Checkbox, Input, and Select design-system components with onCheckedChange, helperText, and options support to simplify consumption
- update Supabase queries to use .returns typing in gamification, visa, and community modules and align the shared header border token

## Testing
- npm run lint *(fails: `next` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e46a70b8bc832190151d5b6c75ba4d