### PR TITLE
Use profiles table for Supabase queries

### DIFF
--- a/components/visa/GapToGoal.tsx
+++ b/components/visa/GapToGoal.tsx
@@ -30,7 +30,7 @@ export const GapToGoal: React.FC = () => {
           .maybeSingle()
           .returns<VisaTarget>(),
         supabaseBrowser
-          .from('user_profiles')
+          .from('profiles')
           .select('goal_band')
           .eq('user_id', user.id)
           .maybeSingle()

--- a/hooks/useRouteGuard.ts
+++ b/hooks/useRouteGuard.ts
@@ -52,7 +52,7 @@ export function useRouteGuard() {
         // hydrate locale if logged in
         if (authed && user) {
           const { data: profile } = await supabase
-            .from('user_profiles') // keep your table name
+            .from('profiles') // keep your table name aligned with your schema
             .select('preferred_language')
             .eq('user_id', user.id)
             .maybeSingle();

--- a/lib/apiGuard.ts
+++ b/lib/apiGuard.ts
@@ -48,7 +48,7 @@ export function withPlan(
     // Read profile (RLS should allow user to read own profile)
     type ProfileRow = { id: string; plan: PlanId | null; role: Role };
     const { data: profile, error: profileErr } = await supabase
-      .from('user_profiles')
+      .from('profiles')
       .select('id, plan, role')
       .eq('id', user.id)
       .single<ProfileRow>();

--- a/lib/requireRole.ts
+++ b/lib/requireRole.ts
@@ -70,9 +70,9 @@ async function getRoleForUser(user: User): Promise<AppRole | null> {
     (user.user_metadata?.role as AppRole | undefined);
   if (metaRole) return metaRole;
 
-  // 2) DB profile (your schema uses user_profiles)
+  // 2) DB profile (your schema uses profiles)
   const { data: prof } = await supabaseAdmin
-    .from('user_profiles') // <-- ensure this table exists in your project
+    .from('profiles') // <-- ensure this table exists in your project
     .select('role')
     .eq('id', user.id)
     .single();

--- a/pages/account/index.tsx
+++ b/pages/account/index.tsx
@@ -23,7 +23,7 @@ export default function SettingsHubPage() {
 
       // Check if the user is an admin
       const { data: profile } = await supabase
-        .from('user_profiles')
+        .from('profiles')
         .select('role')
         .eq('id', data.session?.user?.id)
         .single();

--- a/pages/api/account/delete.ts
+++ b/pages/api/account/delete.ts
@@ -12,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'POST') {
     try {
-      await supabaseAdmin.from('user_profiles').delete().eq('user_id', user.id);
+      await supabaseAdmin.from('profiles').delete().eq('user_id', user.id);
       await supabaseAdmin.from('user_bookmarks').delete().eq('user_id', user.id);
       await supabaseAdmin.auth.admin.deleteUser(user.id);
       return res.status(200).json({ success: true });

--- a/pages/api/account/export.ts
+++ b/pages/api/account/export.ts
@@ -12,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === 'GET') {
     try {
       const { data: profile } = await supabase
-        .from('user_profiles')
+        .from('profiles')
         .select('*')
         .eq('user_id', user.id)
         .maybeSingle();

--- a/pages/api/quick-drill.ts
+++ b/pages/api/quick-drill.ts
@@ -32,7 +32,7 @@ export default async function handler(
 
   if (!skill) {
     const { data: profile } = await supabase
-      .from('user_profiles')
+      .from('profiles')
       .select('ai_recommendation')
       .eq('user_id', user.id)
       .maybeSingle();

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -88,7 +88,7 @@ export default function Dashboard() {
 
         // Load (or create minimal) profile
         const { data, error } = await supabaseBrowser
-          .from('user_profiles')
+          .from('profiles')
           .select('*')
           .eq('user_id', session.user.id)
           .maybeSingle();
@@ -113,7 +113,7 @@ export default function Dashboard() {
           } as any;
 
           const { data: created, error: insertErr } = await supabaseBrowser
-            .from('user_profiles')
+            .from('profiles')
             .insert(minimal)
             .select('*')
             .single();

--- a/pages/leaderboard/index.tsx
+++ b/pages/leaderboard/index.tsx
@@ -17,14 +17,14 @@ export default function WeeklyLeaderboard() {
     (async () => {
       const { data, error } = await supabase
         .from('weekly_leaderboard')
-        .select('user_id, score, user_profiles(full_name)')
+        .select('user_id, score, profiles(full_name)')
         .order('score', { ascending: false })
         .limit(10);
       if (!error && data) {
         const formatted: Entry[] = data.map((d: any) => ({
           user_id: d.user_id,
           score: d.score,
-          full_name: d.user_profiles?.full_name ?? 'Anonymous',
+          full_name: d.profiles?.full_name ?? 'Anonymous',
         }));
         setEntries(formatted);
       }

--- a/pages/learning/skills/[skill].tsx
+++ b/pages/learning/skills/[skill].tsx
@@ -31,7 +31,7 @@ export default function Dashboard() {
       if (!session?.user) { router.replace('/login'); return; }
 
       const { data, error } = await supabase
-        .from('user_profiles')
+        .from('profiles')
         .select('*')
         .eq('user_id', session.user.id)
         .maybeSingle();
@@ -71,7 +71,7 @@ export default function Dashboard() {
     current.push(skill);
 
     void supabase
-      .from('user_profiles')
+      .from('profiles')
       .update({ study_prefs: current })
       .eq('user_id', profile.user_id as string)
       .then(() => {

--- a/pages/notifications/index.tsx
+++ b/pages/notifications/index.tsx
@@ -24,7 +24,7 @@ export default function NotificationSettings() {
           return
         }
         const { data, error } = await supabase
-          .from('user_profiles')
+          .from('profiles')
           .select('notification_channels, quiet_hours_start, quiet_hours_end')
           .eq('user_id', session.user.id)
           .maybeSingle()
@@ -57,7 +57,7 @@ export default function NotificationSettings() {
       if (!session?.user) return
 
       const { error } = await supabase
-        .from('user_profiles')
+        .from('profiles')
         .update({
           notification_channels: channels,
           quiet_hours_start: start || null,

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -43,7 +43,7 @@ export default function ProfilePage() {
         setUserId(session.user.id);
 
         const { data, error } = await supabase
-          .from('user_profiles')
+          .from('profiles')
           .select('*')
           .eq('user_id', session.user.id)
           .maybeSingle();
@@ -101,7 +101,7 @@ export default function ProfilePage() {
       const { error: updErr } = await supabase.auth.updateUser({ data: { avatar_url: publicUrl } });
       if (updErr) throw updErr;
       const { error: profErr } = await supabase
-        .from('user_profiles')
+        .from('profiles')
         .update({ avatar_url: publicUrl })
         .eq('user_id', userId);
       if (profErr) throw profErr;

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -87,7 +87,7 @@ export default function Dashboard() {
 
         // Load (or create minimal) profile
         const { data, error } = await supabaseBrowser
-          .from('user_profiles')
+        .from('profiles')
           .select('*')
           .eq('user_id', session.user.id)
           .maybeSingle();
@@ -112,7 +112,7 @@ export default function Dashboard() {
           } as any;
 
           const { data: created, error: insertErr } = await supabaseBrowser
-            .from('user_profiles')
+            .from('profiles')
             .insert(minimal)
             .select('*')
             .single();

--- a/pages/welcome/index.tsx
+++ b/pages/welcome/index.tsx
@@ -121,7 +121,7 @@ export default function WelcomePage() {
       if (!uid) return;
 
       const { data, error: profileError } = await supabase
-        .from('user_profiles')
+        .from('profiles')
         .select('full_name')
         .eq('user_id', uid)
         .maybeSingle();

--- a/supabase/functions/reminders/index.ts
+++ b/supabase/functions/reminders/index.ts
@@ -91,7 +91,7 @@ Deno.serve(async () => {
 
   for (const [userId, info] of byUser) {
     const { data: profile } = await client
-      .from("user_profiles")
+      .from("profiles")
       .select(
         "email, phone, notification_channels, quiet_hours_start, quiet_hours_end"
       )

--- a/tests/api/auth/login-event.test.ts
+++ b/tests/api/auth/login-event.test.ts
@@ -48,7 +48,7 @@ const adminClient = {
         },
       } as any;
     }
-    if (table === 'user_profiles') {
+    if (table === 'profiles') {
       return {
         select: () => ({
           eq() {


### PR DESCRIPTION
## Summary
- update Supabase queries in hooks, pages, API routes, and the reminders function to read from the `profiles` table instead of the deprecated `user_profiles`
- align dependent UI logic, leaderboard join, and the login-event test stub with the new `profiles` relationship

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5849f43e88321896a269b27fe1d31