### PR TITLE
Add essay coach page and reuse predictor heuristics

### DIFF
--- a/components/predictor/BandPredictorForm.tsx
+++ b/components/predictor/BandPredictorForm.tsx
@@ -1,27 +1,9 @@
 import * as React from 'react';
 import { useRouter } from 'next/router';
 
-type PredictorInput = Readonly<{
-  readingWpm?: number;
-  readingAccuracy?: number;
-  listeningAccuracy?: number;
-  speakingFluency?: number;
-  speakingPronunciation?: number;
-  writingTaskResponse?: number;
-  writingCoherence?: number;
-  writingGrammar?: number;
-  writingLexical?: number;
-  studyHoursPerWeek?: number;
-  pastBand?: number;
-}>;
+import type { PredictorInput, PredictorResult } from '@/lib/predictor';
 
-type PredictorSuccess = Readonly<{
-  ok: true;
-  overall: number;
-  breakdown: { reading: number; listening: number; speaking: number; writing: number };
-  confidence: number;
-  advice: string[];
-}>;
+type PredictorSuccess = Readonly<{ ok: true } & PredictorResult>;
 
 type PredictorFailure = Readonly<{ ok: false; error: string }>;
 type PredictorResponse = PredictorSuccess | PredictorFailure;

--- a/lib/coach/analyzeEssay.ts
+++ b/lib/coach/analyzeEssay.ts
@@ -1,0 +1,205 @@
+// lib/coach/analyzeEssay.ts
+// Lightweight heuristics to convert an IELTS essay into predictor inputs.
+
+import { percentToBand, runPredictor, type PredictorInput } from '@/lib/predictor';
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(max, value));
+const percentRange = (value: number, min: number, max: number) => {
+  if (max === min) return 0;
+  if (value <= min) return 0;
+  if (value >= max) return 100;
+  return ((value - min) / (max - min)) * 100;
+};
+
+const CONNECTORS = [
+  'however',
+  'moreover',
+  'furthermore',
+  'therefore',
+  'because',
+  'although',
+  'whereas',
+  'while',
+  'since',
+  'overall',
+  'in conclusion',
+  'in addition',
+  'additionally',
+  'consequently',
+  'thus',
+  'finally',
+  'firstly',
+  'secondly',
+  'besides',
+  'meanwhile',
+  'instead',
+];
+
+export type EssayStats = Readonly<{
+  wordCount: number;
+  sentenceCount: number;
+  paragraphCount: number;
+  connectorCount: number;
+  uniqueWordRatio: number; // 0..1
+  averageSentenceLength: number;
+  longSentenceRatio: number; // 0..1
+  punctuationPerSentence: number;
+}>;
+
+export type WritingPercentages = Readonly<{
+  taskResponse: number;
+  coherence: number;
+  lexical: number;
+  grammar: number;
+}>;
+
+export type EssayAnalysis = Readonly<{
+  stats: EssayStats;
+  writing: WritingPercentages;
+  predictorInput: PredictorInput;
+  suggestions: string[];
+}>;
+
+export function computeEssayStats(text: string): EssayStats {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  const words = normalized ? normalized.split(/\s+/) : [];
+  const wordCount = words.length;
+
+  const sentencePieces = text
+    .replace(/\s+/g, ' ')
+    .split(/(?<=[.!?])\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const sentenceLengths = sentencePieces.map((s) => s.split(/\s+/).filter(Boolean).length);
+  const sentenceCount = sentenceLengths.length;
+  const averageSentenceLength = sentenceCount
+    ? sentenceLengths.reduce((acc, len) => acc + len, 0) / sentenceCount
+    : wordCount;
+  const longSentenceRatio = sentenceCount
+    ? sentenceLengths.filter((len) => len >= 25).length / sentenceCount
+    : 0;
+
+  const paragraphCount = text
+    .split(/\n\s*\n+/)
+    .map((p) => p.trim())
+    .filter(Boolean).length;
+
+  const lower = text.toLowerCase();
+  const wordTokens = lower.match(/[a-zA-Z']+/g) ?? [];
+  const uniqueWordRatio = wordTokens.length
+    ? new Set(wordTokens).size / wordTokens.length
+    : 0;
+
+  const connectorCount = CONNECTORS.reduce((acc, connector) => {
+    const pattern = new RegExp(`\\b${connector.replace(/\s+/g, '\\s+')}\\b`, 'g');
+    return acc + (lower.match(pattern)?.length ?? 0);
+  }, 0);
+
+  const punctuation = text.match(/[,:;!?]/g) ?? [];
+  const punctuationPerSentence = sentenceCount
+    ? punctuation.length / sentenceCount
+    : punctuation.length;
+
+  return {
+    wordCount,
+    sentenceCount,
+    paragraphCount,
+    connectorCount,
+    uniqueWordRatio,
+    averageSentenceLength,
+    longSentenceRatio,
+    punctuationPerSentence,
+  };
+}
+
+function deriveWritingPercentages(stats: EssayStats): WritingPercentages {
+  const coverageScore = percentRange(stats.wordCount, 120, 320);
+  const paragraphScore = percentRange(stats.paragraphCount, 2, 5);
+  const connectorScore = percentRange(stats.connectorCount, 1, 8);
+  const uniqueScore = percentRange(stats.uniqueWordRatio * 100, 30, 55);
+  const sentenceScore = percentRange(stats.averageSentenceLength, 12, 22);
+  const longPenalty = percentRange(stats.longSentenceRatio * 100, 35, 70);
+  const punctuationScore = percentRange(stats.punctuationPerSentence, 0.6, 2.4);
+
+  const taskResponse = clamp(38 + coverageScore * 0.45 + paragraphScore * 0.25, 0, 100);
+  const coherence = clamp(
+    35 +
+      coverageScore * 0.2 +
+      connectorScore * 0.35 +
+      paragraphScore * 0.2 +
+      sentenceScore * 0.25,
+    0,
+    100,
+  );
+  const lexical = clamp(34 + uniqueScore * 0.65 + coverageScore * 0.2 + connectorScore * 0.1, 0, 100);
+  const grammar = clamp(
+    35 +
+      sentenceScore * 0.3 +
+      punctuationScore * 0.25 +
+      (100 - longPenalty) * 0.2 +
+      coverageScore * 0.15,
+    0,
+    100,
+  );
+
+  return { taskResponse, coherence, lexical, grammar };
+}
+
+function buildPredictorInput(stats: EssayStats, writing: WritingPercentages): PredictorInput {
+  const avg = (writing.taskResponse + writing.coherence + writing.lexical + writing.grammar) / 4;
+  const qualityRatio = avg / 100;
+
+  const readingWpm = Math.round(clamp(150 + qualityRatio * 90, 90, 400));
+  const readingAccuracy = Math.round(clamp(55 + qualityRatio * 40, 0, 100));
+  const listeningAccuracy = Math.round(clamp(56 + qualityRatio * 38, 0, 100));
+  const speakingFluency = Math.round(clamp(55 + qualityRatio * 38, 0, 100));
+  const speakingPronunciation = Math.round(clamp(55 + qualityRatio * 36, 0, 100));
+  const studyHoursPerWeek = Math.round(clamp(4 + qualityRatio * 8 + (stats.connectorCount ? 3 : 0), 0, 40));
+
+  return {
+    readingWpm,
+    readingAccuracy,
+    listeningAccuracy,
+    speakingFluency,
+    speakingPronunciation,
+    writingTaskResponse: writing.taskResponse,
+    writingCoherence: writing.coherence,
+    writingGrammar: writing.grammar,
+    writingLexical: writing.lexical,
+    studyHoursPerWeek,
+  };
+}
+
+function buildSuggestions(stats: EssayStats, writing: WritingPercentages): string[] {
+  const suggestions: string[] = [];
+  if (stats.wordCount < 250) suggestions.push('Develop ideas further to reach 250+ words.');
+  if (stats.paragraphCount < 4) suggestions.push('Aim for at least four distinct paragraphs (intro, 2 body, conclusion).');
+  if (stats.connectorCount < 3) suggestions.push('Add more linking phrases (however, moreover, consequently, etc.).');
+  if (stats.uniqueWordRatio < 0.35) suggestions.push('Swap repeated words with precise synonyms to lift lexical range.');
+  if (stats.longSentenceRatio > 0.4)
+    suggestions.push('Break very long sentences into shorter ones to avoid grammar slips.');
+  if (stats.punctuationPerSentence < 0.8)
+    suggestions.push('Use commas and transitions to clarify complex ideas.');
+
+  const writingBand = percentToBand((writing.taskResponse + writing.coherence + writing.lexical + writing.grammar) / 4);
+  if (writingBand < 6)
+    suggestions.push('Review IELTS band descriptors and model essays for structure inspiration.');
+
+  return suggestions;
+}
+
+export function analyzeEssay(text: string): EssayAnalysis {
+  const stats = computeEssayStats(text);
+  const writing = deriveWritingPercentages(stats);
+  const predictorInput = buildPredictorInput(stats, writing);
+  const suggestions = buildSuggestions(stats, writing);
+
+  return { stats, writing, predictorInput, suggestions };
+}
+
+export function predictEssay(text: string) {
+  const analysis = analyzeEssay(text);
+  const result = runPredictor(analysis.predictorInput);
+  return { analysis, result };
+}
+

--- a/lib/predictor.ts
+++ b/lib/predictor.ts
@@ -1,4 +1,6 @@
 // lib/predictor.ts
+// Shared predictor logic used by the API and UI experiences.
+
 export type PredictorInput = Readonly<{
   readingWpm?: number;
   readingAccuracy?: number;
@@ -13,51 +15,56 @@ export type PredictorInput = Readonly<{
   pastBand?: number;
 }>;
 
-export type Breakdown = Readonly<{
-  reading: number;
-  listening: number;
-  speaking: number;
-  writing: number;
-}>;
-
 export type PredictorResult = Readonly<{
   overall: number;
-  breakdown: Breakdown;
-  confidence: number; // 0..1
+  breakdown: { reading: number; listening: number; speaking: number; writing: number };
+  confidence: number;
   advice: string[];
 }>;
 
 const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+
 const roundHalf = (x: number) => Math.round(x * 2) / 2;
-const scale100ToBand = (x: number, minBand = 4, maxBand = 9) =>
-  clamp(minBand + (clamp(x, 0, 100) / 100) * (maxBand - minBand), minBand, maxBand);
 
-/** Same heuristic used by the API route so UI/tests can reuse the logic. */
-export function scorePredictor(input: PredictorInput): PredictorResult {
-  const study = clamp(Number(input.studyHoursPerWeek ?? 0), 0, 60);
-  const pastBand = input.pastBand != null ? clamp(Number(input.pastBand), 0, 9) : undefined;
+export const percentToBand = (x: number, minBand = 4, maxBand = 9) => {
+  const b = minBand + (clamp(x, 0, 100) / 100) * (maxBand - minBand);
+  return clamp(b, minBand, maxBand);
+};
 
-  const wpm = clamp(Number(input.readingWpm ?? 0), 0, 400);
-  const rAcc = clamp(Number(input.readingAccuracy ?? 0), 0, 100);
-  const reading = roundHalf(scale100ToBand(0.6 * (wpm / 4) + 0.4 * rAcc));
+export function runPredictor(raw: PredictorInput): PredictorResult {
+  const study = clamp(Number(raw.studyHoursPerWeek ?? 0), 0, 60);
+  const pastBand =
+    raw.pastBand != null && Number.isFinite(Number(raw.pastBand))
+      ? clamp(Number(raw.pastBand), 0, 9)
+      : undefined;
 
-  const lAcc = clamp(Number(input.listeningAccuracy ?? 0), 0, 100);
-  const listening = roundHalf(scale100ToBand(lAcc));
+  const wpm = clamp(Number(raw.readingWpm ?? 0), 0, 400);
+  const rAcc = clamp(Number(raw.readingAccuracy ?? 0), 0, 100);
+  const reading = roundHalf(percentToBand(0.6 * (wpm / 4) + 0.4 * rAcc));
 
-  const sFlu = clamp(Number(input.speakingFluency ?? 0), 0, 100);
-  const sPro = clamp(Number(input.speakingPronunciation ?? 0), 0, 100);
-  const speaking = roundHalf(scale100ToBand(0.5 * sFlu + 0.5 * sPro));
+  const lAcc = clamp(Number(raw.listeningAccuracy ?? 0), 0, 100);
+  const listening = roundHalf(percentToBand(lAcc));
 
-  const wTR = clamp(Number(input.writingTaskResponse ?? 0), 0, 100);
-  const wCC = clamp(Number(input.writingCoherence ?? 0), 0, 100);
-  const wGRA = clamp(Number(input.writingGrammar ?? 0), 0, 100);
-  const wLEX = clamp(Number(input.writingLexical ?? 0), 0, 100);
-  const writing = roundHalf(scale100ToBand((wTR + wCC + wGRA + wLEX) / 4));
+  const sFlu = clamp(Number(raw.speakingFluency ?? 0), 0, 100);
+  const sPro = clamp(Number(raw.speakingPronunciation ?? 0), 0, 100);
+  const speaking = roundHalf(percentToBand(0.5 * sFlu + 0.5 * sPro));
+
+  const wTR = clamp(Number(raw.writingTaskResponse ?? 0), 0, 100);
+  const wCC = clamp(Number(raw.writingCoherence ?? 0), 0, 100);
+  const wGRA = clamp(Number(raw.writingGrammar ?? 0), 0, 100);
+  const wLEX = clamp(Number(raw.writingLexical ?? 0), 0, 100);
+  const writing = roundHalf(percentToBand((wTR + wCC + wGRA + wLEX) / 4));
 
   let overall = roundHalf((reading + listening + speaking + writing) / 4);
 
   const studyBoost =
-    study >= 20 ? 1 : study >= 12 ? 0.5 + (study - 12) * (0.5 / 8) : study >= 8 ? (study - 8) * (0.5 / 4) : 0;
+    study >= 20
+      ? 1
+      : study >= 12
+      ? 0.5 + ((study - 12) * (0.5 / 8))
+      : study >= 8
+      ? (study - 8) * (0.5 / 4)
+      : 0;
   overall = roundHalf(clamp(overall + studyBoost, 0, 9));
 
   if (typeof pastBand === 'number') {
@@ -65,17 +72,17 @@ export function scorePredictor(input: PredictorInput): PredictorResult {
   }
 
   const filled =
-    (input.readingWpm != null ? 1 : 0) +
-    (input.readingAccuracy != null ? 1 : 0) +
-    (input.listeningAccuracy != null ? 1 : 0) +
-    (input.speakingFluency != null ? 1 : 0) +
-    (input.speakingPronunciation != null ? 1 : 0) +
-    (input.writingTaskResponse != null ? 1 : 0) +
-    (input.writingCoherence != null ? 1 : 0) +
-    (input.writingGrammar != null ? 1 : 0) +
-    (input.writingLexical != null ? 1 : 0) +
-    (input.studyHoursPerWeek != null ? 1 : 0) +
-    (input.pastBand != null ? 1 : 0);
+    (raw.readingWpm != null ? 1 : 0) +
+    (raw.readingAccuracy != null ? 1 : 0) +
+    (raw.listeningAccuracy != null ? 1 : 0) +
+    (raw.speakingFluency != null ? 1 : 0) +
+    (raw.speakingPronunciation != null ? 1 : 0) +
+    (raw.writingTaskResponse != null ? 1 : 0) +
+    (raw.writingCoherence != null ? 1 : 0) +
+    (raw.writingGrammar != null ? 1 : 0) +
+    (raw.writingLexical != null ? 1 : 0) +
+    (raw.studyHoursPerWeek != null ? 1 : 0) +
+    (raw.pastBand != null ? 1 : 0);
   const confidence = clamp(0.3 + (filled / 11) * 0.7, 0.3, 1);
 
   const advice: string[] = [];
@@ -85,5 +92,13 @@ export function scorePredictor(input: PredictorInput): PredictorResult {
   if (writing < overall) advice.push('Practice Task-2 essays; focus on Coherence and Grammar.');
   if (study < 8) advice.push('Study at least 8–12 hours/week for faster gains.');
 
-  return { overall, breakdown: { reading, listening, speaking, writing }, confidence: Number(confidence.toFixed(2)), advice };
+  return {
+    overall,
+    breakdown: { reading, listening, speaking, writing },
+    confidence: Number(confidence.toFixed(2)),
+    advice,
+  };
 }
+
+export const predictorUtils = { clamp, roundHalf };
+

--- a/pages/api/predictor/score.ts
+++ b/pages/api/predictor/score.ts
@@ -1,118 +1,23 @@
 // pages/api/predictor/score.ts
 import type { NextApiHandler } from 'next';
 
-type PredictorInput = Readonly<{
-  readingWpm?: number;             // words per minute (0-400)
-  readingAccuracy?: number;        // 0-100
-  listeningAccuracy?: number;      // 0-100
-  speakingFluency?: number;        // 0-100
-  speakingPronunciation?: number;  // 0-100
-  writingTaskResponse?: number;    // 0-100
-  writingCoherence?: number;       // 0-100
-  writingGrammar?: number;         // 0-100
-  writingLexical?: number;         // 0-100
-  studyHoursPerWeek?: number;      // 0-40+
-  pastBand?: number;               // 0-9
-}>;
+import { runPredictor, type PredictorInput, type PredictorResult } from '@/lib/predictor';
 
-type Breakdown = Readonly<{
-  reading: number;
-  listening: number;
-  speaking: number;
-  writing: number;
-}>;
-
-type Success = Readonly<{
-  ok: true;
-  overall: number;
-  breakdown: Breakdown;
-  confidence: number; // 0..1
-  advice: string[];
-}>;
+type Success = Readonly<{ ok: true } & PredictorResult>;
 type Failure = Readonly<{ ok: false; error: string }>;
 type ResBody = Success | Failure;
-
-function clamp(n: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, n));
-}
-function roundHalf(x: number) {
-  return Math.round(x * 2) / 2;
-}
-function scale100ToBand(x: number, minBand = 4, maxBand = 9) {
-  const b = minBand + (clamp(x, 0, 100) / 100) * (maxBand - minBand);
-  return clamp(b, minBand, maxBand);
-}
 
 const handler: NextApiHandler<ResBody> = async (req, res) => {
   if (req.method !== 'POST') return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
 
-  const body: PredictorInput = req.body ?? {};
-  // Basic validation (keep permissive; model is heuristic)
-  const study = clamp(Number(body.studyHoursPerWeek ?? 0), 0, 60);
-  const pastBand = body.pastBand != null ? clamp(Number(body.pastBand), 0, 9) : undefined;
-
-  // Reading: blend WPM + accuracy
-  const wpm = clamp(Number(body.readingWpm ?? 0), 0, 400);
-  const rAcc = clamp(Number(body.readingAccuracy ?? 0), 0, 100);
-  const reading = roundHalf(scale100ToBand(0.6 * (wpm / 4) + 0.4 * rAcc));
-
-  // Listening: accuracy heavy
-  const lAcc = clamp(Number(body.listeningAccuracy ?? 0), 0, 100);
-  const listening = roundHalf(scale100ToBand(lAcc));
-
-  // Speaking: average fluency + pronunciation
-  const sFlu = clamp(Number(body.speakingFluency ?? 0), 0, 100);
-  const sPro = clamp(Number(body.speakingPronunciation ?? 0), 0, 100);
-  const speaking = roundHalf(scale100ToBand(0.5 * sFlu + 0.5 * sPro));
-
-  // Writing: average four criteria
-  const wTR = clamp(Number(body.writingTaskResponse ?? 0), 0, 100);
-  const wCC = clamp(Number(body.writingCoherence ?? 0), 0, 100);
-  const wGRA = clamp(Number(body.writingGrammar ?? 0), 0, 100);
-  const wLEX = clamp(Number(body.writingLexical ?? 0), 0, 100);
-  const writing = roundHalf(scale100ToBand((wTR + wCC + wGRA + wLEX) / 4));
-
-  // Base overall: IELTS average rule (round to nearest 0.5)
-  let overall = roundHalf((reading + listening + speaking + writing) / 4);
-
-  // Study boost: up to +0.5 for 8–12h/wk, +1.0 for 13–20h/wk (capped)
-  const studyBoost = study >= 20 ? 1 : study >= 12 ? 0.5 + (study - 12) * (0.5 / 8) : study >= 8 ? (study - 8) * (0.5 / 4) : 0;
-  overall = roundHalf(clamp(overall + studyBoost, 0, 9));
-
-  // Anchor toward past performance slightly
-  if (typeof pastBand === 'number') {
-    overall = roundHalf(0.8 * overall + 0.2 * pastBand);
+  try {
+    const body: PredictorInput = (typeof req.body === 'object' && req.body !== null ? req.body : {}) as PredictorInput;
+    const result = runPredictor(body);
+    return res.status(200).json({ ok: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Prediction failed';
+    return res.status(400).json({ ok: false, error: message });
   }
-
-  // Confidence: higher when inputs are rich
-  const filled =
-    (body.readingWpm != null ? 1 : 0) +
-    (body.readingAccuracy != null ? 1 : 0) +
-    (body.listeningAccuracy != null ? 1 : 0) +
-    (body.speakingFluency != null ? 1 : 0) +
-    (body.speakingPronunciation != null ? 1 : 0) +
-    (body.writingTaskResponse != null ? 1 : 0) +
-    (body.writingCoherence != null ? 1 : 0) +
-    (body.writingGrammar != null ? 1 : 0) +
-    (body.writingLexical != null ? 1 : 0) +
-    (body.studyHoursPerWeek != null ? 1 : 0) +
-    (body.pastBand != null ? 1 : 0);
-  const confidence = clamp(0.3 + (filled / 11) * 0.7, 0.3, 1);
-
-  const advice: string[] = [];
-  if (reading < overall) advice.push('Increase reading speed with timed passages (target +20 WPM).');
-  if (listening < overall) advice.push('Do daily listening dictations to lift accuracy by 5–10%.');
-  if (speaking < overall) advice.push('Record 2-minute answers and shadow native audio for pronunciation.');
-  if (writing < overall) advice.push('Practice Task-2 essays; focus on Coherence and Grammar.');
-  if (study < 8) advice.push('Study at least 8–12 hours/week for faster gains.');
-
-  return res.status(200).json({
-    ok: true,
-    overall,
-    breakdown: { reading, listening, speaking, writing },
-    confidence: Number(confidence.toFixed(2)),
-    advice,
-  });
 };
 
 export default handler;

--- a/pages/coach/index.tsx
+++ b/pages/coach/index.tsx
@@ -1,0 +1,224 @@
+import React, { useMemo, useState } from 'react';
+import Head from 'next/head';
+
+import BandBreakdown from '@/components/predictor/BandBreakdown';
+import { percentToBand, runPredictor, type PredictorResult } from '@/lib/predictor';
+import { analyzeEssay, type EssayAnalysis } from '@/lib/coach/analyzeEssay';
+
+const MIN_WORDS = 80;
+
+function formatNumber(value: number, fraction = 0) {
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: fraction,
+    minimumFractionDigits: fraction,
+  });
+}
+
+export default function CoachIndexPage() {
+  const [essay, setEssay] = useState('');
+  const [analysis, setAnalysis] = useState<EssayAnalysis | null>(null);
+  const [result, setResult] = useState<PredictorResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const liveWordCount = useMemo(() => {
+    const trimmed = essay.trim();
+    if (!trimmed) return 0;
+    return trimmed.split(/\s+/).length;
+  }, [essay]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = essay.trim();
+    const words = trimmed ? trimmed.split(/\s+/).length : 0;
+    if (words < MIN_WORDS) {
+      setError(`Please enter at least ${MIN_WORDS} words.`);
+      setAnalysis(null);
+      setResult(null);
+      return;
+    }
+
+    const computed = analyzeEssay(trimmed);
+    const prediction = runPredictor(computed.predictorInput);
+
+    setAnalysis(computed);
+    setResult(prediction);
+    setError(null);
+  };
+
+  const writingBands = useMemo(() => {
+    if (!analysis) return null;
+    return {
+      task: percentToBand(analysis.writing.taskResponse),
+      coherence: percentToBand(analysis.writing.coherence),
+      lexical: percentToBand(analysis.writing.lexical),
+      grammar: percentToBand(analysis.writing.grammar),
+    };
+  }, [analysis]);
+
+  const combinedAdvice = useMemo(() => {
+    if (!result || !analysis) return [] as string[];
+    const merged = new Set<string>([...analysis.suggestions, ...result.advice]);
+    return Array.from(merged);
+  }, [analysis, result]);
+
+  return (
+    <>
+      <Head>
+        <title>Essay Coach</title>
+      </Head>
+      <main className="min-h-screen bg-background text-foreground">
+        <div className="mx-auto max-w-5xl px-4 py-10">
+          <header className="max-w-3xl">
+            <h1 className="text-h1 font-semibold">Essay Coach</h1>
+            <p className="mt-2 text-small text-muted-foreground">
+              Paste a Task 2 style response to get an instant band estimate, writing breakdown, and coaching tips.
+            </p>
+          </header>
+
+          <form onSubmit={handleSubmit} className="mt-8">
+            <label className="block">
+              <span className="text-small font-medium">Your essay</span>
+              <textarea
+                className="mt-2 h-60 w-full rounded-xl border border-border bg-background px-4 py-3 text-small leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                placeholder="Paste your IELTS Task 2 essay here..."
+                value={essay}
+                onChange={(event) => setEssay(event.target.value)}
+              />
+            </label>
+
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-caption text-muted-foreground">
+              <span>Word count: {liveWordCount}</span>
+              <span>Minimum recommended: {MIN_WORDS} words</span>
+            </div>
+
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <button
+                type="submit"
+                className="rounded-xl bg-primary px-5 py-2.5 text-small font-medium text-primary-foreground hover:opacity-90 disabled:opacity-60"
+                disabled={!essay.trim()}
+              >
+                Get feedback
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-border px-4 py-2 text-small hover:bg-muted"
+                onClick={() => {
+                  setEssay('');
+                  setResult(null);
+                  setAnalysis(null);
+                  setError(null);
+                }}
+              >
+                Clear
+              </button>
+            </div>
+          </form>
+
+          {error ? (
+            <div className="mt-4 rounded-xl border border-destructive/50 bg-destructive/10 p-4 text-small text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          {result && analysis ? (
+            <div className="mt-10 space-y-6">
+              <BandBreakdown
+                overall={result.overall}
+                breakdown={result.breakdown}
+                confidence={result.confidence}
+                className="border-border"
+              />
+
+              <section className="grid gap-6 md:grid-cols-2">
+                <div className="rounded-xl border border-border p-4">
+                  <h2 className="text-h4 font-semibold">Writing breakdown</h2>
+                  <p className="mt-1 text-caption text-muted-foreground">
+                    Percent scores are mapped to approximate IELTS bands using our predictor heuristics.
+                  </p>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                    <MetricCard
+                      label="Task response"
+                      percent={analysis.writing.taskResponse}
+                      band={writingBands?.task ?? 0}
+                    />
+                    <MetricCard
+                      label="Coherence & cohesion"
+                      percent={analysis.writing.coherence}
+                      band={writingBands?.coherence ?? 0}
+                    />
+                    <MetricCard
+                      label="Lexical resource"
+                      percent={analysis.writing.lexical}
+                      band={writingBands?.lexical ?? 0}
+                    />
+                    <MetricCard
+                      label="Grammar range"
+                      percent={analysis.writing.grammar}
+                      band={writingBands?.grammar ?? 0}
+                    />
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-border p-4">
+                  <h2 className="text-h4 font-semibold">Essay stats</h2>
+                  <ul className="mt-3 space-y-2 text-small text-muted-foreground">
+                    <li className="flex items-center justify-between gap-4">
+                      <span>Word count</span>
+                      <span className="font-medium text-foreground">{analysis.stats.wordCount}</span>
+                    </li>
+                    <li className="flex items-center justify-between gap-4">
+                      <span>Paragraphs</span>
+                      <span className="font-medium text-foreground">{analysis.stats.paragraphCount}</span>
+                    </li>
+                    <li className="flex items-center justify-between gap-4">
+                      <span>Sentences</span>
+                      <span className="font-medium text-foreground">{analysis.stats.sentenceCount}</span>
+                    </li>
+                    <li className="flex items-center justify-between gap-4">
+                      <span>Average sentence length</span>
+                      <span className="font-medium text-foreground">
+                        {formatNumber(analysis.stats.averageSentenceLength, 1)} words
+                      </span>
+                    </li>
+                    <li className="flex items-center justify-between gap-4">
+                      <span>Linking phrases spotted</span>
+                      <span className="font-medium text-foreground">{analysis.stats.connectorCount}</span>
+                    </li>
+                    <li className="flex items-center justify-between gap-4">
+                      <span>Unique word ratio</span>
+                      <span className="font-medium text-foreground">
+                        {(analysis.stats.uniqueWordRatio * 100).toFixed(1)}%
+                      </span>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+
+              {combinedAdvice.length ? (
+                <section className="rounded-xl border border-border p-4">
+                  <h2 className="text-h4 font-semibold">Coaching tips</h2>
+                  <ul className="mt-2 list-disc space-y-2 pl-5 text-small text-muted-foreground">
+                    {combinedAdvice.map((tip, index) => (
+                      <li key={index}>{tip}</li>
+                    ))}
+                  </ul>
+                </section>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </main>
+    </>
+  );
+}
+
+function MetricCard({ label, percent, band }: { label: string; percent: number; band: number }) {
+  return (
+    <div className="rounded-lg border border-lightBorder bg-card/60 p-3">
+      <p className="text-caption text-muted-foreground uppercase tracking-wide">{label}</p>
+      <p className="mt-2 text-h4 font-semibold">{Math.round(percent)}%</p>
+      <p className="text-caption text-muted-foreground">≈ Band {band.toFixed(1)}</p>
+    </div>
+  );
+}
+

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -25,7 +25,6 @@ import dynamic from 'next/dynamic';
 const StudyCalendar = dynamic(() => import('@/components/feature/StudyCalendar'), { ssr: false });
 import GoalRoadmap from '@/components/feature/GoalRoadmap';
 import GapToGoal from '@/components/visa/GapToGoal';
-import MotivationCoach from '@/components/coach/MotivationCoach';
 import type { Profile, AIPlan } from '@/types/profile';
 import { SavedItems } from '@/components/dashboard/SavedItems';
 import ShareLinkCard from '@/components/dashboard/ShareLinkCard';
@@ -418,11 +417,6 @@ export default function Dashboard() {
               </Link>
             </div>
           </Card>
-        </div>
-
-        {/* Motivation coach */}
-        <div className="mt-10">
-          <MotivationCoach />
         </div>
 
         {/* Coach notes */}

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -24,7 +24,6 @@ import dynamic from 'next/dynamic';
 const StudyCalendar = dynamic(() => import('@/components/feature/StudyCalendar'), { ssr: false });
 import GoalRoadmap from '@/components/feature/GoalRoadmap';
 import GapToGoal from '@/components/visa/GapToGoal';
-import MotivationCoach from '@/components/coach/MotivationCoach';
 import type { Profile, AIPlan } from '@/types/profile';
 import { SavedItems } from '@/components/dashboard/SavedItems';
 import ShareLinkCard from '@/components/dashboard/ShareLinkCard';
@@ -414,11 +413,6 @@ export default function Dashboard() {
               </Button>
             </div>
           </Card>
-        </div>
-
-        {/* Motivation coach */}
-        <div className="mt-10">
-          <MotivationCoach />
         </div>
 
         {/* Coach notes */}


### PR DESCRIPTION
## Summary
- extract the heuristic band predictor into a shared library
- add an essay coach page that turns text into predictor inputs and surfaces writing advice
- remove the Motivation Coach widget from dashboard/settings to hide AI coach references

## Testing
- not run (npm install is currently failing in the sandbox environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5f024f87083218f82fb251bc2a86b