### PR TITLE
Handle interactive elements within draggable assistant header

### DIFF
--- a/components/auth/AuthAssistant.tsx
+++ b/components/auth/AuthAssistant.tsx
@@ -133,6 +133,15 @@ export default function AuthAssistant() {
 
   function handlePointerDown(event: React.PointerEvent<HTMLDivElement>) {
     if (!panelRef.current) return;
+    const target = event.target as HTMLElement | null;
+    if (target) {
+      const interactive = target.closest(
+        'button, a, input, textarea, select, [role="button"], [role="link"]'
+      );
+      if (interactive) {
+        return;
+      }
+    }
     event.preventDefault();
     const panel = panelRef.current;
     const rect = panel.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- ignore pointer-down events that originate from interactive elements inside the assistant header
- allow the close button to receive click events while keeping drag support elsewhere in the header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5fae6581083218e64004d0f91d3fd