### PR TITLE
Handle completed mock checkpoints on resume

### DIFF
--- a/lib/mock/state.ts
+++ b/lib/mock/state.ts
@@ -64,6 +64,7 @@ export interface MockCheckpoint {
   payload: MockCheckpointPayload;
   elapsed: number;
   duration?: number | null;
+  completed: boolean;
   updatedAt: string;
 }
 
@@ -101,11 +102,13 @@ export async function saveMockCheckpoint(input: SaveCheckpointInput): Promise<bo
 export async function fetchMockCheckpoint(params: {
   attemptId?: string;
   section?: MockSection;
+  includeCompleted?: boolean;
 }): Promise<MockCheckpoint | null> {
   try {
     const search = new URLSearchParams();
     if (params.attemptId) search.set('attemptId', params.attemptId);
     if (params.section) search.set('section', params.section);
+    if (params.includeCompleted) search.set('includeCompleted', 'true');
     const qs = search.toString();
     const url = `/api/mock/checkpoint${qs ? `?${qs}` : ''}`;
     const res = await fetch(url, { method: 'GET' });

--- a/pages/api/mock/checkpoint.ts
+++ b/pages/api/mock/checkpoint.ts
@@ -15,7 +15,7 @@ type PostBody = {
 type PostResponse = { ok: true } | { ok: false; error: string };
 
 type GetResponse =
-  | { ok: true; checkpoint: { attemptId: string; section: MockSection; mockId: string; payload: Record<string, unknown>; elapsed: number; duration?: number | null; updatedAt: string } | null }
+  | { ok: true; checkpoint: { attemptId: string; section: MockSection; mockId: string; payload: Record<string, unknown>; elapsed: number; duration?: number | null; completed: boolean; updatedAt: string } | null }
   | { ok: false; error: string };
 
 const isSection = (value: unknown): value is MockSection =>
@@ -87,10 +87,16 @@ async function postHandler(req: NextApiRequest, res: NextApiResponse<PostRespons
 }
 
 async function getHandler(req: NextApiRequest, res: NextApiResponse<GetResponse>) {
-  const { attemptId, section } = req.query as { attemptId?: string; section?: string };
+  const { attemptId, section, includeCompleted } = req.query as {
+    attemptId?: string;
+    section?: string;
+    includeCompleted?: string;
+  };
   if (section && !isSection(section)) {
     return res.status(400).json({ ok: false, error: 'section is invalid' });
   }
+
+  const includeCompletedBool = includeCompleted === 'true';
 
   const supabase = createSupabaseServerClient({ req, res });
   const { data: userData, error: userErr } = await supabase.auth.getUser();
@@ -101,7 +107,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse<GetResponse>
   try {
     let query = supabase
       .from('mock_attempts')
-      .select('attempt_id, section, mock_id, payload, elapsed_sec, duration_sec, updated_at')
+      .select('attempt_id, section, mock_id, payload, elapsed_sec, duration_sec, completed, updated_at')
       .eq('user_id', userData.user.id)
       .order('updated_at', { ascending: false })
       .limit(1);
@@ -111,6 +117,9 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse<GetResponse>
     }
     if (section) {
       query = query.eq('section', section);
+    }
+    if (!includeCompletedBool) {
+      query = query.eq('completed', false);
     }
 
     const { data, error } = await query;
@@ -130,6 +139,7 @@ async function getHandler(req: NextApiRequest, res: NextApiResponse<GetResponse>
         payload: (row.payload as Record<string, unknown>) ?? {},
         elapsed: typeof row.elapsed_sec === 'number' ? row.elapsed_sec : 0,
         duration: typeof row.duration_sec === 'number' ? row.duration_sec : null,
+        completed: Boolean(row.completed),
         updatedAt: row.updated_at as string,
       },
     });

--- a/pages/mock/resume.tsx
+++ b/pages/mock/resume.tsx
@@ -42,16 +42,18 @@ export default function MockResumePage() {
     return Math.max(0, checkpoint.duration - checkpoint.elapsed);
   }, [checkpoint]);
 
+  const canResume = checkpoint ? !checkpoint.completed : false;
+
   const resumeHref = useMemo(() => {
     if (!checkpoint) return '#';
     return `/mock/${checkpoint.section}/${checkpoint.mockId}`;
   }, [checkpoint]);
 
   const handleResume = useCallback(async () => {
-    if (!checkpoint) return;
+    if (!checkpoint || !canResume) return;
     setMockAttemptId(checkpoint.section, checkpoint.mockId, checkpoint.attemptId);
     await router.push(resumeHref);
-  }, [checkpoint, router, resumeHref]);
+  }, [checkpoint, router, resumeHref, canResume]);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -102,19 +104,31 @@ export default function MockResumePage() {
                   <dd>{formatDuration(remaining)}</dd>
                 </div>
               )}
+              {checkpoint.completed && (
+                <div className="flex items-center justify-between text-foreground/70">
+                  <dt>Status</dt>
+                  <dd>Completed</dd>
+                </div>
+              )}
             </dl>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <button
                 type="button"
                 onClick={handleResume}
-                className="rounded-xl bg-primary px-4 py-2 font-medium text-background hover:opacity-90"
+                disabled={!canResume}
+                className="rounded-xl bg-primary px-4 py-2 font-medium text-background hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                Continue
+                {canResume ? 'Continue' : 'Start a new attempt'}
               </button>
               <Link href="/mock" className="text-small underline underline-offset-4">
                 Start a different test
               </Link>
             </div>
+            {!canResume && (
+              <p className="mt-3 text-caption text-foreground/70">
+                This attempt has been submitted already. Start a new test from the mock library to practice again.
+              </p>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- include checkpoint completion status in the mock checkpoint state helper
- filter completed attempts from the checkpoint API (unless explicitly requested) and return the completion flag
- surface completion state on the resume page so finished attempts cannot be resumed and show guidance to start a new test

## Testing
- npm run lint *(fails: next CLI not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e623d7e6cc8321a7dfeeac705b7f2f