### PR TITLE
Add autosave draft support to writing practice page

### DIFF
--- a/components/writing/Editor.tsx
+++ b/components/writing/Editor.tsx
@@ -1,0 +1,350 @@
+import React from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+
+import { Badge } from '@/components/design-system/Badge';
+import { Button } from '@/components/design-system/Button';
+import { Card, CardContent, CardHeader } from '@/components/design-system/Card';
+import { Modal } from '@/components/design-system/Modal';
+import {
+  clearDraft,
+  countWords,
+  loadDraft,
+  markDraftSynced,
+  saveDraft,
+  shouldSyncServer,
+  type WritingDraftRecord,
+} from '@/lib/storage/drafts';
+
+export interface WritingTask {
+  title: string;
+  prompt: string;
+  minWords: number;
+  maxTimeMinutes?: number;
+  hints?: string[];
+  outline?: string[];
+  assessment?: {
+    criteria: string[];
+  };
+  type?: string;
+}
+
+export interface WritingPaper {
+  id: string;
+  task1: WritingTask;
+  task2: WritingTask;
+}
+
+type Status = 'idle' | 'saving' | 'saved';
+
+const STORAGE_PREFIX = 'writing:';
+
+const createAttemptId = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `attempt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const formatSavedText = (timestamp: number | null) => {
+  if (!timestamp) return 'Not saved yet';
+  const delta = Date.now() - timestamp;
+  if (delta < 15_000) return 'Saved just now';
+  if (delta < 60_000) return `Saved ${Math.round(delta / 1000)}s ago`;
+  if (delta < 3_600_000) return `Saved ${Math.round(delta / 60000)}m ago`;
+  return `Saved at ${new Date(timestamp).toLocaleTimeString()}`;
+};
+
+const isBrowser = typeof window !== 'undefined';
+
+export interface WritingEditorProps {
+  paper: WritingPaper;
+}
+
+export const WritingEditor: React.FC<WritingEditorProps> = ({ paper }) => {
+  const storageKey = React.useMemo(() => `${STORAGE_PREFIX}${paper.id}`, [paper.id]);
+  const pendingDraftRef = React.useRef<WritingDraftRecord | null>(null);
+
+  const [task1, setTask1] = React.useState('');
+  const [task2, setTask2] = React.useState('');
+  const [status, setStatus] = React.useState<Status>('idle');
+  const [lastSavedAt, setLastSavedAt] = React.useState<number | null>(null);
+  const [restoreOpen, setRestoreOpen] = React.useState(false);
+  const [initialized, setInitialized] = React.useState(false);
+
+  const attemptIdRef = React.useRef<string>(createAttemptId());
+  const startedAtRef = React.useRef<number>(Date.now());
+  const syncedAtRef = React.useRef<number | undefined>(undefined);
+
+  React.useEffect(() => {
+    if (!isBrowser) return;
+    const existing = loadDraft(storageKey);
+    if (existing && (existing.content.task1 || existing.content.task2)) {
+      pendingDraftRef.current = existing;
+      setLastSavedAt(existing.updatedAt);
+      setStatus('saved');
+      setRestoreOpen(true);
+      attemptIdRef.current = existing.attemptId;
+      startedAtRef.current = existing.startedAt;
+      syncedAtRef.current = existing.syncedAt;
+    } else {
+      setInitialized(true);
+      setStatus('idle');
+    }
+  }, [storageKey]);
+
+  const wordCount1 = React.useMemo(() => countWords(task1), [task1]);
+  const wordCount2 = React.useMemo(() => countWords(task2), [task2]);
+
+  const persistDraft = React.useCallback(
+    (timestamp: number) => {
+      const draft: WritingDraftRecord = {
+        attemptId: attemptIdRef.current,
+        startedAt: startedAtRef.current,
+        updatedAt: timestamp,
+        syncedAt: syncedAtRef.current,
+        content: {
+          task1,
+          task2,
+          task1WordCount: wordCount1,
+          task2WordCount: wordCount2,
+        },
+      };
+      saveDraft(storageKey, draft);
+      setLastSavedAt(timestamp);
+      return draft;
+    },
+    [storageKey, task1, task2, wordCount1, wordCount2],
+  );
+
+  const syncToServer = React.useCallback(
+    async (draft: WritingDraftRecord) => {
+      if (!shouldSyncServer(draft, Date.now())) return;
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) return;
+      try {
+        const res = await fetch('/api/writing/draft', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            paperId: paper.id,
+            attemptId: draft.attemptId,
+            updatedAt: draft.updatedAt,
+            startedAt: draft.startedAt,
+            content: draft.content,
+          }),
+        });
+        if (!res.ok) return;
+        const json = (await res.json()) as { ok?: boolean };
+        if (json?.ok) {
+          syncedAtRef.current = draft.updatedAt;
+          const next = markDraftSynced(draft, draft.updatedAt);
+          saveDraft(storageKey, next);
+        }
+      } catch {
+        // Ignore server sync failures
+      }
+    },
+    [paper.id, storageKey],
+  );
+
+  const debouncedSave = useDebouncedCallback(() => {
+    const now = Date.now();
+    const draft = persistDraft(now);
+    setStatus('saved');
+    void syncToServer(draft);
+  }, 8000);
+
+  React.useEffect(() => {
+    if (!initialized) return;
+    setStatus('saving');
+    debouncedSave();
+    return () => {
+      debouncedSave.cancel();
+    };
+  }, [task1, task2, debouncedSave, initialized]);
+
+  React.useEffect(() => () => {
+    debouncedSave.flush();
+  }, [debouncedSave]);
+
+  const persistNow = React.useCallback(() => {
+    if (!initialized) return;
+    debouncedSave.cancel();
+    const now = Date.now();
+    const draft = persistDraft(now);
+    setStatus('saved');
+    void syncToServer(draft);
+  }, [debouncedSave, initialized, persistDraft, syncToServer]);
+
+  React.useEffect(() => {
+    if (!isBrowser || !initialized) return;
+    const handleBeforeUnload = () => {
+      persistNow();
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [initialized, persistNow]);
+
+  const handleRestore = React.useCallback(() => {
+    const draft = pendingDraftRef.current;
+    if (draft) {
+      setTask1(draft.content.task1);
+      setTask2(draft.content.task2);
+      setLastSavedAt(draft.updatedAt);
+      attemptIdRef.current = draft.attemptId;
+      startedAtRef.current = draft.startedAt;
+      syncedAtRef.current = draft.syncedAt;
+    }
+    pendingDraftRef.current = null;
+    setRestoreOpen(false);
+    setInitialized(true);
+    setStatus(draft ? 'saved' : 'idle');
+  }, []);
+
+  const handleDiscard = React.useCallback(() => {
+    pendingDraftRef.current = null;
+    clearDraft(storageKey);
+    setTask1('');
+    setTask2('');
+    setLastSavedAt(null);
+    attemptIdRef.current = createAttemptId();
+    startedAtRef.current = Date.now();
+    syncedAtRef.current = undefined;
+    setRestoreOpen(false);
+    setInitialized(true);
+    setStatus('idle');
+  }, [storageKey]);
+
+  const handleClearAll = React.useCallback(() => {
+    if (!isBrowser) return;
+    const confirmClear = window.confirm('Clear this draft? Your unsaved writing will be lost.');
+    if (!confirmClear) return;
+    clearDraft(storageKey);
+    setTask1('');
+    setTask2('');
+    setLastSavedAt(null);
+    attemptIdRef.current = createAttemptId();
+    startedAtRef.current = Date.now();
+    syncedAtRef.current = undefined;
+    setStatus('idle');
+  }, [storageKey]);
+
+  return (
+    <div className="grid gap-6">
+      <Modal open={restoreOpen} onClose={handleRestore} title="Resume draft?" size="sm">
+        <p className="text-body text-muted-foreground">
+          We found a saved draft from your last session. Would you like to continue where you left off?
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="secondary" onClick={handleDiscard}>
+            Start fresh
+          </Button>
+          <Button variant="primary" onClick={handleRestore}>
+            Restore
+          </Button>
+        </div>
+      </Modal>
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-h3 font-semibold">Task 1</h2>
+          <p className="text-small text-muted-foreground">{paper.task1.title}</p>
+        </div>
+        <Badge variant={status === 'saving' ? 'info' : 'success'} size="sm">
+          {status === 'saving' ? 'Saving…' : formatSavedText(lastSavedAt)}
+        </Badge>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-small font-medium text-muted-foreground">Prompt</span>
+            <p className="text-body leading-relaxed">{paper.task1.prompt}</p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-caption text-muted-foreground">
+            <span>Minimum {paper.task1.minWords} words</span>
+            {paper.task1.maxTimeMinutes ? <span>Suggested time: {paper.task1.maxTimeMinutes} minutes</span> : null}
+            {paper.task1.type ? <span>Type: {paper.task1.type}</span> : null}
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          {paper.task1.hints && paper.task1.hints.length > 0 ? (
+            <div className="rounded-ds-xl border border-border/70 bg-muted/30 p-4">
+              <p className="text-small font-medium text-muted-foreground">Hints</p>
+              <ul className="mt-2 list-disc space-y-1 pl-4 text-small text-muted-foreground/90">
+                {paper.task1.hints.map((hint) => (
+                  <li key={hint}>{hint}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <label className="grid gap-2">
+            <span className="text-small font-medium text-muted-foreground">Your response</span>
+            <textarea
+              className="min-h-[180px] w-full rounded-ds-xl border border-border bg-background p-4 text-body leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="Summarise the key trends…"
+              value={task1}
+              onChange={(event) => setTask1(event.target.value)}
+              onBlur={persistNow}
+            />
+            <span className="text-caption text-muted-foreground">
+              {wordCount1} words • minimum {paper.task1.minWords}
+            </span>
+          </label>
+        </CardContent>
+      </Card>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-h3 font-semibold">Task 2</h2>
+          <p className="text-small text-muted-foreground">{paper.task2.title}</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-small font-medium text-muted-foreground">Prompt</span>
+            <p className="text-body leading-relaxed">{paper.task2.prompt}</p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-caption text-muted-foreground">
+            <span>Minimum {paper.task2.minWords} words</span>
+            {paper.task2.maxTimeMinutes ? <span>Suggested time: {paper.task2.maxTimeMinutes} minutes</span> : null}
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          {paper.task2.outline && paper.task2.outline.length > 0 ? (
+            <div className="rounded-ds-xl border border-border/70 bg-muted/30 p-4">
+              <p className="text-small font-medium text-muted-foreground">Suggested outline</p>
+              <ul className="mt-2 list-disc space-y-1 pl-4 text-small text-muted-foreground/90">
+                {paper.task2.outline.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <label className="grid gap-2">
+            <span className="text-small font-medium text-muted-foreground">Your essay</span>
+            <textarea
+              className="min-h-[280px] w-full rounded-ds-xl border border-border bg-background p-4 text-body leading-relaxed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              placeholder="Plan, write, and review your essay…"
+              value={task2}
+              onChange={(event) => setTask2(event.target.value)}
+              onBlur={persistNow}
+            />
+            <span className="text-caption text-muted-foreground">
+              {wordCount2} words • minimum {paper.task2.minWords}
+            </span>
+          </label>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end">
+        <Button variant="secondary" onClick={handleClearAll}>
+          Clear draft
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default WritingEditor;

--- a/lib/storage/drafts.ts
+++ b/lib/storage/drafts.ts
@@ -1,0 +1,139 @@
+const STORAGE_VERSION = 1;
+
+export interface WritingDraftContent {
+  task1: string;
+  task2: string;
+  task1WordCount: number;
+  task2WordCount: number;
+}
+
+export interface WritingDraftRecord {
+  attemptId: string;
+  startedAt: number;
+  updatedAt: number;
+  syncedAt?: number;
+  content: WritingDraftContent;
+}
+
+type SerializedDraft = {
+  v: number;
+  attemptId: string;
+  startedAt: number;
+  updatedAt: number;
+  syncedAt?: number;
+  content: WritingDraftContent;
+};
+
+const isBrowser = typeof window !== 'undefined';
+
+const clampNumber = (value: unknown, fallback: number) => {
+  const n = typeof value === 'number' && Number.isFinite(value) ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const sanitizeContent = (payload: any): WritingDraftContent => {
+  const task1 = typeof payload?.task1 === 'string' ? payload.task1 : '';
+  const task2 = typeof payload?.task2 === 'string' ? payload.task2 : '';
+  const task1WordCount = clampNumber(payload?.task1WordCount, countWords(task1));
+  const task2WordCount = clampNumber(payload?.task2WordCount, countWords(task2));
+  return {
+    task1,
+    task2,
+    task1WordCount,
+    task2WordCount,
+  };
+};
+
+const sanitizeDraft = (raw: any): WritingDraftRecord | null => {
+  if (!raw || typeof raw !== 'object') return null;
+  const attemptId = typeof raw.attemptId === 'string' && raw.attemptId.trim() ? raw.attemptId : null;
+  if (!attemptId) return null;
+  const startedAt = clampNumber(raw.startedAt, Date.now());
+  const updatedAt = clampNumber(raw.updatedAt, startedAt);
+  const syncedAt = raw.syncedAt !== undefined ? clampNumber(raw.syncedAt, updatedAt) : undefined;
+
+  const content = sanitizeContent(raw.content);
+
+  return {
+    attemptId,
+    startedAt,
+    updatedAt,
+    syncedAt,
+    content,
+  };
+};
+
+export function serializeDraft(draft: WritingDraftRecord): string {
+  const payload: SerializedDraft = {
+    v: STORAGE_VERSION,
+    attemptId: draft.attemptId,
+    startedAt: draft.startedAt,
+    updatedAt: draft.updatedAt,
+    content: draft.content,
+  };
+  if (typeof draft.syncedAt === 'number') {
+    payload.syncedAt = draft.syncedAt;
+  }
+  return JSON.stringify(payload);
+}
+
+export function deserializeDraft(raw: string | null | undefined): WritingDraftRecord | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<SerializedDraft> & { version?: number };
+    const version = clampNumber(parsed?.v ?? parsed?.version ?? STORAGE_VERSION, STORAGE_VERSION);
+    if (version > STORAGE_VERSION) return null;
+    return sanitizeDraft(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function loadDraft(key: string): WritingDraftRecord | null {
+  if (!isBrowser) return null;
+  try {
+    return deserializeDraft(window.localStorage.getItem(key));
+  } catch {
+    return null;
+  }
+}
+
+export function saveDraft(key: string, draft: WritingDraftRecord): void {
+  if (!isBrowser) return;
+  try {
+    window.localStorage.setItem(key, serializeDraft(draft));
+  } catch {
+    // Swallow quota or private browsing exceptions
+  }
+}
+
+export function clearDraft(key: string): void {
+  if (!isBrowser) return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // ignore removal failures
+  }
+}
+
+export function markDraftSynced(draft: WritingDraftRecord, timestamp: number): WritingDraftRecord {
+  return { ...draft, syncedAt: timestamp };
+}
+
+export function shouldSyncServer(draft: WritingDraftRecord, now: number, minimumElapsedMs = 3 * 60 * 1000): boolean {
+  if (!draft?.attemptId) return false;
+  if (now - draft.startedAt < minimumElapsedMs) return false;
+  if (typeof draft.syncedAt === 'number' && draft.updatedAt <= draft.syncedAt) return false;
+  return true;
+}
+
+export function countWords(text: string): number {
+  if (!text) return 0;
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  return words.length;
+}
+
+export type WritingDraftSyncPayload = {
+  paperId: string;
+  draft: WritingDraftRecord;
+};

--- a/pages/api/writing/draft.ts
+++ b/pages/api/writing/draft.ts
@@ -1,0 +1,80 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+
+import { getServerClient } from '@/lib/supabaseServer';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+const BodySchema = z.object({
+  paperId: z.string().min(1),
+  attemptId: z.string().min(1),
+  startedAt: z.number().optional(),
+  updatedAt: z.number(),
+  content: z.object({
+    task1: z.string(),
+    task2: z.string(),
+    task1WordCount: z.number(),
+    task2WordCount: z.number(),
+  }),
+});
+
+type Resp =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Resp>) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ ok: false, error: 'Method not allowed' });
+  }
+
+  const parsed = BodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'Invalid payload' });
+  }
+
+  const supabase = getServerClient(req, res);
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return res.status(401).json({ ok: false, error: 'Unauthenticated' });
+  }
+
+  const { paperId, attemptId, startedAt, updatedAt, content } = parsed.data;
+
+  try {
+    const startedIso = new Date(startedAt ?? updatedAt).toISOString();
+    const updatedIso = new Date(updatedAt).toISOString();
+
+    const { error } = await supabaseAdmin
+      .from('attempts_writing')
+      .upsert(
+        {
+          id: attemptId,
+          user_id: user.id,
+          prompt_id: paperId,
+          started_at: startedIso,
+          submitted_at: null,
+          content_text: JSON.stringify({
+            version: 1,
+            updatedAt: updatedIso,
+            tasks: {
+              task1: { text: content.task1, wordCount: content.task1WordCount },
+              task2: { text: content.task2, wordCount: content.task2WordCount },
+            },
+          }),
+        },
+        { onConflict: 'id' },
+      );
+
+    if (error) {
+      throw error;
+    }
+
+    return res.status(200).json({ ok: true });
+  } catch (err: any) {
+    console.error('writing draft persistence failed', err);
+    return res.status(200).json({ ok: false, error: err?.message ?? 'Persistence failed' });
+  }
+}

--- a/pages/writing/[id].tsx
+++ b/pages/writing/[id].tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { Badge } from '@/components/design-system/Badge';
+import { Card } from '@/components/design-system/Card';
+import { WritingEditor, type WritingPaper } from '@/components/writing/Editor';
+import samplePaper from '@/data/writing/sample-001.json';
+
+const fallbackPaper = samplePaper as WritingPaper;
+
+const loadPaper = async (slug: string): Promise<WritingPaper> => {
+  try {
+    const mod = await import(`@/data/writing/${slug}.json`);
+    return mod.default as WritingPaper;
+  } catch {
+    return fallbackPaper;
+  }
+};
+
+const useWritingPaper = (id?: string) => {
+  const [paper, setPaper] = React.useState<WritingPaper | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    loadPaper(id)
+      .then((data) => {
+        if (!cancelled) setPaper(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('We could not load that prompt. Showing a sample instead.');
+        if (!cancelled) setPaper(fallbackPaper);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return { paper, loading, error } as const;
+};
+
+export default function WritingAttemptPage() {
+  const router = useRouter();
+  const { id } = router.query as { id?: string };
+  const { paper, loading, error } = useWritingPaper(id);
+
+  return (
+    <>
+      <Head>
+        <title>{paper ? `${paper.task2.title} – Writing practice` : 'Writing practice'} • GramorX</title>
+      </Head>
+      <section className="bg-lightBg py-16 dark:bg-dark/80">
+        <Container>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h1 className="font-slab text-h2 text-foreground md:text-display">Writing practice</h1>
+              <p className="mt-2 max-w-2xl text-body text-muted-foreground">
+                Draft Task 1 and Task 2 responses with automatic saving. Refreshing or closing the tab will not lose your work.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Badge variant="neutral" size="sm">Task 1 visual report</Badge>
+              <Badge variant="neutral" size="sm">Task 2 essay</Badge>
+            </div>
+          </div>
+
+          <Card className="card-surface mt-8 p-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <Button variant="secondary" onClick={() => router.push('/writing')}>
+                ← All prompts
+              </Button>
+              {paper ? <Badge variant="info" size="sm">Prompt: {paper.id}</Badge> : null}
+            </div>
+
+            <div className="mt-6">
+              {loading && <p className="text-body text-muted-foreground">Loading prompt…</p>}
+              {error && <p className="text-small text-warning">{error}</p>}
+              {paper && !loading ? (
+                <div className="mt-6">
+                  <WritingEditor paper={paper} />
+                </div>
+              ) : null}
+            </div>
+          </Card>
+        </Container>
+      </section>
+    </>
+  );
+}

--- a/tests/lib/storage/drafts.test.ts
+++ b/tests/lib/storage/drafts.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  countWords,
+  deserializeDraft,
+  markDraftSynced,
+  serializeDraft,
+  shouldSyncServer,
+  type WritingDraftRecord,
+} from '../../../lib/storage/drafts';
+
+describe('storage/drafts serializer', () => {
+  const baseDraft: WritingDraftRecord = {
+    attemptId: 'draft-1',
+    startedAt: 1_000,
+    updatedAt: 2_000,
+    content: {
+      task1: 'First task content',
+      task2: 'Second task response',
+      task1WordCount: 3,
+      task2WordCount: 3,
+    },
+  };
+
+  it('round-trips a draft', () => {
+    const raw = serializeDraft(baseDraft);
+    const parsed = deserializeDraft(raw);
+    expect(parsed).toEqual(baseDraft);
+  });
+
+  it('ignores malformed payloads', () => {
+    expect(deserializeDraft('not-json')).toBeNull();
+    expect(deserializeDraft('{"attemptId": ""}')).toBeNull();
+  });
+
+  it('marks a draft as synced and prevents re-sync until updated', () => {
+    const synced = markDraftSynced(baseDraft, 2_000);
+    expect(shouldSyncServer(synced, 2_000 + 200_000)).toBe(false);
+
+    const updated: WritingDraftRecord = { ...synced, updatedAt: synced.updatedAt + 10_000 };
+    const almostThreeMinutes = updated.startedAt + 180_000 - 1;
+    expect(shouldSyncServer(updated, almostThreeMinutes)).toBe(false);
+    expect(shouldSyncServer(updated, almostThreeMinutes + 2)).toBe(true);
+  });
+
+  it('counts words robustly', () => {
+    expect(countWords('')).toBe(0);
+    expect(countWords(' one  two three ')).toBe(3);
+    expect(countWords('\n spaced\nwords \t tabs')).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated writing editor that debounces saves, restores drafts, and shows saved status
- introduce shared draft storage utilities plus an API endpoint to sync to Supabase after longer sessions
- expose the editor on a new /writing/[id] page and cover draft serialization with unit tests

## Testing
- npx vitest run tests/lib/storage/drafts.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5f8752e3483219462e85fabc2f1c3