### PR TITLE
Add accessible listening transcript and improve speaking recorder

### DIFF
--- a/components/audio/Player.tsx
+++ b/components/audio/Player.tsx
@@ -1,0 +1,135 @@
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+type Source = { src: string; type?: string };
+
+export type AudioPlayerProps = {
+  /** Primary audio source URL. */
+  src: string;
+  /** Optional additional `<source>` elements. */
+  sources?: Source[];
+  /** Override preload strategy. Defaults to `auto`, but falls back to `metadata` on slow connections. */
+  preload?: 'none' | 'metadata' | 'auto';
+  /** Allow callers to force metadata-only preloading. */
+  preferMetadataOnly?: boolean;
+  /** Cross-origin policy for the underlying audio element. Defaults to `anonymous`. */
+  crossOrigin?: '' | 'anonymous' | 'use-credentials';
+  /** Optional class name applied to the `<audio>` element. */
+  className?: string;
+  /** When true, renders a minimal player without visible controls. */
+  hidden?: boolean;
+  /** Optional aria label passed to the `<audio>` element. */
+  'aria-label'?: string;
+  /** Callback fired when the player decides on a preload strategy. */
+  onPreloadStrategyChange?: (strategy: 'none' | 'metadata' | 'auto') => void;
+  /** MIME type hint for the primary source. Defaults to audio/mpeg. */
+  primaryType?: string;
+} & React.AudioHTMLAttributes<HTMLAudioElement>;
+
+type ImperativeApi = HTMLAudioElement | null;
+
+function detectLowBandwidth(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const connection = (navigator as any).connection || (navigator as any).mozConnection || (navigator as any).webkitConnection;
+  if (!connection) return false;
+  const saveData = Boolean(connection.saveData);
+  const type = String(connection.effectiveType || '').toLowerCase();
+  // Consider 2g / slow-2g or explicit Save-Data preference as low-bandwidth.
+  return saveData || type.includes('2g') || type.includes('slow');
+}
+
+/**
+ * Lightweight audio player that auto-adjusts preload strategy for low-bandwidth networks
+ * and exposes an imperative ref compatible with native `<audio>` methods.
+ */
+export const AudioPlayer = forwardRef<ImperativeApi, AudioPlayerProps>(function AudioPlayer(
+  {
+    src,
+    sources,
+    preload = 'auto',
+    preferMetadataOnly = false,
+    crossOrigin = 'anonymous',
+    className,
+    hidden,
+    onPreloadStrategyChange,
+    primaryType,
+    ...rest
+  },
+  forwardedRef
+) {
+  const localRef = useRef<HTMLAudioElement | null>(null);
+  const [strategy, setStrategy] = useState<'none' | 'metadata' | 'auto'>(() =>
+    preferMetadataOnly || detectLowBandwidth() ? 'metadata' : preload
+  );
+
+  useImperativeHandle(forwardedRef, () => localRef.current, []);
+
+  // Re-evaluate network conditions only once on mount.
+  useEffect(() => {
+    if (preferMetadataOnly) {
+      setStrategy('metadata');
+      return;
+    }
+    if (detectLowBandwidth()) {
+      setStrategy('metadata');
+    }
+  }, [preferMetadataOnly]);
+
+  // Notify listeners when strategy changes.
+  useEffect(() => {
+    onPreloadStrategyChange?.(strategy);
+  }, [strategy, onPreloadStrategyChange]);
+
+  // Apply attributes whenever relevant props change.
+  useEffect(() => {
+    const audio = localRef.current;
+    if (!audio) return;
+    audio.preload = strategy;
+    audio.crossOrigin = crossOrigin;
+    // Encourage byte-range requests by enabling controls (even if hidden) and metadata-only preload.
+    if (strategy === 'metadata') {
+      audio.setAttribute('preload', 'metadata');
+    }
+    if (hidden) {
+      audio.style.display = 'none';
+    }
+  }, [crossOrigin, hidden, strategy]);
+
+  const sourceNodes = useMemo(() => {
+    if (!sources || !sources.length) return null;
+    return sources.map((item) => (
+      <source key={`${item.src}|${item.type || 'audio/mpeg'}`} src={item.src} type={item.type} />
+    ));
+  }, [sources]);
+
+  const resolvedClassName = useMemo(() => {
+    return [hidden ? 'sr-only' : '', className || ''].filter(Boolean).join(' ');
+  }, [className, hidden]);
+
+  return (
+    <audio
+      ref={localRef}
+      className={resolvedClassName}
+      preload={strategy}
+      crossOrigin={crossOrigin}
+      controls={!hidden}
+      {...rest}
+    >
+      {/* Prefer explicit MIME types to help Safari pick the optimal codec. */}
+      <source src={src} type={primaryType || 'audio/mpeg'} />
+      {sourceNodes}
+      {/* Fallback */}
+      Your browser does not support the audio element.
+    </audio>
+  );
+});
+
+AudioPlayer.displayName = 'AudioPlayer';
+
+export default AudioPlayer;

