### PR TITLE
Add server-backed mock attempt checkpoints and resume flow

### DIFF
--- a/lib/mock/state.ts
+++ b/lib/mock/state.ts
@@ -1,0 +1,119 @@
+export type MockSection = 'listening' | 'reading' | 'writing' | 'speaking';
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+const ACTIVE_KEY = (section: MockSection, mockId: string) => `mock:active:${section}:${mockId}`;
+
+const getStorage = (): StorageLike | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch (err) {
+    return null;
+  }
+};
+
+const randomId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `mock-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+};
+
+export const ensureMockAttemptId = (section: MockSection, mockId: string) => {
+  const storage = getStorage();
+  if (!storage) return randomId();
+  const key = ACTIVE_KEY(section, mockId);
+  const existing = storage.getItem(key);
+  if (existing) return existing;
+  const fresh = randomId();
+  try {
+    storage.setItem(key, fresh);
+  } catch {
+    // ignore storage write failures
+  }
+  return fresh;
+};
+
+export const clearMockAttemptId = (section: MockSection, mockId: string) => {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(ACTIVE_KEY(section, mockId));
+  } catch {
+    // ignore
+  }
+};
+
+export const setMockAttemptId = (section: MockSection, mockId: string, attemptId: string) => {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(ACTIVE_KEY(section, mockId), attemptId);
+  } catch {
+    // ignore storage write failures
+  }
+};
+
+export type MockCheckpointPayload = Record<string, unknown>;
+
+export interface MockCheckpoint {
+  attemptId: string;
+  section: MockSection;
+  mockId: string;
+  payload: MockCheckpointPayload;
+  elapsed: number;
+  duration?: number | null;
+  updatedAt: string;
+}
+
+export interface SaveCheckpointInput {
+  attemptId: string;
+  section: MockSection;
+  mockId: string;
+  payload: MockCheckpointPayload;
+  elapsed: number;
+  duration?: number;
+  completed?: boolean;
+}
+
+type SaveResponse = { ok: true } | { ok: false; error: string };
+
+type FetchResponse =
+  | { ok: true; checkpoint: MockCheckpoint | null }
+  | { ok: false; error: string };
+
+export async function saveMockCheckpoint(input: SaveCheckpointInput): Promise<boolean> {
+  try {
+    const res = await fetch('/api/mock/checkpoint', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!res.ok) return false;
+    const json = (await res.json()) as SaveResponse;
+    return json.ok;
+  } catch (err) {
+    return false;
+  }
+}
+
+export async function fetchMockCheckpoint(params: {
+  attemptId?: string;
+  section?: MockSection;
+}): Promise<MockCheckpoint | null> {
+  try {
+    const search = new URLSearchParams();
+    if (params.attemptId) search.set('attemptId', params.attemptId);
+    if (params.section) search.set('section', params.section);
+    const qs = search.toString();
+    const url = `/api/mock/checkpoint${qs ? `?${qs}` : ''}`;
+    const res = await fetch(url, { method: 'GET' });
+    if (!res.ok) return null;
+    const json = (await res.json()) as FetchResponse;
+    if (!json.ok) return null;
+    return json.checkpoint ?? null;
+  } catch (err) {
+    return null;
+  }
+}

--- a/pages/api/mock/checkpoint.ts
+++ b/pages/api/mock/checkpoint.ts
@@ -1,0 +1,140 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import type { MockSection } from '@/lib/mock/state';
+
+type PostBody = {
+  attemptId?: string;
+  section?: MockSection;
+  mockId?: string;
+  payload?: Record<string, unknown>;
+  elapsed?: number;
+  duration?: number;
+  completed?: boolean;
+};
+
+type PostResponse = { ok: true } | { ok: false; error: string };
+
+type GetResponse =
+  | { ok: true; checkpoint: { attemptId: string; section: MockSection; mockId: string; payload: Record<string, unknown>; elapsed: number; duration?: number | null; updatedAt: string } | null }
+  | { ok: false; error: string };
+
+const isSection = (value: unknown): value is MockSection =>
+  typeof value === 'string' && ['listening', 'reading', 'writing', 'speaking'].includes(value);
+
+const normalizeElapsed = (value?: number) => {
+  if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.round(value));
+};
+
+const normalizeDuration = (value?: number) => {
+  if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) return null;
+  return Math.max(0, Math.round(value));
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<PostResponse | GetResponse>) {
+  if (req.method === 'POST') {
+    return postHandler(req, res);
+  }
+  if (req.method === 'GET') {
+    return getHandler(req, res);
+  }
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).json({ ok: false, error: 'Method not allowed' });
+}
+
+async function postHandler(req: NextApiRequest, res: NextApiResponse<PostResponse>) {
+  const { attemptId, section, mockId, payload, elapsed, duration, completed = false }: PostBody = req.body || {};
+
+  if (!attemptId || typeof attemptId !== 'string') {
+    return res.status(400).json({ ok: false, error: 'attemptId is required' });
+  }
+  if (!isSection(section)) {
+    return res.status(400).json({ ok: false, error: 'section is invalid' });
+  }
+  if (!mockId || typeof mockId !== 'string') {
+    return res.status(400).json({ ok: false, error: 'mockId is required' });
+  }
+
+  const supabase = createSupabaseServerClient({ req, res });
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData?.user?.id) {
+    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  }
+
+  try {
+    const { error } = await supabase
+      .from('mock_attempts')
+      .upsert(
+        {
+          user_id: userData.user.id,
+          attempt_id: attemptId,
+          section,
+          mock_id: mockId,
+          payload: payload ?? {},
+          elapsed_sec: normalizeElapsed(elapsed),
+          duration_sec: normalizeDuration(duration),
+          completed,
+        },
+        { onConflict: 'user_id,attempt_id,section' }
+      );
+
+    if (error) throw error;
+    return res.status(200).json({ ok: true });
+  } catch (err: any) {
+    const message = err?.message || 'Failed to save checkpoint';
+    return res.status(500).json({ ok: false, error: message });
+  }
+}
+
+async function getHandler(req: NextApiRequest, res: NextApiResponse<GetResponse>) {
+  const { attemptId, section } = req.query as { attemptId?: string; section?: string };
+  if (section && !isSection(section)) {
+    return res.status(400).json({ ok: false, error: 'section is invalid' });
+  }
+
+  const supabase = createSupabaseServerClient({ req, res });
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData?.user?.id) {
+    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  }
+
+  try {
+    let query = supabase
+      .from('mock_attempts')
+      .select('attempt_id, section, mock_id, payload, elapsed_sec, duration_sec, updated_at')
+      .eq('user_id', userData.user.id)
+      .order('updated_at', { ascending: false })
+      .limit(1);
+
+    if (attemptId) {
+      query = query.eq('attempt_id', attemptId);
+    }
+    if (section) {
+      query = query.eq('section', section);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    if (!data || data.length === 0) {
+      return res.status(200).json({ ok: true, checkpoint: null });
+    }
+
+    const row = data[0];
+    return res.status(200).json({
+      ok: true,
+      checkpoint: {
+        attemptId: row.attempt_id as string,
+        section: row.section as MockSection,
+        mockId: row.mock_id as string,
+        payload: (row.payload as Record<string, unknown>) ?? {},
+        elapsed: typeof row.elapsed_sec === 'number' ? row.elapsed_sec : 0,
+        duration: typeof row.duration_sec === 'number' ? row.duration_sec : null,
+        updatedAt: row.updated_at as string,
+      },
+    });
+  } catch (err: any) {
+    const message = err?.message || 'Failed to fetch checkpoint';
+    return res.status(500).json({ ok: false, error: message });
+  }
+}

--- a/pages/mock/listening/[id].tsx
+++ b/pages/mock/listening/[id].tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { clearMockAttemptId, ensureMockAttemptId, fetchMockCheckpoint, saveMockCheckpoint } from '@/lib/mock/state';
 
 type QBase = { id: string; prompt?: string; type: 'mcq' | 'gap' | 'map' | 'short'; options?: string[]; answer: string };
 type Section = { id: string; title: string; audioUrl?: string; questions: QBase[] };
@@ -38,10 +39,11 @@ const loadPaper = async (id: string): Promise<ListeningPaper> => {
   }
 };
 
-const saveDraft = (id: string, data: { answers: AnswerMap; startedAt: string }) => {
+type DraftState = { answers: AnswerMap; startedAt: string; sectionIdx?: number };
+const saveDraft = (id: string, data: DraftState) => {
   try { localStorage.setItem(DRAFT_KEY(id), JSON.stringify(data)); } catch {}
 };
-const loadDraft = (id: string): { answers: AnswerMap; startedAt?: string } | null => {
+const loadDraft = (id: string): DraftState | null => {
   try {
     const raw = localStorage.getItem(DRAFT_KEY(id));
     return raw ? JSON.parse(raw) : null;
@@ -69,6 +71,17 @@ export default function ListeningMockPage() {
   const [secIdx, setSecIdx] = useState(0);
   const [timeLeft, setTimeLeft] = useState<number>(1800);
   const startRef = useRef<string>('');
+  const attemptRef = useRef<string>('');
+  const [attemptReady, setAttemptReady] = useState(false);
+  const [checkpointHydrated, setCheckpointHydrated] = useState(false);
+  const latestRef = useRef<{ answers: AnswerMap; secIdx: number; timeLeft: number }>({ answers: {}, secIdx: 0, timeLeft: 0 });
+
+  useEffect(() => {
+    if (!id) return;
+    const attempt = ensureMockAttemptId('listening', id);
+    attemptRef.current = attempt;
+    setAttemptReady(true);
+  }, [id]);
 
   useEffect(() => {
     if (!id) return;
@@ -77,11 +90,38 @@ export default function ListeningMockPage() {
       setPaper(p);
       setTimeLeft(p.durationSec);
       const draft = loadDraft(id);
-      if (draft?.answers) setAnswers(draft.answers);
+      if (draft?.answers) {
+        setAnswers(draft.answers);
+        if (typeof draft.sectionIdx === 'number') setSecIdx(draft.sectionIdx);
+      }
       startRef.current = draft?.startedAt ?? new Date().toISOString();
-      if (!draft) saveDraft(id, { answers: {}, startedAt: startRef.current });
+      if (!draft) saveDraft(id, { answers: {}, startedAt: startRef.current, sectionIdx: 0 });
     })();
   }, [id]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady) return;
+    let cancelled = false;
+
+    (async () => {
+      const checkpoint = await fetchMockCheckpoint({ attemptId: attemptRef.current, section: 'listening' });
+      if (cancelled) return;
+      if (checkpoint && checkpoint.mockId === paper.id) {
+        const payload = (checkpoint.payload || {}) as { answers?: AnswerMap; sectionIdx?: number; startedAt?: string };
+        if (payload.answers) setAnswers(payload.answers);
+        if (typeof payload.sectionIdx === 'number') setSecIdx(payload.sectionIdx);
+        if (typeof payload.startedAt === 'string') startRef.current = payload.startedAt;
+        const duration = typeof checkpoint.duration === 'number' ? checkpoint.duration : paper.durationSec;
+        const remaining = Math.max(0, duration - checkpoint.elapsed);
+        setTimeLeft(Math.max(0, Math.min(paper.durationSec, remaining)));
+      }
+      setCheckpointHydrated(true);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [paper, attemptReady]);
 
   useEffect(() => {
     if (!id || !paper) return;
@@ -91,8 +131,54 @@ export default function ListeningMockPage() {
 
   useEffect(() => {
     if (!id) return;
-    saveDraft(id, { answers, startedAt: startRef.current });
-  }, [id, answers]);
+    saveDraft(id, { answers, startedAt: startRef.current, sectionIdx: secIdx });
+  }, [id, answers, secIdx]);
+
+  useEffect(() => {
+    latestRef.current = { answers, secIdx, timeLeft };
+  }, [answers, secIdx, timeLeft]);
+
+  const persistCheckpoint = useCallback(
+    (opts?: { completed?: boolean }) => {
+      if (!paper || !attemptReady || !checkpointHydrated || !attemptRef.current) return;
+      const state = latestRef.current;
+      const elapsed = Math.max(0, Math.min(paper.durationSec, paper.durationSec - state.timeLeft));
+      void saveMockCheckpoint({
+        attemptId: attemptRef.current,
+        section: 'listening',
+        mockId: paper.id,
+        payload: {
+          paperId: paper.id,
+          answers: state.answers,
+          sectionIdx: state.secIdx,
+          startedAt: startRef.current,
+        },
+        elapsed,
+        duration: paper.durationSec,
+        completed: opts?.completed,
+      });
+    },
+    [paper, attemptReady, checkpointHydrated]
+  );
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const handler = () => persistCheckpoint();
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [paper, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const timeout = setTimeout(() => persistCheckpoint(), 1000);
+    return () => clearTimeout(timeout);
+  }, [answers, secIdx, paper, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const interval = setInterval(() => persistCheckpoint(), 15000);
+    return () => clearInterval(interval);
+  }, [paper, attemptReady, checkpointHydrated, persistCheckpoint]);
 
   const current = paper?.sections[secIdx];
   const percent = useMemo(() => {
@@ -135,6 +221,23 @@ export default function ListeningMockPage() {
       attemptId = `local-${Date.now()}`;
       try { localStorage.setItem(`listen:attempt-res:${attemptId}`, JSON.stringify({ paper, answers })); } catch {}
     } finally {
+      if (attemptRef.current) {
+        void saveMockCheckpoint({
+          attemptId: attemptRef.current,
+          section: 'listening',
+          mockId: paper.id,
+          payload: {
+            paperId: paper.id,
+            answers,
+            sectionIdx: secIdx,
+            startedAt: startRef.current,
+          },
+          elapsed: paper.durationSec - timeLeft,
+          duration: paper.durationSec,
+          completed: true,
+        });
+        clearMockAttemptId('listening', paper.id);
+      }
       clearDraft(id);
       router.replace(`/review/listening/${id}?attempt=${encodeURIComponent(attemptId)}`);
     }

--- a/pages/mock/reading/[id].tsx
+++ b/pages/mock/reading/[id].tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { clearMockAttemptId, ensureMockAttemptId, fetchMockCheckpoint, saveMockCheckpoint } from '@/lib/mock/state';
 
 type QType = 'tfng' | 'yynn' | 'heading' | 'match' | 'mcq' | 'gap';
 type Q = { id: string; type: QType; prompt?: string; options?: string[]; answer: string };
@@ -54,18 +55,107 @@ export default function ReadingMockPage() {
   const [answers, setAnswers] = useState<AnswerMap>({});
   const [passageIdx, setPassageIdx] = useState(0);
   const [timeLeft, setTimeLeft] = useState(3600);
+  const attemptRef = useRef<string>('');
+  const [attemptReady, setAttemptReady] = useState(false);
+  const [checkpointHydrated, setCheckpointHydrated] = useState(false);
+  const latestRef = useRef<{ answers: AnswerMap; passageIdx: number; timeLeft: number }>({ answers: {}, passageIdx: 0, timeLeft: 0 });
 
-  useEffect(() => { if (!id) return; (async () => {
-    const p = await loadPaper(id);
-    setPaper(p);
-    setTimeLeft(p.durationSec);
-    const dr = loadDraft(id);
-    if (dr) setAnswers(dr.answers || {});
-    if (!dr) saveDraft(id, { answers: {} });
-  })(); }, [id]);
+  useEffect(() => {
+    if (!id) return;
+    const attempt = ensureMockAttemptId('reading', id);
+    attemptRef.current = attempt;
+    setAttemptReady(true);
+  }, [id]);
 
-  useEffect(() => { if (!paper) return; const t = setInterval(() => setTimeLeft((x) => (x > 0 ? x - 1 : 0)), 1000); return () => clearInterval(t); }, [paper]);
-  useEffect(() => { if (!id) return; saveDraft(id, { answers }); }, [id, answers]);
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      const p = await loadPaper(id);
+      setPaper(p);
+      setTimeLeft(p.durationSec);
+      const dr = loadDraft(id);
+      if (dr) {
+        setAnswers(dr.answers || {});
+        if (typeof dr.passageIdx === 'number') setPassageIdx(dr.passageIdx);
+      }
+      if (!dr) saveDraft(id, { answers: {}, passageIdx: 0 });
+    })();
+  }, [id]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady) return;
+    let cancelled = false;
+
+    (async () => {
+      const checkpoint = await fetchMockCheckpoint({ attemptId: attemptRef.current, section: 'reading' });
+      if (cancelled) return;
+      if (checkpoint && checkpoint.mockId === paper.id) {
+        const payload = (checkpoint.payload || {}) as { answers?: AnswerMap; passageIdx?: number };
+        if (payload.answers) setAnswers(payload.answers);
+        if (typeof payload.passageIdx === 'number') setPassageIdx(payload.passageIdx);
+        const duration = typeof checkpoint.duration === 'number' ? checkpoint.duration : paper.durationSec;
+        const remaining = Math.max(0, duration - checkpoint.elapsed);
+        setTimeLeft(Math.max(0, Math.min(paper.durationSec, remaining)));
+      }
+      setCheckpointHydrated(true);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [paper, attemptReady]);
+
+  useEffect(() => {
+    if (!paper) return;
+    const t = setInterval(() => setTimeLeft((x) => (x > 0 ? x - 1 : 0)), 1000);
+    return () => clearInterval(t);
+  }, [paper]);
+
+  useEffect(() => {
+    latestRef.current = { answers, passageIdx, timeLeft };
+  }, [answers, passageIdx, timeLeft]);
+
+  useEffect(() => {
+    if (!id) return;
+    saveDraft(id, { answers, passageIdx });
+  }, [id, answers, passageIdx]);
+
+  const persistCheckpoint = useCallback(
+    (opts?: { completed?: boolean }) => {
+      if (!paper || !attemptReady || !checkpointHydrated || !attemptRef.current) return;
+      const state = latestRef.current;
+      const elapsed = Math.max(0, Math.min(paper.durationSec, paper.durationSec - state.timeLeft));
+      void saveMockCheckpoint({
+        attemptId: attemptRef.current,
+        section: 'reading',
+        mockId: paper.id,
+        payload: { paperId: paper.id, answers: state.answers, passageIdx: state.passageIdx },
+        elapsed,
+        duration: paper.durationSec,
+        completed: opts?.completed,
+      });
+    },
+    [paper, attemptReady, checkpointHydrated]
+  );
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const handler = () => persistCheckpoint();
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [paper, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const handle = setTimeout(() => persistCheckpoint(), 1000);
+    return () => clearTimeout(handle);
+  }, [answers, passageIdx, paper, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const interval = setInterval(() => persistCheckpoint(), 15000);
+    return () => clearInterval(interval);
+  }, [paper, attemptReady, checkpointHydrated, persistCheckpoint]);
 
   const current = paper?.passages[passageIdx];
 
@@ -87,6 +177,18 @@ export default function ReadingMockPage() {
       attemptId = `local-${Date.now()}`;
       try { localStorage.setItem(`read:attempt-res:${attemptId}`, JSON.stringify({ paper, answers })); } catch {}
     } finally {
+      if (attemptRef.current) {
+        void saveMockCheckpoint({
+          attemptId: attemptRef.current,
+          section: 'reading',
+          mockId: paper.id,
+          payload: { paperId: paper.id, answers, passageIdx },
+          elapsed: paper.durationSec - timeLeft,
+          duration: paper.durationSec,
+          completed: true,
+        });
+        clearMockAttemptId('reading', paper.id);
+      }
       clearDraft(id);
       router.replace(`/review/reading/${id}?attempt=${attemptId}`);
     }
@@ -172,8 +274,9 @@ const Options: React.FC<{ options: string[]; value: string; onPick: (v: string) 
     ))}
   </div>
 );
-const saveDraft = (id: string, data: any) => { try { localStorage.setItem(DRAFT_KEY(id), JSON.stringify(data)); } catch {} };
-const loadDraft = (id: string) => { try { const raw = localStorage.getItem(DRAFT_KEY(id)); return raw ? JSON.parse(raw) : null; } catch { return null; } };
+type DraftState = { answers: AnswerMap; passageIdx?: number };
+const saveDraft = (id: string, data: DraftState) => { try { localStorage.setItem(DRAFT_KEY(id), JSON.stringify(data)); } catch {} };
+const loadDraft = (id: string): DraftState | null => { try { const raw = localStorage.getItem(DRAFT_KEY(id)); return raw ? JSON.parse(raw) : null; } catch { return null; } };
 const clearDraft = (id: string) => { try { localStorage.removeItem(DRAFT_KEY(id)); } catch {} };
 const hhmmss = (sec: number) => `${Math.floor(sec/60).toString().padStart(2,'0')}:${Math.floor(sec%60).toString().padStart(2,'0')}`;
 const normalize = (s: string) => s.trim().toLowerCase();

--- a/pages/mock/resume.tsx
+++ b/pages/mock/resume.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import type { MockCheckpoint, MockSection } from '@/lib/mock/state';
+import { fetchMockCheckpoint, setMockAttemptId } from '@/lib/mock/state';
+
+const SECTION_LABEL: Record<MockSection, string> = {
+  listening: 'Listening',
+  reading: 'Reading',
+  writing: 'Writing',
+  speaking: 'Speaking',
+};
+
+const formatDuration = (seconds: number) => {
+  const s = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60).toString().padStart(2, '0');
+  const sec = Math.floor(s % 60).toString().padStart(2, '0');
+  return h > 0 ? `${h}:${m}:${sec}` : `${m}:${sec}`;
+};
+
+export default function MockResumePage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [checkpoint, setCheckpoint] = useState<MockCheckpoint | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const cp = await fetchMockCheckpoint({});
+      if (!active) return;
+      setCheckpoint(cp);
+      setLoading(false);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const remaining = useMemo(() => {
+    if (!checkpoint || typeof checkpoint.duration !== 'number') return null;
+    return Math.max(0, checkpoint.duration - checkpoint.elapsed);
+  }, [checkpoint]);
+
+  const resumeHref = useMemo(() => {
+    if (!checkpoint) return '#';
+    return `/mock/${checkpoint.section}/${checkpoint.mockId}`;
+  }, [checkpoint]);
+
+  const handleResume = useCallback(async () => {
+    if (!checkpoint) return;
+    setMockAttemptId(checkpoint.section, checkpoint.mockId, checkpoint.attemptId);
+    await router.push(resumeHref);
+  }, [checkpoint, router, resumeHref]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto flex max-w-2xl flex-col gap-6 px-4 py-10">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-h3 font-semibold">Resume mock test</h1>
+          <p className="text-small text-foreground/80">
+            Pick up where you left off. We keep your progress synced so timers and answers stay accurate across devices.
+          </p>
+        </header>
+
+        {loading && (
+          <div className="rounded-2xl border border-border bg-background/60 p-6 text-small text-foreground/70">
+            Checking for saved progress…
+          </div>
+        )}
+
+        {!loading && !checkpoint && (
+          <div className="rounded-2xl border border-border bg-background/60 p-6">
+            <p className="text-small text-foreground/80">
+              You don&apos;t have any saved mock attempts. Start a new test from the mock library to create one.
+            </p>
+            <div className="mt-4">
+              <Link href="/mock" className="text-small underline underline-offset-4">
+                Browse mock tests
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {!loading && checkpoint && (
+          <div className="rounded-2xl border border-border bg-background/60 p-6">
+            <div className="mb-4 flex flex-col gap-1">
+              <span className="text-caption uppercase tracking-wide text-foreground/60">Latest checkpoint</span>
+              <span className="text-body font-semibold">{SECTION_LABEL[checkpoint.section]} section</span>
+              <span className="text-small text-foreground/70">
+                Saved {new Date(checkpoint.updatedAt).toLocaleString()}
+              </span>
+            </div>
+            <dl className="grid gap-2 text-small text-foreground/80">
+              <div className="flex items-center justify-between">
+                <dt>Mock ID</dt>
+                <dd className="font-mono text-foreground/90">{checkpoint.mockId}</dd>
+              </div>
+              {remaining !== null && (
+                <div className="flex items-center justify-between">
+                  <dt>Time remaining</dt>
+                  <dd>{formatDuration(remaining)}</dd>
+                </div>
+              )}
+            </dl>
+            <div className="mt-6 flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleResume}
+                className="rounded-xl bg-primary px-4 py-2 font-medium text-background hover:opacity-90"
+              >
+                Continue
+              </button>
+              <Link href="/mock" className="text-small underline underline-offset-4">
+                Start a different test
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/pages/mock/speaking/[id].tsx
+++ b/pages/mock/speaking/[id].tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { clearMockAttemptId, ensureMockAttemptId, fetchMockCheckpoint, saveMockCheckpoint } from '@/lib/mock/state';
 
 type SpeakingScript = {
   id: string;
@@ -55,14 +56,89 @@ export default function SpeakingMockPage() {
   const chunks = useRef<Blob[]>([]);
   const [recording, setRecording] = useState(false);
   const [attemptId, setAttemptId] = useState<string>('');
+  const attemptRef = useRef<string>('');
+  const [attemptReady, setAttemptReady] = useState(false);
+  const [checkpointHydrated, setCheckpointHydrated] = useState(false);
+  const latestRef = useRef<{ stage: typeof stage; timer: number }>({ stage: 'p1', timer: 0 });
+
+  useEffect(() => {
+    if (!id) return;
+    const attempt = ensureMockAttemptId('speaking', id);
+    attemptRef.current = attempt;
+    setAttemptReady(true);
+  }, [id]);
 
   useEffect(() => { if (!id) return; (async () => setScript(await loadScript(id)))(); }, [id]);
+
+  useEffect(() => {
+    if (!script || !attemptReady) return;
+    let cancelled = false;
+
+    (async () => {
+      const checkpoint = await fetchMockCheckpoint({ attemptId: attemptRef.current, section: 'speaking' });
+      if (cancelled) return;
+      if (checkpoint && checkpoint.mockId === script.id) {
+        const payload = (checkpoint.payload || {}) as { stage?: typeof stage; timer?: number };
+        if (payload.stage && payload.stage !== 'done') setStage(payload.stage);
+        if (typeof payload.timer === 'number') setTimer(payload.timer);
+      }
+      setCheckpointHydrated(true);
+    })();
+
+    return () => { cancelled = true; };
+  }, [script, attemptReady]);
 
   useEffect(() => {
     let interval: any;
     if (timer > 0) interval = setInterval(() => setTimer((x) => x - 1), 1000);
     return () => clearInterval(interval);
   }, [timer]);
+
+  useEffect(() => {
+    latestRef.current = { stage, timer };
+  }, [stage, timer]);
+
+  const persistCheckpoint = useCallback(
+    (opts?: { completed?: boolean }) => {
+      if (!script || !attemptReady || !checkpointHydrated || !attemptRef.current) return;
+      const state = latestRef.current;
+      void saveMockCheckpoint({
+        attemptId: attemptRef.current,
+        section: 'speaking',
+        mockId: script.id,
+        payload: { scriptId: script.id, stage: state.stage, timer: state.timer },
+        elapsed: 0,
+        completed: opts?.completed,
+      });
+    },
+    [script, attemptReady, checkpointHydrated]
+  );
+
+  useEffect(() => {
+    if (!script || !attemptReady || !checkpointHydrated) return;
+    const handler = () => persistCheckpoint();
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [script, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!script || !attemptReady || !checkpointHydrated) return;
+    const timeout = setTimeout(() => persistCheckpoint(), 800);
+    return () => clearTimeout(timeout);
+  }, [stage, script, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!script || !attemptReady || !checkpointHydrated) return;
+    const interval = setInterval(() => persistCheckpoint(), 15000);
+    return () => clearInterval(interval);
+  }, [script, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (stage === 'done' && script && attemptRef.current) {
+      persistCheckpoint({ completed: true });
+      clearMockAttemptId('speaking', script.id);
+    }
+  }, [stage, script, persistCheckpoint]);
 
   const startRec = async () => {
     if (recording) return;
@@ -112,6 +188,17 @@ export default function SpeakingMockPage() {
       try { const url = URL.createObjectURL(blob); localStorage.setItem(`speak:rec:${idOut}`, url); } catch {}
     } finally {
       setAttemptId(idOut);
+      if (attemptRef.current && script) {
+        void saveMockCheckpoint({
+          attemptId: attemptRef.current,
+          section: 'speaking',
+          mockId: script.id,
+          payload: { scriptId: script.id, stage: 'done', timer: 0 },
+          elapsed: 0,
+          completed: true,
+        });
+        clearMockAttemptId('speaking', script.id);
+      }
     }
   };
 

--- a/pages/mock/writing/[id].tsx
+++ b/pages/mock/writing/[id].tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { clearMockAttemptId, ensureMockAttemptId, fetchMockCheckpoint, saveMockCheckpoint } from '@/lib/mock/state';
 
 type WritingPaper = {
   id: string;
@@ -48,18 +49,97 @@ export default function WritingMockPage() {
   const [task1, setTask1] = useState('');
   const [task2, setTask2] = useState('');
   const [timeLeft, setTimeLeft] = useState(3600);
+  const attemptRef = useRef<string>('');
+  const [attemptReady, setAttemptReady] = useState(false);
+  const [checkpointHydrated, setCheckpointHydrated] = useState(false);
+  const latestRef = useRef<{ task1: string; task2: string; timeLeft: number }>({ task1: '', task2: '', timeLeft: 0 });
 
-  useEffect(() => { if (!id) return; (async () => {
-    const p = await loadPaper(id);
-    setPaper(p);
-    setTimeLeft(p.durationSec);
-    const dr = loadDraft(id);
-    if (dr) { setTask1(dr.task1 || ''); setTask2(dr.task2 || ''); }
-    if (!dr) saveDraft(id, { task1: '', task2: '' });
-  })(); }, [id]);
+  useEffect(() => {
+    if (!id) return;
+    const attempt = ensureMockAttemptId('writing', id);
+    attemptRef.current = attempt;
+    setAttemptReady(true);
+  }, [id]);
 
-  useEffect(() => { if (!paper) return; const t = setInterval(() => setTimeLeft((x) => (x>0?x-1:0)), 1000); return () => clearInterval(t); }, [paper]);
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      const p = await loadPaper(id);
+      setPaper(p);
+      setTimeLeft(p.durationSec);
+      const dr = loadDraft(id);
+      if (dr) { setTask1(dr.task1 || ''); setTask2(dr.task2 || ''); }
+      if (!dr) saveDraft(id, { task1: '', task2: '' });
+    })();
+  }, [id]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady) return;
+    let cancelled = false;
+
+    (async () => {
+      const checkpoint = await fetchMockCheckpoint({ attemptId: attemptRef.current, section: 'writing' });
+      if (cancelled) return;
+      if (checkpoint && checkpoint.mockId === paper.id) {
+        const payload = (checkpoint.payload || {}) as { task1?: string; task2?: string };
+        if (typeof payload.task1 === 'string') setTask1(payload.task1);
+        if (typeof payload.task2 === 'string') setTask2(payload.task2);
+        const duration = typeof checkpoint.duration === 'number' ? checkpoint.duration : paper.durationSec;
+        const remaining = Math.max(0, duration - checkpoint.elapsed);
+        setTimeLeft(Math.max(0, Math.min(paper.durationSec, remaining)));
+      }
+      setCheckpointHydrated(true);
+    })();
+
+    return () => { cancelled = true; };
+  }, [paper, attemptReady]);
+
+  useEffect(() => {
+    if (!paper) return;
+    const t = setInterval(() => setTimeLeft((x) => (x>0?x-1:0)), 1000);
+    return () => clearInterval(t);
+  }, [paper]);
+  useEffect(() => {
+    latestRef.current = { task1, task2, timeLeft };
+  }, [task1, task2, timeLeft]);
   useEffect(() => { if (!id) return; saveDraft(id, { task1, task2 }); }, [id, task1, task2]);
+
+  const persistCheckpoint = useCallback(
+    (opts?: { completed?: boolean }) => {
+      if (!paper || !attemptReady || !checkpointHydrated || !attemptRef.current) return;
+      const state = latestRef.current;
+      const elapsed = Math.max(0, Math.min(paper.durationSec, paper.durationSec - state.timeLeft));
+      void saveMockCheckpoint({
+        attemptId: attemptRef.current,
+        section: 'writing',
+        mockId: paper.id,
+        payload: { paperId: paper.id, task1: state.task1, task2: state.task2 },
+        elapsed,
+        duration: paper.durationSec,
+        completed: opts?.completed,
+      });
+    },
+    [paper, attemptReady, checkpointHydrated]
+  );
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const handler = () => persistCheckpoint();
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [paper, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const timeout = setTimeout(() => persistCheckpoint(), 800);
+    return () => clearTimeout(timeout);
+  }, [task1, task2, paper, attemptReady, checkpointHydrated, persistCheckpoint]);
+
+  useEffect(() => {
+    if (!paper || !attemptReady || !checkpointHydrated) return;
+    const interval = setInterval(() => persistCheckpoint(), 15000);
+    return () => clearInterval(interval);
+  }, [paper, attemptReady, checkpointHydrated, persistCheckpoint]);
 
   const wc1 = countWords(task1);
   const wc2 = countWords(task2);
@@ -82,6 +162,18 @@ export default function WritingMockPage() {
       attemptId = `local-${Date.now()}`;
       try { localStorage.setItem(`write:attempt-res:${attemptId}`, JSON.stringify({ paper, task1, task2 })); } catch {}
     } finally {
+      if (attemptRef.current) {
+        void saveMockCheckpoint({
+          attemptId: attemptRef.current,
+          section: 'writing',
+          mockId: paper.id,
+          payload: { paperId: paper.id, task1, task2 },
+          elapsed: paper.durationSec - timeLeft,
+          duration: paper.durationSec,
+          completed: true,
+        });
+        clearMockAttemptId('writing', paper.id);
+      }
       clearDraft(id);
       router.replace(`/review/writing/${id}?attempt=${attemptId}`);
     }
@@ -117,8 +209,9 @@ export default function WritingMockPage() {
     </Shell>
   );
 }
-const saveDraft = (id: string, data: any) => { try { localStorage.setItem(DRAFT_KEY(id), JSON.stringify(data)); } catch {} };
-const loadDraft = (id: string) => { try { const raw = localStorage.getItem(DRAFT_KEY(id)); return raw ? JSON.parse(raw) : null; } catch { return null; } };
+type DraftState = { task1: string; task2: string };
+const saveDraft = (id: string, data: DraftState) => { try { localStorage.setItem(DRAFT_KEY(id), JSON.stringify(data)); } catch {} };
+const loadDraft = (id: string): DraftState | null => { try { const raw = localStorage.getItem(DRAFT_KEY(id)); return raw ? JSON.parse(raw) : null; } catch { return null; } };
 const clearDraft = (id: string) => { try { localStorage.removeItem(DRAFT_KEY(id)); } catch {} };
 const countWords = (s: string) => (s.trim() ? s.trim().split(/\s+/).length : 0);
 const hhmmss = (sec: number) => `${Math.floor(sec/60).toString().padStart(2,'0')}:${Math.floor(sec%60).toString().padStart(2,'0')}`;

--- a/supabase/tables/mock_attempts.sql
+++ b/supabase/tables/mock_attempts.sql
@@ -1,0 +1,38 @@
+create table if not exists public.mock_attempts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  attempt_id text not null,
+  section text not null check (section in ('listening', 'reading', 'writing', 'speaking')),
+  mock_id text not null,
+  payload jsonb not null default '{}'::jsonb,
+  elapsed_sec integer not null default 0,
+  duration_sec integer,
+  completed boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists mock_attempts_user_attempt_section_idx
+  on public.mock_attempts (user_id, attempt_id, section);
+
+create index if not exists mock_attempts_user_updated_idx
+  on public.mock_attempts (user_id, updated_at desc);
+
+alter table public.mock_attempts enable row level security;
+
+create policy if not exists "Users can read own mock attempts"
+  on public.mock_attempts for select
+  using (auth.uid() = user_id);
+
+create policy if not exists "Users can insert own mock attempts"
+  on public.mock_attempts for insert
+  with check (auth.uid() = user_id);
+
+create policy if not exists "Users can update own mock attempts"
+  on public.mock_attempts for update
+  using (auth.uid() = user_id);
+
+create trigger set_mock_attempts_timestamp
+  before update on public.mock_attempts
+  for each row
+  execute procedure public.set_updated_at();


### PR DESCRIPTION
## Summary
- add a shared mock state helper that manages attempt ids and persists checkpoints through the new API
- create `/api/mock/checkpoint` to upsert and read the latest checkpoint rows stored in `mock_attempts`
- sync listening, reading, writing, and speaking pages with the checkpoint API and add a `/mock/resume` entry point for resuming progress
- define the `mock_attempts` table with RLS policies for user-owned checkpoints

## Testing
- `npm run lint` *(fails: next binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f884338c8321bdd87a59ba28edaa