### PR TITLE
Align pricing data across modules

### DIFF
--- a/lib/billing/manual.ts
+++ b/lib/billing/manual.ts
@@ -1,9 +1,8 @@
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
-import { PLANS, type PlanKey, type Cycle } from '@/lib/pricing';
+import { PLANS, getPlanBillingAmount, type PlanKey, type Cycle } from '@/lib/pricing';
 
 export function priceCents(plan: PlanKey, cycle: Cycle): number {
-  const card = PLANS[plan];
-  const major = cycle === 'monthly' ? card.displayPriceMonthly : card.displayPriceAnnual;
+  const major = getPlanBillingAmount(plan, cycle);
   // Stripe will also use 2dp for USD; if you ever support JPY, handle 0dp separately.
   return Math.round(major * 100);
 }

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -5,6 +5,32 @@ export type PlanKey = 'starter' | 'booster' | 'master';
 export type PlanId = 'free' | PlanKey;
 export type Cycle = 'monthly' | 'annual';
 
+type PlanPrice = {
+  /** Amount billed each month for the monthly cycle (in major units). */
+  monthly: number;
+  /** Total amount billed upfront for the annual cycle (in major units). */
+  annual: number;
+};
+
+/**
+ * Canonical USD pricing for all paid plans.
+ *  - `monthly` is the amount a customer pays for one month.
+ *  - `annual` is the full upfront charge for one year (should be 12 × the per-month display value).
+ */
+export const USD_PLAN_PRICES: Record<PlanKey, PlanPrice> = {
+  starter: { monthly: 9, annual: 96 },
+  booster: { monthly: 19, annual: 192 },
+  master: { monthly: 39, annual: 420 },
+};
+
+export const getPlanDisplayPrice = (plan: PlanKey, cycle: Cycle): number =>
+  cycle === 'monthly'
+    ? USD_PLAN_PRICES[plan].monthly
+    : USD_PLAN_PRICES[plan].annual / 12;
+
+export const getPlanBillingAmount = (plan: PlanKey, cycle: Cycle): number =>
+  cycle === 'monthly' ? USD_PLAN_PRICES[plan].monthly : USD_PLAN_PRICES[plan].annual;
+
 export const PLAN_LABEL: Record<PlanKey, string> = {
   starter: 'Seedling 🌱',
   booster: 'Rocket 🚀',
@@ -39,8 +65,8 @@ export const PLANS: Record<PlanKey, PlanCard> = {
     title: 'Seedling',
     icon: 'fa-seedling',
     currency: CURRENCY,
-    displayPriceMonthly: 9,
-    displayPriceAnnual: 8, // shown as per-month equivalent for the annual plan
+    displayPriceMonthly: getPlanDisplayPrice('starter', 'monthly'),
+    displayPriceAnnual: getPlanDisplayPrice('starter', 'annual'),
     stripe: {
       priceIdMonthly: process.env.NEXT_PUBLIC_STRIPE_PRICE_STARTER_M,
       priceIdAnnual:  process.env.NEXT_PUBLIC_STRIPE_PRICE_STARTER_Y,
@@ -53,8 +79,8 @@ export const PLANS: Record<PlanKey, PlanCard> = {
     badge: 'MOST POPULAR',
     mostPopular: true,
     currency: CURRENCY,
-    displayPriceMonthly: 19,
-    displayPriceAnnual: 16,
+    displayPriceMonthly: getPlanDisplayPrice('booster', 'monthly'),
+    displayPriceAnnual: getPlanDisplayPrice('booster', 'annual'),
     stripe: {
       priceIdMonthly: process.env.NEXT_PUBLIC_STRIPE_PRICE_BOOSTER_M,
       priceIdAnnual:  process.env.NEXT_PUBLIC_STRIPE_PRICE_BOOSTER_Y,
@@ -65,8 +91,8 @@ export const PLANS: Record<PlanKey, PlanCard> = {
     title: 'Owl',
     icon: 'fa-feather',
     currency: CURRENCY,
-    displayPriceMonthly: 39,
-    displayPriceAnnual: 35,
+    displayPriceMonthly: getPlanDisplayPrice('master', 'monthly'),
+    displayPriceAnnual: getPlanDisplayPrice('master', 'annual'),
     stripe: {
       priceIdMonthly: process.env.NEXT_PUBLIC_STRIPE_PRICE_MASTER_M,
       priceIdAnnual:  process.env.NEXT_PUBLIC_STRIPE_PRICE_MASTER_Y,

--- a/pages/pricing/index.tsx
+++ b/pages/pricing/index.tsx
@@ -12,11 +12,13 @@ import { Ribbon } from '@/components/design-system/Ribbon';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import SocialProofStrip from '@/components/marketing/SocialProofStrip';
+import {
+  getPlanDisplayPrice,
+  type Cycle,
+  type PlanKey,
+} from '@/lib/pricing';
 
 // ------------------ Types ------------------
-type PlanKey = 'starter' | 'booster' | 'master';
-type Cycle = 'monthly' | 'annual';
-
 type PlanRow = {
   key: PlanKey;
   title: 'Seedling' | 'Rocket' | 'Owl';
@@ -34,37 +36,39 @@ type Currency =
   | 'USD' | 'EUR' | 'GBP' | 'INR' | 'PKR' | 'AED' | 'SAR' | 'AUD' | 'CAD' | 'NGN' | 'BRL' | 'PHP';
 
 // ------------------ Data ------------------
-const PLANS: readonly PlanRow[] = [
-  {
-    key: 'starter',
+const PLAN_PRESENTATION: Record<PlanKey, Omit<PlanRow, 'key' | 'priceMonthly' | 'priceAnnual'>> = {
+  starter: {
     title: 'Seedling',
     subtitle: 'Essentials to get started',
-    priceMonthly: 999,
-    priceAnnual: 899,
     features: ['Daily vocab', '1 grammar drill/week', 'Community access'],
     icon: 'fa-seedling',
   },
-  {
-    key: 'booster',
+  booster: {
     title: 'Rocket',
     subtitle: 'Best for fast progress',
-    priceMonthly: 1999,
-    priceAnnual: 1699,
     features: ['All IELTS modules', 'AI feedback', 'Mock tests', 'Progress analytics'],
     badge: 'MOST POPULAR',
     mostPopular: true,
     icon: 'fa-rocket',
   },
-  {
-    key: 'master',
+  master: {
     title: 'Owl',
     subtitle: 'Advanced & coaching',
-    priceMonthly: 3999,
-    priceAnnual: 3499,
     features: ['Priority support', '1:1 reviews', 'Advanced drills'],
     icon: 'fa-feather',
   },
-] as const;
+};
+
+const toUsdCents = (major: number) => Math.round(major * 100);
+
+const PLAN_KEYS: readonly PlanKey[] = ['starter', 'booster', 'master'];
+
+const PLANS: readonly PlanRow[] = PLAN_KEYS.map((key) => ({
+  key,
+  ...PLAN_PRESENTATION[key],
+  priceMonthly: toUsdCents(getPlanDisplayPrice(key, 'monthly')),
+  priceAnnual: toUsdCents(getPlanDisplayPrice(key, 'annual')),
+})) as const;
 
 // Simple demo FX rates relative to USD. Replace with live rates from your backend/payments provider.
 const FX: Record<Currency, number> = {

--- a/types/pricing.ts
+++ b/types/pricing.ts
@@ -6,6 +6,8 @@
 // - Adds alias mapping so "seedling/rocket/owl" map to "starter/booster/master"
 // -----------------------------------------------------------------------------
 
+import { USD_PLAN_PRICES } from '@/lib/pricing';
+
 export type PlanId = 'free' | 'starter' | 'booster' | 'master';
 
 export interface Plan {
@@ -57,8 +59,8 @@ export const PLANS: Record<PlanId, Plan> = {
     name: 'Starter (Seedling)',
     shortName: 'Starter',
     tagline: 'Build consistent habits',
-    monthlyUSD: 9,
-    annualUSD: 84,
+    monthlyUSD: USD_PLAN_PRICES.starter.monthly,
+    annualUSD: USD_PLAN_PRICES.starter.annual,
     quota: { dailyMocks: 2, aiEvaluationsPerDay: 10, storageGB: 5 },
     features: [
       'All Free features',
@@ -74,8 +76,8 @@ export const PLANS: Record<PlanId, Plan> = {
     shortName: 'Booster',
     tagline: 'Serious prep, fast',
     highlight: true,
-    monthlyUSD: 19,
-    annualUSD: 180,
+    monthlyUSD: USD_PLAN_PRICES.booster.monthly,
+    annualUSD: USD_PLAN_PRICES.booster.annual,
     quota: { dailyMocks: 5, aiEvaluationsPerDay: 40, storageGB: 15 },
     features: [
       'All Starter features',
@@ -90,8 +92,8 @@ export const PLANS: Record<PlanId, Plan> = {
     name: 'Master (Owl)',
     shortName: 'Master',
     tagline: 'Max score, full control',
-    monthlyUSD: 39,
-    annualUSD: 360,
+    monthlyUSD: USD_PLAN_PRICES.master.monthly,
+    annualUSD: USD_PLAN_PRICES.master.annual,
     quota: { dailyMocks: 10, aiEvaluationsPerDay: 120, storageGB: 50 },
     features: [
       'All Booster features',


### PR DESCRIPTION
## Summary
- centralize the canonical USD pricing amounts and expose helpers for display vs. billing
- refactor the marketing pricing page to read shared pricing data instead of hardcoded cents
- sync manual billing logic and pricing types with the canonical figures

## Testing
- npm run lint *(fails: next binary unavailable before dependencies can be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e578a9d10c8321918740705cf3afa0