--- a/components/listening/AudioSectionsPlayer.tsx
+++ b/components/listening/AudioSectionsPlayer.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@/components/design-system/Icon";
 // components/listening/AudioSectionsPlayer.tsx
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ProgressBar } from '@/components/design-system/ProgressBar';
+import AudioPlayer from '@/components/audio/Player';
 
 type MCQ = {
   id: string;
@@ -45,11 +46,13 @@ export type AudioSectionsPlayerProps = {
   initialSectionIndex?: number;
   autoAdvance?: boolean;       // default: true
   allowSeek?: boolean;         // default: false (exam-like)
-  isSubmitted?: boolean;       // unlocks transcript
   onReady?: () => void;
   onPlay?: (sectionIndex: number) => void;
   onPause?: (sectionIndex: number) => void;
   onSectionChange?: (sectionIndex: number) => void;
+  onTimeUpdate?: (payload: { sectionIndex: number; sectionMs: number; absoluteMs: number }) => void;
+  seekToMs?: number | null;
+  onExternalSeekResolved?: () => void;
   className?: string;
 };
 
@@ -63,11 +66,13 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
   initialSectionIndex = 0,
   autoAdvance = true,
   allowSeek = false,
-  isSubmitted = false,
   onReady,
   onPlay,
   onPause,
   onSectionChange,
+  onTimeUpdate,
+  seekToMs = null,
+  onExternalSeekResolved,
   className = '',
 }) => {
   // ---- SSR-safe mount gate (no conditional hooks) ----
@@ -77,6 +82,7 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
   // ---- refs & state ----
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const rafRef = useRef<number | null>(null);
+  const lastSeekRef = useRef<number | null>(null);
   const [ready, setReady] = useState(false);
   const [playing, setPlaying] = useState(false);
   const [sectionIndex, setSectionIndex] = useState<number>(clamp(initialSectionIndex, 0, Math.max(0, sections.length - 1)));
@@ -117,6 +123,7 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
     // update progress within section
     const within = clamp(nowMs - startMs, 0, Math.max(0, endMs - startMs));
     setLocalTimeMs(within);
+    onTimeUpdate?.({ sectionIndex, sectionMs: within, absoluteMs: nowMs });
 
     // stop/advance at section end
     if (nowMs >= endMs - 10) {
@@ -141,7 +148,17 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
     }
 
     rafRef.current = requestAnimationFrame(tick);
-  }, [autoAdvance, current, loadToSection, onPause, onPlay, onSectionChange, sectionIndex, sections.length]);
+  }, [
+    autoAdvance,
+    current,
+    loadToSection,
+    onPause,
+    onPlay,
+    onSectionChange,
+    onTimeUpdate,
+    sectionIndex,
+    sections.length,
+  ]);
 
   const startRaf = useCallback(() => {
     if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
@@ -155,54 +172,60 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
     }
   }, []);
 
-  // ---- audio lifecycle ----
-  useEffect(() => {
-    if (!mounted || !hasAudio) return;
-    const audio = new Audio(masterAudioUrl);
-    audioRef.current = audio;
+  const handleCanPlay = useCallback(() => {
+    setReady(true);
+    onReady?.();
+    loadToSection(sectionIndex);
+  }, [loadToSection, onReady, sectionIndex]);
 
-    const handleCanPlay = () => {
-      setReady(true);
-      onReady?.();
-      // ensure we are at current section start
-      loadToSection(sectionIndex);
-    };
+  const handlePlay = useCallback(() => {
+    setPlaying(true);
+    onPlay?.(sectionIndex);
+    startRaf();
+  }, [onPlay, sectionIndex, startRaf]);
 
-    const handlePlay = () => {
-      setPlaying(true);
-      onPlay?.(sectionIndex);
-      startRaf();
-    };
+  const handlePause = useCallback(() => {
+    setPlaying(false);
+    onPause?.(sectionIndex);
+    stopRaf();
+  }, [onPause, sectionIndex, stopRaf]);
 
-    const handlePause = () => {
-      setPlaying(false);
-      onPause?.(sectionIndex);
-      stopRaf();
-    };
-
-    audio.addEventListener('canplay', handleCanPlay);
-    audio.addEventListener('play', handlePlay);
-    audio.addEventListener('pause', handlePause);
-
-    // iOS: required attributes
-    audio.preload = 'auto';
-    audio.crossOrigin = 'anonymous';
-
-    return () => {
-      stopRaf();
-      audio.pause();
-      audio.removeEventListener('canplay', handleCanPlay);
-      audio.removeEventListener('play', handlePlay);
-      audio.removeEventListener('pause', handlePause);
-      audioRef.current = null;
-    };
-  }, [mounted, hasAudio, masterAudioUrl, onPause, onPlay, onReady, sectionIndex, startRaf, stopRaf, loadToSection]);
+  const handleEnded = useCallback(() => {
+    setPlaying(false);
+    stopRaf();
+  }, [stopRaf]);
 
   // jump audio when section changes (user nav)
   useEffect(() => {
     if (!ready) return;
     loadToSection(sectionIndex);
   }, [ready, sectionIndex, loadToSection]);
