### PR TITLE
Adjust PIN expiry timestamp detection

### DIFF
--- a/pages/api/account/redeem-pin.ts
+++ b/pages/api/account/redeem-pin.ts
@@ -95,7 +95,8 @@ function resolveExpiry(row: Record<string, any>) {
       const date = new Date(value);
       if (!Number.isNaN(date.getTime())) return date;
     } else if (typeof value === 'number') {
-      return new Date(value * (value > 1_000_000_000 ? 1 : 1000));
+      const isMilliseconds = value >= 1e11 || `${Math.trunc(value)}`.length >= 12;
+      return new Date(isMilliseconds ? value : value * 1000);
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- update the PIN expiry resolver to treat numeric timestamps below the millisecond range as epoch seconds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e65000ca9c832191c635994ef40d78