### PR TITLE
Add saved items link to user navigation

### DIFF
--- a/components/navigation/constants.tsx
+++ b/components/navigation/constants.tsx
@@ -36,6 +36,7 @@ export const NAV: ReadonlyArray<{ href: string; label: string }> = [
 
 export const USER_MENU_LINKS: ReadonlyArray<{ id: string; href: string; label: string }> = [
   { id: 'account',      href: '/account',           label: 'Account' },
+  { id: 'saved',        href: '/saved',             label: 'Saved items' },
   { id: 'settings',     href: '/settings',          label: 'Settings' },
   { id: 'notifications', href: '/notifications',    label: 'Notifications' },
   { id: 'billing',      href: '/account/billing',   label: 'Billing' },


### PR DESCRIPTION
## Summary
- add a Saved items entry to the shared user menu links so bookmarked content is easier to find across desktop and mobile navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5814127888321b011e79f71e53d76