+
+  useEffect(() => () => stopRaf(), [stopRaf]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    if (seekToMs == null) return;
+    if (seekToMs === lastSeekRef.current) return;
+    lastSeekRef.current = seekToMs;
+
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const targetIndex = sections.findIndex((s) => seekToMs >= s.startMs && seekToMs <= s.endMs);
+    if (targetIndex !== -1) {
+      if (targetIndex !== sectionIndex) {
+        setSectionIndex(targetIndex);
+        onSectionChange?.(targetIndex);
+      }
+      const target = sections[targetIndex];
+      const within = clamp(seekToMs - target.startMs, 0, Math.max(0, target.endMs - target.startMs));
+      setLocalTimeMs(within);
+    }
+
+    audio.currentTime = seekToMs / 1000;
+    onExternalSeekResolved?.();
+  }, [mounted, onExternalSeekResolved, onSectionChange, sectionIndex, sections, seekToMs]);
 
   // ---- controls ----
   const play = useCallback(() => {
@@ -347,28 +370,18 @@ export const AudioSectionsPlayer: React.FC<AudioSectionsPlayerProps> = ({
         </div>
       </div>
 
-      {/* Transcript */}
-      <div className="mt-4">
-        <div className="text-small opacity-70 mb-1">Transcript</div>
-        <div
-          className={`p-3.5 rounded-ds border border-lightBorder dark:border-white/10 ${isSubmitted ? '' : 'blur-sm select-none pointer-events-none'}`}
-          aria-live="polite"
-        >
-          {current.transcript ? (
-            <p className="opacity-90">{current.transcript}</p>
-          ) : (
-            <p className="opacity-60">No transcript available for this section.</p>
-          )}
-        </div>
-        {!isSubmitted && (
-          <div className="text-small opacity-60 mt-1">
-            Transcript will unlock after you submit.
-          </div>
-        )}
-      </div>
-
       {/* Hidden audio element holder (managed via ref) */}
-      <div className="sr-only" aria-hidden="true" />
+      <AudioPlayer
+        ref={audioRef}
+        src={masterAudioUrl}
+        hidden
+        preload="metadata"
+        preferMetadataOnly
+        onCanPlay={handleCanPlay}
+        onPlay={handlePlay}
+        onPause={handlePause}
+        onEnded={handleEnded}
+      />
     </div>
   );
 };

--- a/components/listening/Transcript.tsx
+++ b/components/listening/Transcript.tsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Icon } from '@/components/design-system/Icon';
+
+type Cue = {
+  id: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+};
+
+type TranscriptProps = {
+  transcript?: string | null;
+  locked?: boolean;
+  currentTimeMs?: number;
+  onSeek?: (relativeMs: number) => void;
+  followActiveCue?: boolean;
+  className?: string;
+};
+
+function parseTimestamp(raw: string): number | null {
+  const cleaned = raw.trim().replace(',', '.');
+  if (!cleaned) return null;
+  const parts = cleaned.split(':');
+  if (parts.length < 2 || parts.length > 3) return null;
+  const [h, m, s] =
+    parts.length === 3
+      ? [Number(parts[0]), Number(parts[1]), Number(parts[2])]
+      : [0, Number(parts[0]), Number(parts[1])];
+  if ([h, m, s].some((v) => Number.isNaN(v))) return null;
+  const secs = s;
+  const whole = Math.trunc(secs);
+  const frac = secs - whole;
+  const total = h * 3600 + m * 60 + whole + frac;
+  return Math.max(0, Math.round(total * 1000));
+}
+
+const TIMING_RE = /(?<start>\d{1,2}:\d{2}(?::\d{2})?(?:[.,]\d{1,3})?)\s*-->\s*(?<end>\d{1,2}:\d{2}(?::\d{2})?(?:[.,]\d{1,3})?)/;
+
+function stripHtml(text: string) {
+  return text.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function parseTranscript(raw?: string | null): Cue[] {
+  if (!raw) return [];
+  const normalized = raw
+    .replace(/\r/g, '')
+    .replace(/^WEBVTT[^\n]*\n?/i, '')
+    .replace(/<br\s*\/>/gi, '\n')
+    .trim();
+  if (!normalized) return [];
+
+  const blocks = normalized.split(/\n{2,}/);
+  const cues: Cue[] = [];
+
+  blocks.forEach((block, idx) => {
+    const lines = block.split('\n').map((line) => line.trim()).filter(Boolean);
+    if (!lines.length) return;
+
+    let pointer = 0;
+    if (/^\d+$/.test(lines[0])) pointer += 1;
+    const timingLine = lines[pointer] || '';
+    const match = timingLine.match(TIMING_RE);
+
+    let start = 0;
+    let end = 0;
+    if (match?.groups) {
+      start = parseTimestamp(match.groups.start) ?? 0;
+      end = parseTimestamp(match.groups.end) ?? start;
+      pointer += 1;
+    }
+
+    const text = stripHtml(lines.slice(pointer).join(' '));
+    if (!text) return;
+
+    if (!match) {
+      // Not a timecoded block; approximate order by index.
+      start = cues.length ? cues[cues.length - 1].endMs : 0;
+      end = start + Math.max(2000, text.split(' ').length * 600);
+    } else if (end <= start) {
+      end = start + Math.max(500, text.split(' ').length * 400);
+    }
+
+    cues.push({
+      id: `${idx}-${start}`,
+      startMs: start,
+      endMs: end,
+      text,
+    });
+  });
+
+  if (cues.length) {
+    return cues.sort((a, b) => a.startMs - b.startMs);
+  }
+
+  // Fallback: treat each line as a cue even without timing.
+  const fallbackLines = normalized.split(/\n+/).map((line) => stripHtml(line)).filter(Boolean);
+  return fallbackLines.map((text, idx) => ({
+    id: `plain-${idx}`,
+    startMs: idx * 4000,
+    endMs: (idx + 1) * 4000,
+    text,
+  }));
+}
+
+function formatTimestamp(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+export const Transcript: React.FC<TranscriptProps> = ({
+  transcript,
+  locked = false,
+  currentTimeMs = 0,
+  onSeek,
+  followActiveCue = true,
+  className = '',
+}) => {
+  const cues = useMemo(() => parseTranscript(transcript), [transcript]);
+  const [expanded, setExpanded] = useState(false);
+  const contentId = useMemo(() => `transcript-panel-${Math.random().toString(36).slice(2, 8)}`, []);
+  const cueRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (locked) setExpanded(false);
+  }, [locked]);
+
+  const activeIndex = useMemo(() => {
+    if (!cues.length) return -1;
+    const idx = cues.findIndex((cue) => currentTimeMs >= cue.startMs && currentTimeMs < cue.endMs);
+    return idx;
+  }, [cues, currentTimeMs]);
+
+  useEffect(() => {
+    if (!followActiveCue || !expanded) return;
+    if (activeIndex < 0) return;
+    const el = cueRefs.current[activeIndex];
+    if (el) {
+      el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [activeIndex, expanded, followActiveCue]);
+
+  const handleToggle = () => {
+    if (locked || !cues.length) return;
+    setExpanded((prev) => !prev);
+  };
+
+  const handleCueClick = (cue: Cue) => {
+    if (!onSeek || locked) return;
+    onSeek(cue.startMs);
+  };
+
+  const disabled = locked || !cues.length;
+  const showContent = expanded && !locked && cues.length > 0;
+
+  return (
+    <div className={`card-surface rounded-ds p-4 ${className}`}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        className={`flex w-full items-center justify-between gap-2 rounded-ds border border-lightBorder px-3 py-2 text-left transition hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10`}
+        aria-expanded={showContent}
+        aria-controls={contentId}
+        disabled={disabled}
+      >
+        <span className="flex items-center gap-2 font-semibold">
+          <Icon name={showContent ? 'chevron-up' : 'chevron-down'} />
+          Transcript
+        </span>
+        <span className="text-small text-grayish">
+          {locked ? 'Locked' : cues.length ? (showContent ? 'Hide' : 'Show') : 'Unavailable'}
+        </span>
+      </button>
+
+      {locked ? (
+        <p className="mt-3 text-small text-grayish">
+          Transcript will unlock after you submit your answers.
+        </p>
+      ) : (
+        <div
+          id={contentId}
+          hidden={!showContent}
+          className="mt-3 max-h-64 overflow-y-auto rounded-ds border border-lightBorder bg-white/40 p-3 text-small leading-relaxed dark:border-white/10 dark:bg-white/5"
+          aria-live="polite"
+        >
+          {cues.length ? (
+            <ul className="space-y-2">
+              {cues.map((cue, idx) => {
+                const active = idx === activeIndex;
+                return (
+                  <li key={cue.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleCueClick(cue)}
+                      ref={(node) => {
+                        cueRefs.current[idx] = node;
+                      }}
+                      className={`w-full rounded-ds border px-3 py-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 ${
+                        active
+                          ? 'border-primary/70 bg-primary/10 text-primary'
+                          : 'border-lightBorder dark:border-white/10 hover:bg-black/5 dark:hover:bg-white/10'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <span className="flex-1 whitespace-pre-line break-words text-sm">{cue.text}</span>
+                        <span className={`ml-2 shrink-0 text-caption ${active ? 'text-primary' : 'text-muted-foreground'}`}>
+                          {formatTimestamp(cue.startMs)}
+                        </span>
+                      </div>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className="text-small text-grayish">No transcript available for this section.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Transcript;

--- a/components/speaking/Recorder.tsx
+++ b/components/speaking/Recorder.tsx
@@ -1,11 +1,21 @@
 import React, {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
+import { useToast } from '@/components/design-system/Toaster';
 import { useRecorder } from '@/hooks/useRecorder';
+
+type Phase = 'idle' | 'recording' | 'preview' | 'uploading';
+
+type PreviewState = {
+  file: File;
+  meta: { durationSec: number; mime: string };
+};
 
 export type RecorderHandle = {
   start: () => Promise<void>;
@@ -17,7 +27,7 @@ export type RecorderHandle = {
 export type RecorderProps = {
   autoStart?: boolean;
   maxDurationSec?: number; // hard stop
-  onComplete?: (file: File, meta: { durationSec: number; mime: string }) => void;
+  onComplete?: (file: File, meta: { durationSec: number; mime: string }) => void | Promise<void>;
   onError?: (msg: string) => void;
   className?: string;
 };
@@ -31,8 +41,9 @@ export const Recorder = forwardRef<RecorderHandle, RecorderProps>(
       onError,
       className = '',
     },
-    ref
+    ref,
   ) => {
+    const { success: toastSuccess, error: toastError } = useToast();
     const {
       isRecording,
       isPaused,
@@ -47,70 +58,146 @@ export const Recorder = forwardRef<RecorderHandle, RecorderProps>(
       reset,
     } = useRecorder({ preferredMimeType: 'audio/webm' });
 
-    // expose imperative API
-    useImperativeHandle(ref, () => ({
-      start: () => start(),
-      pause: () => pause(),
-      resume: () => resume(),
-      stop: () => stop(),
-      reset: () => reset(),
-    }));
-
+    const [phase, setPhase] = useState<Phase>('idle');
+    const [preview, setPreview] = useState<PreviewState | null>(null);
     const startedRef = useRef(false);
+    const durationRef = useRef(0);
 
-    // auto-start for exam flow
     useEffect(() => {
-      if (autoStart && !startedRef.current && !isRecording && durationSec === 0) {
-        startedRef.current = true;
-        start().catch((e) => onError?.(String(e)));
-      }
-    }, [autoStart, isRecording, durationSec, start, onError]);
+      durationRef.current = durationSec;
+    }, [durationSec]);
 
-    // hard max duration
+    useEffect(() => {
+      if (error) {
+        const message = error;
+        toastError('Recorder error', message);
+        onError?.(message);
+      }
+    }, [error, onError, toastError]);
+
+    useEffect(() => {
+      if (!audioUrl) return;
+      return () => {
+        try {
+          URL.revokeObjectURL(audioUrl);
+        } catch {}
+      };
+    }, [audioUrl]);
+
+    const finalizeRecording = useCallback(async () => {
+      try {
+        const result = await stop();
+        const file = result.file;
+        if (file) {
+          const meta = { durationSec: Math.max(1, durationRef.current), mime: mimeType };
+          setPreview({ file, meta });
+          setPhase('preview');
+        } else {
+          setPhase('idle');
+        }
+        return result;
+      } catch (e) {
+        const message = (e as { message?: string })?.message ?? 'Failed to stop recording';
+        toastError('Recorder error', message);
+        onError?.(message);
+        setPhase('idle');
+        return {};
+      }
+    }, [mimeType, onError, stop, toastError]);
+
+    const handleStart = useCallback(async () => {
+      try {
+        await start();
+        setPhase('recording');
+      } catch (e) {
+        const message = (e as { message?: string })?.message ?? 'Microphone access denied';
+        toastError('Could not start recording', message);
+        onError?.(message);
+        setPhase('idle');
+      }
+    }, [onError, start, toastError]);
+
+    const handlePause = useCallback(() => {
+      pause();
+    }, [pause]);
+
+    const handleResume = useCallback(() => {
+      resume();
+    }, [resume]);
+
+    const handleReset = useCallback(() => {
+      setPreview(null);
+      setPhase('idle');
+      reset();
+    }, [reset]);
+
+    const handleSubmit = useCallback(async () => {
+      if (!preview) return;
+      try {
+        setPhase('uploading');
+        await Promise.resolve(onComplete?.(preview.file, preview.meta));
+        toastSuccess('Recording submitted');
+        handleReset();
+      } catch (e) {
+        const message = (e as { message?: string })?.message ?? 'Upload failed';
+        toastError('Upload failed', message);
+        onError?.(message);
+        setPhase('preview');
+      }
+    }, [handleReset, onComplete, onError, preview, toastError, toastSuccess]);
+
+    const handleAutoStart = useCallback(() => {
+      if (!autoStart || startedRef.current || isRecording || durationSec > 0) return;
+      startedRef.current = true;
+      void handleStart();
+    }, [autoStart, durationSec, handleStart, isRecording]);
+
+    useEffect(() => {
+      handleAutoStart();
+    }, [handleAutoStart]);
+
+    useEffect(() => {
+      if (isRecording) {
+        setPhase((prev) => (prev === 'uploading' ? prev : 'recording'));
+      }
+    }, [isRecording]);
+
     useEffect(() => {
       if (isRecording && durationSec >= maxDurationSec) {
-        stop()
-          .then(({ file }) => {
-            if (file && onComplete)
-              onComplete(file, { durationSec, mime: mimeType });
-          })
-          .catch((e) => onError?.(String(e)));
+        void finalizeRecording();
       }
-    }, [
-      durationSec,
-      isRecording,
-      maxDurationSec,
-      stop,
-      onComplete,
-      mimeType,
-      onError,
-    ]);
+    }, [durationSec, finalizeRecording, isRecording, maxDurationSec]);
 
-    // bubble errors
-    useEffect(() => {
-      if (error) onError?.(error);
-    }, [error, onError]);
+    useImperativeHandle(ref, () => ({
+      start: handleStart,
+      pause: handlePause,
+      resume: handleResume,
+      stop: finalizeRecording,
+      reset: handleReset,
+    }));
 
     const minutes = Math.floor(durationSec / 60)
       .toString()
       .padStart(2, '0');
     const seconds = (durationSec % 60).toString().padStart(2, '0');
 
-    const canStart = !isRecording && !isPaused;
-    const canPause = isRecording && !isPaused;
-    const canResume = isRecording && isPaused;
-    const canStop = isRecording;
-
     const status = useMemo(() => {
-      if (isRecording && isPaused) return 'Paused';
-      if (isRecording) return 'Recording';
+      if (phase === 'uploading') return 'Uploading';
+      if (phase === 'preview') return 'Preview';
+      if (phase === 'recording') return isPaused ? 'Paused' : 'Recording';
       return 'Idle';
-    }, [isRecording, isPaused]);
+    }, [phase, isPaused]);
+
+    const canStart = phase === 'idle';
+    const canPause = phase === 'recording' && !isPaused;
+    const canResume = phase === 'recording' && isPaused;
+    const canStop = phase === 'recording';
+    const canSubmit = phase === 'preview';
+
+    const loading = phase === 'uploading';
 
     return (
-      <div
-        className={`card-surface p-4 ${className}`}
-      >
+      <div className={`card-surface p-4 ${className}`} aria-busy={loading}>
         <div className="flex items-center justify-between">
           <div className="text-small text-grayish">
             Status: <span className="font-medium">{status}</span>
@@ -120,60 +207,77 @@ export const Recorder = forwardRef<RecorderHandle, RecorderProps>(
           </div>
         </div>
 
-        <div className="mt-3 flex gap-2">
+        <div className="mt-3 flex flex-wrap gap-2">
           <button
             className="px-3 py-2 rounded-xl bg-success text-white disabled:bg-grayish/30 disabled:text-grayish"
-            disabled={!canStart}
-            onClick={() => start().catch((e) => onError?.(String(e)))}
+            disabled={!canStart || loading}
+            onClick={handleStart}
           >
             Start
           </button>
           <button
             className="px-3 py-2 rounded-xl bg-warning text-black disabled:bg-grayish/30 disabled:text-grayish"
-            disabled={!canPause}
-            onClick={() => pause()}
+            disabled={!canPause || loading}
+            onClick={handlePause}
           >
             Pause
           </button>
           <button
             className="px-3 py-2 rounded-xl bg-electricBlue text-white disabled:bg-grayish/30 disabled:text-grayish"
-            disabled={!canResume}
-            onClick={() => resume()}
+            disabled={!canResume || loading}
+            onClick={handleResume}
           >
             Resume
           </button>
           <button
             className="px-3 py-2 rounded-xl bg-danger text-white disabled:bg-grayish/30 disabled:text-grayish"
-            disabled={!canStop}
-            onClick={() =>
-              stop()
-                .then(({ file }) => {
-                  if (file && onComplete)
-                    onComplete(file, { durationSec, mime: mimeType });
-                })
-                .catch((e) => onError?.(String(e)))
-            }
+            disabled={!canStop || loading}
+            onClick={() => void finalizeRecording()}
           >
-            Stop & Save
+            Stop
           </button>
           <button
-            className="ml-auto px-3 py-2 rounded-xl border border-lightBorder dark:border-white/10 text-lightText dark:text-white"
-            onClick={() => reset()}
-            disabled={isRecording}
+            className="ml-auto px-3 py-2 rounded-xl border border-lightBorder text-lightText disabled:opacity-60 dark:border-white/10 dark:text-white"
+            onClick={handleReset}
+            disabled={phase === 'recording' || loading}
           >
             Reset
           </button>
         </div>
 
-        {audioUrl && (
-          <div className="mt-4">
-            <audio src={audioUrl} controls className="w-full" />
-            <div className="text-caption text-grayish mt-1">Format: {mimeType}</div>
+        {preview && phase !== 'uploading' && (
+          <div className="mt-4 space-y-3">
+            <audio src={audioUrl ?? undefined} controls className="w-full" />
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                className="px-3 py-2 rounded-xl border border-lightBorder text-lightText dark:border-white/10 dark:text-white"
+                onClick={handleReset}
+                disabled={loading}
+              >
+                Re-record
+              </button>
+              <button
+                type="button"
+                className="px-3 py-2 rounded-xl bg-primary text-white disabled:bg-grayish/30"
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+              >
+                Submit recording
+              </button>
+            </div>
+            <div className="text-caption text-grayish">
+              Duration: ~{preview.meta.durationSec}s • Format: {preview.meta.mime}
+            </div>
           </div>
+        )}
+
+        {phase === 'uploading' && (
+          <div className="mt-4 text-small text-grayish">Uploading your recording…</div>
         )}
       </div>
     );
-  }
+  },
 );
 
 (Recorder as any).displayName = 'Recorder';

--- a/lib/speaking/uploadSpeakingBlob.ts
+++ b/lib/speaking/uploadSpeakingBlob.ts
@@ -1,39 +1,52 @@
 // /lib/speaking/uploadSpeakingBlob.ts
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { uploadWithRetry } from '@/lib/upload/supabase';
+
+export type SpeakingUploadResult = {
+  signedUrl: string;
+  path: string;
+  attemptId: string;
+  clipId?: string;
+};
 
 /**
- * Uploads an audio blob to Supabase Storage and returns a signed URL.
- * Bucket: "speaking"   Path: speaking/<userId>/<attemptId>/<ctx>/<timestamp>.webm
- *
- * ctx: 'p1'|'p2'|'p3'|'chat'
+ * Uploads an audio blob to Supabase Storage and returns the storage path with a signed URL.
+ * Bucket: "speaking"   Default path: <userId>/<attemptId>/<ctx>/<timestamp>.webm
  */
 export async function uploadSpeakingBlob(
   blob: Blob,
   ctx: 'p1' | 'p2' | 'p3' | 'chat',
-  attemptId: string
-): Promise<string> {
+  attemptId: string,
+  pathOverride?: string,
+): Promise<SpeakingUploadResult> {
   const { data: sess } = await supabaseBrowser.auth.getSession();
   const userId = sess.session?.user?.id;
   if (!userId) throw new Error('Unauthorized');
 
-  const ts = Date.now();
-  const path = `speaking/${userId}/${attemptId}/${ctx}/${ts}.webm`;
+  const bucket = 'speaking';
+  const timestamp = Date.now();
+  const safeCtx = ctx || 'p1';
+  const relativePath = pathOverride?.replace(/^\/+/, '') || `${userId}/${attemptId}/${safeCtx}/${timestamp}.webm`;
 
-  const { data, error } = await supabaseBrowser.storage
-    .from('speaking')
-    .upload(path, blob, {
-      contentType: 'audio/webm',
-      upsert: false,
-    });
+  await uploadWithRetry(
+    () =>
+      supabaseBrowser.storage.from(bucket).upload(relativePath, blob, {
+        contentType: blob.type || 'audio/webm',
+        upsert: Boolean(pathOverride),
+      }),
+    { maxAttempts: 4, baseDelayMs: 500 },
+  );
 
-  if (error) throw error;
-
-  // Signed URL for playback in UI
   const { data: signed, error: signedErr } = await supabaseBrowser.storage
-    .from('speaking')
-    .createSignedUrl(data.path, 60 * 60 * 24); // 24h
+    .from(bucket)
+    .createSignedUrl(relativePath, 60 * 60 * 24);
 
   if (signedErr) throw signedErr;
 
-  return signed.signedUrl;
+  return {
+    signedUrl: signed.signedUrl,
+    path: relativePath,
+    attemptId,
+    clipId: undefined,
+  };
 }

--- a/lib/upload/supabase.ts
+++ b/lib/upload/supabase.ts
@@ -1,0 +1,70 @@
+import type { StorageError } from '@supabase/storage-js';
+
+export type UploadRetryOptions = {
+  /** Total number of attempts (initial try + retries). Default: 3 */
+  maxAttempts?: number;
+  /** Initial delay before the first retry in milliseconds. Default: 400ms */
+  baseDelayMs?: number;
+  /** Multiplier applied to the delay after each failed attempt. Default: 2 */
+  backoffFactor?: number;
+  /** Optional AbortSignal to cancel in-flight retries. */
+  signal?: AbortSignal;
+  /** Optional hook invoked before each retry (after the first failure). */
+  onRetry?: (attempt: number, error: StorageError) => void;
+};
+
+async function wait(ms: number, signal?: AbortSignal) {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (signal) signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    if (signal) signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Wraps a Supabase Storage upload request with exponential backoff retries.
+ */
+export async function uploadWithRetry<T>(
+  uploadFn: () => Promise<{ data: T; error: StorageError | null }>,
+  options: UploadRetryOptions = {},
+): Promise<T> {
+  const {
+    maxAttempts = 3,
+    baseDelayMs = 400,
+    backoffFactor = 2,
+    signal,
+    onRetry,
+  } = options;
+
+  let attempt = 0;
+  let delay = baseDelayMs;
+  let lastError: StorageError | null = null;
+
+  while (attempt < maxAttempts) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
+    const { data, error } = await uploadFn();
+    if (!error) {
+      return data;
+    }
+
+    lastError = error;
+    attempt += 1;
+    if (attempt >= maxAttempts) break;
+
+    onRetry?.(attempt, error);
+    await wait(delay, signal);
+    delay *= backoffFactor;
+  }
+
+  throw lastError ?? new Error('Upload failed');
+}

--- a/pages/listening/[slug].tsx
+++ b/pages/listening/[slug].tsx
@@ -14,6 +14,7 @@ import { scoreAll } from '@/lib/listening/score';
 import { rawToBand } from '@/lib/listening/band';
 import { SaveItemButton } from '@/components/SaveItemButton';
 import AudioSectionsPlayer from '@/components/listening/AudioSectionsPlayer';
+import Transcript from '@/components/listening/Transcript';
 
 type MCQ = {
   id: string;
@@ -63,6 +64,8 @@ export default function ListeningTestPage() {
   const [currentIdx, setCurrentIdx] = useState(0);
   const [autoPlay, setAutoPlay] = useState(true);
   const [checked, setChecked] = useState(false);
+  const [sectionProgressMs, setSectionProgressMs] = useState(0);
+  const [pendingSeekMs, setPendingSeekMs] = useState<number | null>(null);
 
   // --- Save state ---
   const [saving, setSaving] = useState(false);
@@ -304,6 +307,11 @@ export default function ListeningTestPage() {
     ? Math.max(0, Math.round((currentSection.endMs - currentSection.startMs) / 1000))
     : 0;
 
+  useEffect(() => {
+    setSectionProgressMs(0);
+    setPendingSeekMs(null);
+  }, [currentIdx]);
+
   // --- Loading skeleton ---
   if (!test) {
     return (
@@ -365,7 +373,20 @@ export default function ListeningTestPage() {
             initialSectionIndex={currentIdx}
             autoAdvance={autoPlay}
             onSectionChange={setCurrentIdx}
+            onTimeUpdate={({ sectionMs }) => setSectionProgressMs(sectionMs)}
+            seekToMs={pendingSeekMs}
+            onExternalSeekResolved={() => setPendingSeekMs(null)}
             className="mt-8"
+          />
+          <Transcript
+            className="mt-4"
+            transcript={currentSection?.transcript}
+            locked={!checked}
+            currentTimeMs={sectionProgressMs}
+            onSeek={(relativeMs) => {
+              if (!currentSection) return;
+              setPendingSeekMs(currentSection.startMs + relativeMs);
+            }}
           />
           <div className="mt-4 text-small opacity-80">
             Section {currentSection?.orderNo} of {secCount} • {sliceSecs}s slice

--- a/pages/speaking/simulator/part1.tsx
+++ b/pages/speaking/simulator/part1.tsx
@@ -126,7 +126,7 @@ export default function SpeakingSimPart1() {
       const id = await ensureAttempt();
       const path = `attempts/${id}/p1/q${qIdx + 1}-${Date.now()}.webm`;
 
-      const { path: savedPath, clipId } = await uploadSpeakingBlob(blob, 'p1', id, path);
+      const uploaded = await uploadSpeakingBlob(blob, 'p1', id, path);
 
       const b64 = await blobToBase64(blob);
       const r = await authedFetch('/api/speaking/score-save', {
@@ -136,8 +136,8 @@ export default function SpeakingSimPart1() {
           part: 'p1',
           audioBase64: b64,
           mime: blob.type || 'audio/webm',
-          path: savedPath || path,
-          clipId,
+          path: uploaded.path || path,
+          clipId: uploaded.clipId,
         }),
       }).then((r) => r.json());
 


### PR DESCRIPTION
## Summary
- add a low-bandwidth aware audio player and expose timing hooks for listening sections
- provide an accessible transcript accordion with cue parsing and seeking from the listening page
- rework the speaking recorder preview/upload flow and add retriable Supabase uploads for speaking clips

## Testing
- npm run lint *(fails: next command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e623fec07083219dd45a76774233e0