### PR TITLE
Polish key support pages with design-system patterns

### DIFF
--- a/pages/403.tsx
+++ b/pages/403.tsx
@@ -28,19 +28,28 @@ const ForbiddenPage: NextPage<Props> = ({ reason }) => {
       <Head>
         <title>403 — Forbidden</title>
       </Head>
-      <main className="min-h-[100dvh] flex items-center justify-center bg-background text-foreground px-6">
-        <Container>
-          <Card className="p-10 text-center space-y-6">
-            <h1 className="text-6xl font-bold text-primary">403</h1>
-            <p className="text-h4 text-mutedText">
-              You don’t have permission to access this page
-              {reason ? `: ${reason}` : '.'}
-            </p>
-            <p className="italic text-accent">{joke}</p>
-            <div className="mt-6">
-              <Link href="/" passHref legacyBehavior>
-                <Button variant="primary">Go Home</Button>
-              </Link>
+      <main
+        id="main"
+        aria-labelledby="forbidden-title"
+        className="flex min-h-[100dvh] items-center bg-background py-12 text-foreground"
+      >
+        <Container className="flex justify-center px-6">
+          <Card className="max-w-xl text-center" padding="lg">
+            <div className="space-y-6">
+              <p className="text-caption uppercase tracking-[0.2em] text-muted-foreground">Restricted area</p>
+              <h1 id="forbidden-title" className="text-display font-semibold text-primary">
+                403
+              </h1>
+              <p className="text-h4 text-muted-foreground">
+                You don’t have permission to access this page
+                {reason ? `: ${reason}` : '.'}
+              </p>
+              <p className="text-body italic text-accent">{joke}</p>
+              <div className="flex justify-center">
+                <Button asChild size="lg" variant="primary">
+                  <Link href="/">Back to dashboard</Link>
+                </Button>
+              </div>
             </div>
           </Card>
         </Container>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,7 @@
 // pages/_app.tsx
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import Link from 'next/link';
 import { useEffect, useMemo, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { ThemeProvider } from 'next-themes';
@@ -26,6 +27,10 @@ import { PremiumThemeProvider } from '@/premium-ui/theme/PremiumThemeProvider';
 import { ImpersonationBanner } from '@/components/admin/ImpersonationBanner';
 import SidebarAI from '@/components/ai/SidebarAI';
 import AuthAssistant from '@/components/auth/AuthAssistant';
+import { Card } from '@/components/design-system/Card';
+import { Input } from '@/components/design-system/Input';
+import { Textarea } from '@/components/design-system/Textarea';
+import { Button } from '@/components/design-system/Button';
 
 import DashboardLayout from '@/components/layouts/DashboardLayout';
 import PublicMarketingLayout from '@/components/layouts/PublicMarketingLayout';
@@ -73,32 +78,59 @@ function GuardSkeleton() {
 
 // Minimal inline onboarding gate (no extra imports)
 function TeacherOnboardingGate() {
+  const router = useRouter();
+
+  const handleSubmit = React.useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void router.push('/teacher/register');
+    },
+    [router]
+  );
+
   return (
-    <div className="mx-auto max-w-xl rounded-ds-2xl border border-border p-6 card-surface">
-      <h1 className="text-xl font-semibold">Complete Teacher Onboarding</h1>
-      <p className="mt-2 text-muted-foreground">
-        Your account is created but not approved yet. Please complete the onboarding form. After admin approval,
-        you&apos;ll get access to teacher tools.
-      </p>
-      <div className="mt-4 grid gap-3">
-        <div className="grid gap-2">
-          <label className="text-sm">Full Name</label>
-          <input className="input w-full" placeholder="Your name" />
+    <Card className="mx-auto max-w-2xl" padding="lg" insetBorder>
+      <form
+        className="space-y-5"
+        onSubmit={handleSubmit}
+        aria-describedby="teacher-onboarding-note"
+      >
+        <div className="space-y-2">
+          <p className="text-caption uppercase tracking-[0.12em] text-muted-foreground">Teacher onboarding</p>
+          <h2 className="text-h3 font-semibold text-foreground">Complete your profile</h2>
+          <p className="text-small text-muted-foreground">
+            Your account is created but not approved yet. Share a quick profile so our team can unlock the teacher
+            workspace for you.
+          </p>
         </div>
-        <div className="grid gap-2">
-          <label className="text-sm">Subject / Expertise</label>
-          <input className="input w-full" placeholder="e.g., IELTS Writing" />
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Input name="full-name" label="Full name" placeholder="Your name" autoComplete="name" />
+          <Input name="subject" label="Subject / expertise" placeholder="e.g., IELTS Writing" />
         </div>
-        <div className="grid gap-2">
-          <label className="text-sm">Experience</label>
-          <input className="input w-full" placeholder="Years / brief profile" />
+
+        <Textarea
+          name="experience"
+          label="Experience"
+          placeholder="Tell us about your IELTS teaching experience"
+          hint="This is a placeholder form. Connect it to your API when ready."
+          rows={4}
+        />
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <Button type="submit" size="lg">
+            Open onboarding form
+          </Button>
+          <Button asChild variant="link" size="sm">
+            <Link href="/teacher/register">Fill it later</Link>
+          </Button>
         </div>
-        <button className="btn mt-2">Submit for Approval</button>
-      </div>
-      <p className="mt-3 text-xs text-muted-foreground">
-        Note: This is a placeholder form. Hook it to your real onboarding page or API when ready.
-      </p>
-    </div>
+
+        <p id="teacher-onboarding-note" className="text-caption text-muted-foreground">
+          Data entered here is not saved yet — you&apos;ll complete the official onboarding on the next screen.
+        </p>
+      </form>
+    </Card>
   );
 }
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,17 +2,33 @@
 import { Html, Head, Main, NextScript } from 'next/document';
 import { HEX, WHITE } from '@/lib/tokens';
 
+const orgJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'GramorX',
+  url: 'https://gramorx.com',
+  logo: '/brand/logo.png',
+} as const;
+
+const orgJsonLdJson = JSON.stringify(orgJsonLd);
+
+const localeBootstrapScript = `(() => {
+  try {
+    const match = document.cookie.match(/(?:^|;)\\s*locale=([^;]+)/);
+    const locale = match ? decodeURIComponent(match[1]) : 'en';
+    const isRTL = /^(ur|ar|fa|he)(-|$)/i.test(locale);
+    const root = document.documentElement;
+    root.setAttribute('lang', locale || 'en');
+    root.setAttribute('dir', isRTL ? 'rtl' : 'ltr');
+  } catch (error) {
+    console.warn('locale bootstrap failed', error);
+  }
+})();`;
+
 export default function Document() {
-  const orgJsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'Organization',
-    name: 'GramorX',
-    url: 'https://gramorx.com',
-    logo: '/brand/logo.png',
-  };
 
   return (
-    <Html lang="en" dir="ltr" className="bg-background text-foreground">
+    <Html lang="en" dir="ltr" className="bg-background text-foreground" suppressHydrationWarning>
       <Head>
         {/* Base SEO */}
         <meta
@@ -26,8 +42,8 @@ export default function Document() {
 
         {/* Color scheme & theme */}
         <meta name="color-scheme" content="dark light" />
-        <meta name="theme-color" content={HEX.ink} media="(prefers-color-scheme: dark)" />
-        <meta name="theme-color" content={WHITE} media="(prefers-color-scheme: light)" />
+        <meta key="theme-dark" name="theme-color" content={HEX.ink} media="(prefers-color-scheme: dark)" />
+        <meta key="theme-light" name="theme-color" content={WHITE} media="(prefers-color-scheme: light)" />
 
         {/* Open Graph / Twitter */}
         <meta property="og:type" content="website" />
@@ -41,8 +57,9 @@ export default function Document() {
         <meta name="twitter:card" content="summary_large_image" />
 
         {/* Preconnects */}
-        <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
 
         {/* PWA + Icons */}
         <link rel="manifest" href="/manifest.json" />
@@ -50,24 +67,10 @@ export default function Document() {
         <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
 
         {/* JSON-LD */}
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
-        />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: orgJsonLdJson }} />
 
         {/* Pre-paint locale->dir fixer */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{
-              var m=document.cookie.match(/(?:^|;)\\s*locale=([^;]+)/);
-              var loc=m?decodeURIComponent(m[1]):'en';
-              var isRTL=/^(ur|ar|fa|he)(-|$)/i.test(loc);
-              var html=document.documentElement;
-              html.setAttribute('lang', loc || 'en');
-              html.setAttribute('dir', isRTL?'rtl':'ltr');
-            }catch(e){}})();`,
-          }}
-        />
+        <script dangerouslySetInnerHTML={{ __html: localeBootstrapScript }} />
       </Head>
       <body className="bg-background text-foreground antialiased">
         <Main />

--- a/pages/accessibility.tsx
+++ b/pages/accessibility.tsx
@@ -3,16 +3,18 @@ import * as React from "react";
 import Head from "next/head";
 import Link from "next/link";
 import { Container } from "@/components/design-system/Container";
+import { Card } from "@/components/design-system/Card";
+import { Button } from "@/components/design-system/Button";
+import { Input } from "@/components/design-system/Input";
 
 export default function AccessibilityPage() {
   const [announceMsg, setAnnounceMsg] = React.useState<string>("");
   const liveRef = React.useRef<HTMLDivElement | null>(null);
 
-  const announce = (msg: string) => {
+  const announce = React.useCallback((msg: string) => {
     setAnnounceMsg("");
-    // brief delay ensures SR re-announces same text
     setTimeout(() => setAnnounceMsg(msg), 20);
-  };
+  }, []);
 
   return (
     <>
@@ -27,168 +29,152 @@ export default function AccessibilityPage() {
       {/* Skip link (appears when focused) */}
       <a
         href="#main"
-        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:border focus:border-border focus:bg-card focus:px-3 focus:py-2 focus:text-small focus:text-foreground"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-ds-lg focus:border focus:border-border focus:bg-card focus:px-3 focus:py-2 focus:text-small focus:text-foreground"
       >
         Skip to main content
       </a>
 
-      <div className="py-6">
-        <Container>
-          <header className="mb-4">
+      <div className="py-8">
+        <Container className="space-y-6">
+          <header className="space-y-2">
+            <p className="text-caption uppercase tracking-[0.14em] text-muted-foreground">Inclusive by default</p>
             <h1 className="text-h2 font-bold text-foreground">Accessibility</h1>
             <p className="text-small text-muted-foreground">
-              Quick WCAG checks & interactive playground to catch issues before launch.
+              Quick WCAG checks and interactive playground to catch issues before launch.
             </p>
           </header>
 
           <main id="main" role="main" className="space-y-6">
             {/* Quick Checks */}
-            <section aria-labelledby="quick-checks" className="rounded-xl border border-border bg-card p-4">
-              <h2 id="quick-checks" className="text-body font-semibold text-foreground">
-                Quick checks
-              </h2>
-              <ul className="mt-2 list-disc space-y-1 pl-5 text-small text-foreground">
-                <li>All interactive controls are reachable by <kbd>Tab</kbd> and visible on focus.</li>
-                <li>Images use <code className="rounded bg-background px-1">alt</code> text or are marked decorative.</li>
-                <li>Color is not the only way information is conveyed.</li>
-                <li>Text has sufficient contrast; respect <code className="rounded bg-background px-1">prefers-reduced-motion</code>.</li>
-                <li>Page uses landmarks: header, nav, main, footer.</li>
-                <li>Form fields have associated labels; errors are announced.</li>
-              </ul>
-              <div className="mt-3 text-caption text-muted-foreground">
-                Tip: run automated checks with axe (Browser DevTools) and Lighthouse; then do a manual keyboard pass.
+            <Card as="section" aria-labelledby="quick-checks" padding="lg" insetBorder>
+              <div className="space-y-3">
+                <h2 id="quick-checks" className="text-h4 font-semibold text-foreground">
+                  Quick checks
+                </h2>
+                <ul className="list-disc space-y-1 pl-5 text-small text-foreground">
+                  <li>All interactive controls are reachable by <kbd>Tab</kbd> and visible on focus.</li>
+                  <li>Images use <code className="rounded bg-background px-1">alt</code> text or are marked decorative.</li>
+                  <li>Color is not the only way information is conveyed.</li>
+                  <li>
+                    Text has sufficient contrast; respect <code className="rounded bg-background px-1">prefers-reduced-motion</code>.
+                  </li>
+                  <li>Page uses landmarks: header, nav, main, footer.</li>
+                  <li>Form fields have associated labels; errors are announced.</li>
+                </ul>
+                <p className="text-caption text-muted-foreground">
+                  Tip: run automated checks with axe (Browser DevTools) and Lighthouse; then do a manual keyboard pass.
+                </p>
               </div>
-            </section>
+            </Card>
 
             {/* Keyboard Playground */}
-            <section aria-labelledby="keyboard-play" className="rounded-xl border border-border bg-card p-4">
-              <h2 id="keyboard-play" className="text-body font-semibold text-foreground">
-                Keyboard playground
-              </h2>
-              <p className="mb-3 text-small text-muted-foreground">
-                Use <kbd>Tab</kbd>/<kbd>Shift+Tab</kbd> and <kbd>Space</kbd>/<kbd>Enter</kbd> to operate controls below.
-              </p>
+            <Card as="section" aria-labelledby="keyboard-play" padding="lg" insetBorder>
+              <div className="space-y-4">
+                <div className="space-y-1">
+                  <h2 id="keyboard-play" className="text-h4 font-semibold text-foreground">
+                    Keyboard playground
+                  </h2>
+                  <p className="text-small text-muted-foreground">
+                    Use <kbd>Tab</kbd>/<kbd>Shift+Tab</kbd> and <kbd>Space</kbd>/<kbd>Enter</kbd> to operate controls below.
+                  </p>
+                </div>
 
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                <fieldset className="rounded-lg border border-border p-3">
-                  <legend className="px-1 text-caption text-muted-foreground">Form sample</legend>
-                  <div className="space-y-2">
-                    <label className="block text-caption text-muted-foreground" htmlFor="name">
-                      Name
-                    </label>
-                    <input
-                      id="name"
-                      type="text"
-                      className="w-full rounded-md border border-border bg-background px-3 py-2 text-small text-foreground outline-none focus:border-primary"
-                      placeholder="Your full name"
-                    />
-                    <button
-                      type="button"
-                      className="rounded-md border border-border bg-background px-3 py-1.5 text-small text-foreground hover:bg-border/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                      onClick={() => announce("Form validated. No errors found.")}
-                    >
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <fieldset className="space-y-3 rounded-ds-xl border border-border/60 bg-background p-4">
+                    <legend className="px-1 text-caption text-muted-foreground">Form sample</legend>
+                    <Input id="name" name="name" label="Name" placeholder="Your full name" />
+                    <Button type="button" onClick={() => announce("Form validated. No errors found.")}>
                       Validate
-                    </button>
-                  </div>
-                </fieldset>
+                    </Button>
+                  </fieldset>
 
-                <div className="rounded-lg border border-border p-3">
-                  <div className="text-caption text-muted-foreground">Buttons & links</div>
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <button
-                      type="button"
-                      className="rounded-md border border-border bg-background px-3 py-1.5 text-small hover:bg-border/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                      onClick={() => announce("Primary action triggered")}
-                    >
-                      Action
-                    </button>
-                    <button
-                      type="button"
-                      disabled
-                      aria-disabled="true"
-                      className="rounded-md border border-border bg-background px-3 py-1.5 text-small text-muted-foreground opacity-60"
-                    >
-                      Disabled
-                    </button>
-                    <Link
-                      href="/pricing"
-                      className="rounded-md border border-border bg-background px-3 py-1.5 text-small text-foreground hover:bg-border/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                    >
-                      Go to pricing
-                    </Link>
+                  <div className="space-y-3 rounded-ds-xl border border-border/60 bg-background p-4">
+                    <div className="text-caption text-muted-foreground">Buttons &amp; links</div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button type="button" onClick={() => announce("Primary action triggered")}>Action</Button>
+                      <Button type="button" variant="outline" disabled>
+                        Disabled
+                      </Button>
+                      <Button asChild variant="soft">
+                        <Link href="/pricing">Go to pricing</Link>
+                      </Button>
+                    </div>
                   </div>
                 </div>
-              </div>
 
-              {/* ARIA live region */}
-              <div
-                ref={liveRef}
-                aria-live="polite"
-                aria-atomic="true"
-                className="sr-only"
-              >
-                {announceMsg}
+                {/* ARIA live region */}
+                <div ref={liveRef} aria-live="polite" aria-atomic="true" className="sr-only">
+                  {announceMsg}
+                </div>
               </div>
-            </section>
+            </Card>
 
             {/* Landmarks / Motion */}
-            <section aria-labelledby="landmarks" className="rounded-xl border border-border bg-card p-4">
-              <h2 id="landmarks" className="text-body font-semibold text-foreground">Landmarks & motion</h2>
-              <ul className="mt-2 list-disc space-y-1 pl-5 text-small text-foreground">
-                <li>
-                  This page includes <code className="rounded bg-background px-1">main</code> landmark and a top-level
-                  “Skip to main content” link.
-                </li>
-                <li>
-                  Honor reduced motion: avoid non-essential animations when{" "}
-                  <code className="rounded bg-background px-1">prefers-reduced-motion: reduce</code> is set.
-                </li>
-              </ul>
-              <details className="mt-3 rounded-lg border border-border bg-background p-3 text-small">
-                <summary className="cursor-pointer text-foreground">Why it matters</summary>
-                <p className="mt-2 text-muted-foreground">
-                  Clear focus styles and proper landmarks help keyboard and screen-reader users navigate quickly. Live
-                  regions announce changes that aren’t triggered by focus.
-                </p>
-              </details>
-            </section>
+            <Card as="section" aria-labelledby="landmarks" padding="lg" insetBorder>
+              <div className="space-y-3">
+                <h2 id="landmarks" className="text-h4 font-semibold text-foreground">
+                  Landmarks &amp; motion
+                </h2>
+                <ul className="list-disc space-y-1 pl-5 text-small text-foreground">
+                  <li>
+                    This page includes <code className="rounded bg-background px-1">main</code> landmark and a top-level “Skip to
+                    main content” link.
+                  </li>
+                  <li>
+                    Honor reduced motion: avoid non-essential animations when{' '}
+                    <code className="rounded bg-background px-1">prefers-reduced-motion: reduce</code> is set.
+                  </li>
+                </ul>
+                <details className="rounded-ds-xl border border-border/60 bg-background p-3 text-small">
+                  <summary className="cursor-pointer text-foreground">Why it matters</summary>
+                  <p className="mt-2 text-muted-foreground">
+                    Clear focus styles and proper landmarks help keyboard and screen-reader users navigate quickly. Live regions
+                    announce changes that aren’t triggered by focus.
+                  </p>
+                </details>
+              </div>
+            </Card>
 
             {/* Resources */}
-            <section aria-labelledby="resources" className="rounded-xl border border-border bg-card p-4">
-              <h2 id="resources" className="text-body font-semibold text-foreground">Resources</h2>
-              <ul className="mt-2 list-disc space-y-1 pl-5 text-small">
-                <li>
-                  <a
-                    className="text-primary underline-offset-2 hover:underline"
-                    href="https://www.w3.org/WAI/standards-guidelines/wcag/"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    WCAG Overview — W3C WAI
-                  </a>
-                </li>
-                <li>
-                  <a
-                    className="text-primary underline-offset-2 hover:underline"
-                    href="https://developer.chrome.com/docs/lighthouse/accessibility"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Lighthouse Accessibility
-                  </a>
-                </li>
-                <li>
-                  <a
-                    className="text-primary underline-offset-2 hover:underline"
-                    href="https://www.deque.com/axe/"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    axe DevTools
-                  </a>
-                </li>
-              </ul>
-            </section>
+            <Card as="section" aria-labelledby="resources" padding="lg" insetBorder>
+              <div className="space-y-3">
+                <h2 id="resources" className="text-h4 font-semibold text-foreground">
+                  Resources
+                </h2>
+                <ul className="space-y-2 text-small">
+                  <li>
+                    <a
+                      className="text-primary underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      href="https://www.w3.org/WAI/standards-guidelines/wcag/"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      WCAG Overview — W3C WAI
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      className="text-primary underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      href="https://developer.chrome.com/docs/lighthouse/accessibility"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Lighthouse Accessibility
+                    </a>
+                  </li>
+                  <li>
+                    <a
+                      className="text-primary underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      href="https://www.deque.com/axe/"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      axe DevTools
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </Card>
           </main>
         </Container>
       </div>

--- a/pages/account/billing.tsx
+++ b/pages/account/billing.tsx
@@ -1,8 +1,16 @@
 // pages/account/billing.tsx
 import * as React from 'react';
+import Head from 'next/head';
 import Link from 'next/link';
 import type { GetServerSideProps } from 'next';
 import { createPagesServerClient } from '@supabase/auth-helpers-nextjs';
+
+import { Container } from '@/components/design-system/Container';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+import { Badge } from '@/components/design-system/Badge';
+import { Alert } from '@/components/design-system/Alert';
+import { Skeleton } from '@/components/design-system/Skeleton';
 
 type Invoice = {
   id: string;
@@ -58,6 +66,58 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   return { props: {} };
 };
 
+const toTitleCase = (value: string) =>
+  value
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+
+const getStatusVariant = (status: Summary['status']) => {
+  switch (status) {
+    case 'active':
+      return 'success';
+    case 'trialing':
+      return 'info';
+    case 'past_due':
+    case 'incomplete':
+      return 'warning';
+    case 'unpaid':
+      return 'danger';
+    case 'paused':
+      return 'secondary';
+    case 'canceled':
+    default:
+      return 'neutral';
+  }
+};
+
+const getInvoiceVariant = (status: Invoice['status']) => {
+  switch (status) {
+    case 'paid':
+      return 'success';
+    case 'open':
+      return 'info';
+    case 'draft':
+      return 'secondary';
+    case 'uncollectible':
+      return 'danger';
+    case 'void':
+    default:
+      return 'neutral';
+  }
+};
+
+const getDueVariant = (status: Due['status']) => {
+  switch (status) {
+    case 'due':
+      return 'warning';
+    case 'collected':
+      return 'success';
+    case 'canceled':
+    default:
+      return 'neutral';
+  }
+};
+
 // ------------------- Client component -------------------
 export default function BillingPage() {
   const [loading, setLoading] = React.useState(true);
@@ -67,6 +127,29 @@ export default function BillingPage() {
   const [dues, setDues] = React.useState<Due[]>([]);
   const [portalLoading, setPortalLoading] = React.useState(false);
   const [portalAvailable, setPortalAvailable] = React.useState(true);
+
+  const dateFormatter = React.useMemo(
+    () => new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }),
+    []
+  );
+  const dateTimeFormatter = React.useMemo(
+    () => new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }),
+    []
+  );
+  const currencyFormatter = React.useCallback(
+    (amount: number, currency: string) =>
+      new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount),
+    []
+  );
+
+  const formatDate = React.useCallback(
+    (value?: string | null) => (value ? dateFormatter.format(new Date(value)) : null),
+    [dateFormatter]
+  );
+  const formatDateTime = React.useCallback(
+    (value: string) => dateTimeFormatter.format(new Date(value)),
+    [dateTimeFormatter]
+  );
 
   React.useEffect(() => {
     (async () => {
@@ -108,133 +191,180 @@ export default function BillingPage() {
     }
   }
 
+  const renderPlanMeta = () => {
+    const renews = formatDate(summary?.renewsAt);
+    const trialEnds = formatDate(summary?.trialEndsAt);
+
+    if (!renews && !trialEnds) return null;
+
+    return (
+      <p className="text-small text-muted-foreground">
+        {renews && <span>Renews {renews}</span>}
+        {renews && trialEnds && <span aria-hidden="true"> · </span>}
+        {trialEnds && <span>Trial ends {trialEnds}</span>}
+      </p>
+    );
+  };
+
   return (
-    <div className="mx-auto max-w-3xl p-4">
-      <header className="mb-6">
-        <h1 className="text-2xl font-semibold">Billing</h1>
-        <p className="opacity-70">Manage your plan and invoices.</p>
-      </header>
+    <>
+      <Head>
+        <title>Billing · GramorX</title>
+        <meta name="description" content="Manage your subscription, invoices, and pending dues." />
+      </Head>
 
-      {loading && <div className="rounded-2xl p-4 ring-1 ring-inset">Loading billing…</div>}
+      <div className="py-8">
+        <Container className="max-w-4xl space-y-6">
+          <header className="space-y-1">
+            <h1 className="text-h2 font-semibold text-foreground">Billing</h1>
+            <p className="text-small text-muted-foreground">Manage your plan and invoices.</p>
+          </header>
 
-      {!loading && error && (
-        <div className="rounded-2xl p-4 ring-1 ring-inset">
-          <div className="font-medium">Couldn’t load billing</div>
-          <div className="text-sm opacity-70">{error}</div>
-          <div className="mt-3">
-            <Link className="underline" href="/pricing">
-              Go to Pricing
-            </Link>
-          </div>
-        </div>
-      )}
-
-      {!loading && !error && summary && (
-        <>
-          {/* Current plan */}
-          <section className="mb-6 rounded-2xl p-4 ring-1 ring-inset">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-sm opacity-70">Current plan</div>
-                <div className="text-lg font-semibold capitalize">{summary.plan}</div>
-                <div className="text-sm opacity-70">
-                  Status: {summary.status}
-                  {summary.renewsAt && <> · Renews {new Date(summary.renewsAt).toLocaleDateString()}</>}
-                  {summary.trialEndsAt && <> · Trial ends {new Date(summary.trialEndsAt).toLocaleDateString()}</>}
-                </div>
+          {loading && (
+            <Card padding="lg" insetBorder aria-busy="true">
+              <div className="space-y-3">
+                <Skeleton className="h-6 w-1/3 rounded-ds-xl" />
+                <Skeleton className="h-10 w-full rounded-ds-xl" />
+                <Skeleton className="h-10 w-5/6 rounded-ds-xl" />
               </div>
-
-              {portalAvailable ? (
-                <button
-                  onClick={openPortal}
-                  disabled={portalLoading}
-                  className="rounded-xl px-4 py-2 ring-1 ring-inset"
-                  aria-busy={portalLoading}
-                >
-                  {portalLoading ? 'Opening…' : 'Change plan'}
-                </button>
-              ) : (
-                <Link href="/pricing" className="rounded-xl px-4 py-2 ring-1 ring-inset">
-                  Change plan
-                </Link>
-              )}
-            </div>
-
-            {!portalAvailable && (
-              <p className="mt-3 text-sm opacity-70">
-                Payments are temporarily unavailable. If you recently subscribed,
-                your card was <span className="font-medium">not charged</span> and the
-                amount is marked as <span className="font-medium">due</span>. We’ll notify
-                you before retrying payment.
-              </p>
-            )}
-          </section>
-
-          {/* Pending dues */}
-          {dues.length > 0 && (
-            <section className="mb-6 rounded-2xl p-4 ring-1 ring-inset">
-              <h2 className="mb-2 text-lg font-semibold">Pending dues</h2>
-              <ul className="space-y-2">
-                {dues.map((d) => (
-                  <li key={d.id} className="flex items-center justify-between rounded-xl p-3 ring-1 ring-inset">
-                    <div>
-                      <div className="font-medium capitalize">
-                        {d.plan_key} · {d.cycle}
-                      </div>
-                      <div className="text-sm opacity-70">
-                        {new Date(d.created_at).toLocaleString()}
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <div className="font-semibold">
-                        {d.currency} {(d.amount_cents / 100).toFixed(2)}
-                      </div>
-                      <div className="text-xs opacity-70">Not charged yet</div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-              <p className="mt-2 text-sm opacity-70">
-                Due to a temporary technical issue, your card has not been charged. We’ll
-                notify you before retrying payment.
-              </p>
-            </section>
+            </Card>
           )}
 
-          {/* Invoices */}
-          <section className="rounded-2xl p-4 ring-1 ring-inset">
-            <h2 className="mb-3 text-lg font-semibold">Invoices</h2>
-            {invoices.length === 0 ? (
-              <p className="text-sm opacity-70">No invoices yet.</p>
-            ) : (
-              <ul className="space-y-2">
-                {invoices.map((inv) => (
-                  <li key={inv.id} className="flex items-center justify-between rounded-xl p-3 ring-1 ring-inset">
+          {!loading && error && (
+            <Alert variant="error" appearance="soft" title="Couldn’t load billing" role="alert">
+              <p className="mt-2 text-small text-muted-foreground">{error}</p>
+              <div className="mt-3">
+                <Button asChild variant="link" size="sm">
+                  <Link href="/pricing">Go to pricing</Link>
+                </Button>
+              </div>
+            </Alert>
+          )}
+
+          {!loading && !error && summary && (
+            <>
+              {/* Current plan */}
+              <Card as="section" padding="lg" insetBorder aria-labelledby="current-plan-heading">
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-2">
                     <div>
-                      <div className="font-medium">{inv.status.toUpperCase()}</div>
-                      <div className="text-sm opacity-70">
-                        {new Date(inv.createdAt).toLocaleString()}
+                      <p className="text-caption uppercase tracking-[0.12em] text-muted-foreground">Current plan</p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        <h2 id="current-plan-heading" className="text-h3 font-semibold capitalize text-foreground">
+                          {toTitleCase(summary.plan)}
+                        </h2>
+                        <Badge variant={getStatusVariant(summary.status)}>{toTitleCase(summary.status)}</Badge>
                       </div>
                     </div>
-                    <div className="text-right">
-                      <div className="font-semibold">
-                        {inv.currency} {(inv.amount / 100).toFixed(2)}
-                      </div>
-                      {inv.hostedInvoiceUrl ? (
-                        <a className="text-sm underline" href={inv.hostedInvoiceUrl} target="_blank" rel="noreferrer">
-                          View invoice
-                        </a>
-                      ) : (
-                        <span className="text-sm opacity-70">No PDF</span>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-        </>
-      )}
-    </div>
+                    {renderPlanMeta()}
+                  </div>
+
+                  {portalAvailable ? (
+                    <Button onClick={openPortal} loading={portalLoading} size="lg">
+                      {portalLoading ? 'Opening…' : 'Change plan'}
+                    </Button>
+                  ) : (
+                    <Button asChild variant="outline" size="lg">
+                      <Link href="/pricing">Change plan</Link>
+                    </Button>
+                  )}
+                </div>
+
+                {!portalAvailable && (
+                  <Alert variant="warning" className="mt-4" appearance="soft">
+                    Payments are temporarily unavailable. If you recently subscribed, your card was{' '}
+                    <span className="font-medium">not charged</span> and the amount is marked as{' '}
+                    <span className="font-medium">due</span>. We’ll notify you before retrying payment.
+                  </Alert>
+                )}
+              </Card>
+
+              {/* Pending dues */}
+              {dues.length > 0 && (
+                <Card as="section" padding="lg" insetBorder aria-labelledby="pending-dues">
+                  <div className="space-y-4">
+                    <h2 id="pending-dues" className="text-h4 font-semibold text-foreground">
+                      Pending dues
+                    </h2>
+                    <ul className="space-y-3">
+                      {dues.map((d) => (
+                        <li key={d.id} className="rounded-ds-xl border border-border/60 bg-background p-4">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="space-y-2">
+                              <Badge variant={getDueVariant(d.status)}>{toTitleCase(d.status)}</Badge>
+                              <div className="text-small text-muted-foreground">
+                                {toTitleCase(d.plan_key)} · {toTitleCase(d.cycle)}
+                              </div>
+                              <div className="text-caption text-muted-foreground">
+                                {formatDateTime(d.created_at)}
+                              </div>
+                            </div>
+                            <div className="text-right">
+                              <p className="text-h4 font-semibold text-foreground">
+                                {currencyFormatter(d.amount_cents / 100, d.currency)}
+                              </p>
+                              <p className="text-caption text-muted-foreground">Not charged yet</p>
+                            </div>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                    <p className="text-small text-muted-foreground">
+                      Due to a temporary technical issue, your card has not been charged. We’ll notify you before retrying
+                      payment.
+                    </p>
+                  </div>
+                </Card>
+              )}
+
+              {/* Invoices */}
+              <Card as="section" padding="lg" insetBorder aria-labelledby="invoices-heading">
+                <div className="space-y-4">
+                  <h2 id="invoices-heading" className="text-h4 font-semibold text-foreground">
+                    Invoices
+                  </h2>
+                  {invoices.length === 0 ? (
+                    <p className="text-small text-muted-foreground">No invoices yet.</p>
+                  ) : (
+                    <ul className="space-y-3">
+                      {invoices.map((inv) => (
+                        <li key={inv.id} className="rounded-ds-xl border border-border/60 bg-background p-4">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="space-y-2">
+                              <Badge variant={getInvoiceVariant(inv.status)}>{toTitleCase(inv.status)}</Badge>
+                              <p className="text-caption text-muted-foreground">{formatDateTime(inv.createdAt)}</p>
+                            </div>
+                            <div className="text-right space-y-2">
+                              <p className="text-h4 font-semibold text-foreground">
+                                {currencyFormatter(inv.amount / 100, inv.currency)}
+                              </p>
+                              {inv.hostedInvoiceUrl ? (
+                                <Button asChild variant="link" size="sm">
+                                  <a href={inv.hostedInvoiceUrl} target="_blank" rel="noreferrer">
+                                    View invoice
+                                  </a>
+                                </Button>
+                              ) : (
+                                <span className="text-caption text-muted-foreground">No PDF</span>
+                              )}
+                            </div>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </Card>
+            </>
+          )}
+
+          {!loading && !error && !summary && (
+            <Alert variant="info" appearance="soft" title="No subscription data">
+              We couldn’t find an active subscription yet. Start a plan from the pricing page when you’re ready.
+            </Alert>
+          )}
+        </Container>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- refresh the 403 forbidden view with design-system typography and clearer recovery action
- rebuild the inline teacher onboarding gate and accessibility playground using Card/Input/Button patterns
- update billing, accessibility, and document head plumbing to surface status badges, safer theme metadata, and clearer messaging

## Testing
- npm run lint *(fails: `next` binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e479d98ea88321947230e2a8b633c2