### PR TITLE
Fix notification settings profiles schema and filters

### DIFF
--- a/pages/api/account/delete.ts
+++ b/pages/api/account/delete.ts
@@ -12,7 +12,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'POST') {
     try {
-      await supabaseAdmin.from('profiles').delete().eq('user_id', user.id);
+      await supabaseAdmin.from('profiles').delete().eq('id', user.id);
       await supabaseAdmin.from('user_bookmarks').delete().eq('user_id', user.id);
       await supabaseAdmin.auth.admin.deleteUser(user.id);
       return res.status(200).json({ success: true });

--- a/pages/notifications/index.tsx
+++ b/pages/notifications/index.tsx
@@ -26,7 +26,7 @@ export default function NotificationSettings() {
         const { data, error } = await supabase
           .from('profiles')
           .select('notification_channels, quiet_hours_start, quiet_hours_end')
-          .eq('user_id', session.user.id)
+          .eq('id', session.user.id)
           .maybeSingle()
 
         if (error) throw new Error(error.message)
@@ -63,7 +63,7 @@ export default function NotificationSettings() {
           quiet_hours_start: start || null,
           quiet_hours_end: end || null,
         })
-        .eq('user_id', session.user.id)
+        .eq('id', session.user.id)
 
       if (error) throw new Error(error.message)
       toastSuccess('Settings saved')

--- a/supabase/functions/reminders/index.ts
+++ b/supabase/functions/reminders/index.ts
@@ -95,7 +95,7 @@ Deno.serve(async () => {
       .select(
         "email, phone, notification_channels, quiet_hours_start, quiet_hours_end"
       )
-      .eq("user_id", userId)
+      .eq("id", userId)
       .maybeSingle();
     if (!profile) continue;
     if (isQuiet(now, profile.quiet_hours_start, profile.quiet_hours_end)) continue;

--- a/supabase/migrations/20250913_notification_settings.sql
+++ b/supabase/migrations/20250913_notification_settings.sql
@@ -4,3 +4,10 @@ alter table public.user_profiles
   add column if not exists notification_channels text[] default '{}'::text[],
   add column if not exists quiet_hours_start time,
   add column if not exists quiet_hours_end time;
+
+-- Ensure the same fields exist on the new profiles table
+alter table public.profiles
+  add column if not exists phone text,
+  add column if not exists notification_channels text[] default '{}'::text[],
+  add column if not exists quiet_hours_start time,
+  add column if not exists quiet_hours_end time;


### PR DESCRIPTION
## Summary
- add notification settings columns to the profiles table alongside the legacy user_profiles table
- query and update profiles by their primary key in the notifications page and reminders function
- delete profiles rows by id during account removal to match the profiles schema

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5a2449fc0832188239e267601c380