### PR TITLE
Fix teacher registration redirect logic

### DIFF
--- a/pages/teacher/register.tsx
+++ b/pages/teacher/register.tsx
@@ -21,8 +21,8 @@ export default function TeacherRegisterPage() {
 
   React.useEffect(() => {
     if (isLoading) return;
-    if (profile?.teacher_onboarding_completed && !profile.teacher_approved) {
-      router.replace('/teacher'); // go to pending screen
+    if (profile?.teacher_onboarding_completed) {
+      router.replace('/teacher'); // go to pending or dashboard screen
     }
   }, [isLoading, profile, router]);
 


### PR DESCRIPTION
## Summary
- ensure the teacher registration page redirects to the teacher area whenever onboarding is complete so approved teachers are not left on the form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e573c1ab388321a5e8d18b412b8441