### PR TITLE
Implement mistakes review and progress analytics updates

### DIFF
--- a/components/mistakes/MistakeCard.tsx
+++ b/components/mistakes/MistakeCard.tsx
@@ -1,47 +1,97 @@
+import Link from 'next/link';
 import React from 'react';
-import { Card } from '@/components/design-system/Card';
+
+import { Badge } from '@/components/design-system/Badge';
 import { Button } from '@/components/design-system/Button';
+import { Card } from '@/components/design-system/Card';
 
 export type Mistake = {
   id: string;
-  mistake: string;
+  prompt: string;
   correction: string | null;
-  type: string;
-  next_review: string | null;
+  skill: string;
   repetitions: number;
+  nextReview: string | null;
+  createdAt: string;
+  lastSeenAt: string;
+  retryPath: string | null;
 };
 
 export type MistakeCardProps = {
   mistake: Mistake;
-  onReview: (id: string, repetitions: number) => void;
+  onReview: (mistake: Mistake) => void;
+  onResolve: (id: string) => void;
 };
 
-export const MistakeCard: React.FC<MistakeCardProps> = ({ mistake, onReview }) => {
-  const next = mistake.next_review
-    ? new Date(mistake.next_review).toLocaleDateString()
-    : 'today';
+export const MistakeCard: React.FC<MistakeCardProps> = ({ mistake, onReview, onResolve }) => {
+  const dueLabel = formatDate(mistake.nextReview ?? null);
+  const lastSeenLabel = formatDate(mistake.lastSeenAt);
 
   return (
-    <Card className="p-4 rounded-ds-2xl">
-      <div className="font-medium">{mistake.mistake}</div>
-      {mistake.correction && (
-        <div className="text-small text-grayish dark:text-muted-foreground mt-1">
-          Correct: {mistake.correction}
+    <Card className="rounded-ds-2xl p-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <h3 className="font-medium text-body text-foreground">{mistake.prompt}</h3>
+          {mistake.correction && (
+            <p className="text-small text-muted-foreground">
+              <span className="font-medium text-foreground/80">Correction:</span> {mistake.correction}
+            </p>
+          )}
         </div>
-      )}
-      <div className="text-caption text-grayish dark:text-muted-foreground mt-2">
-        Next review: {next}
+        <Badge variant="info" className="uppercase tracking-wide">
+          {formatSkill(mistake.skill)}
+        </Badge>
+      </header>
+
+      <dl className="mt-4 grid gap-3 text-caption text-muted-foreground sm:grid-cols-3">
+        <div>
+          <dt className="font-medium text-foreground/70">Next review</dt>
+          <dd>{dueLabel}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-foreground/70">Last seen</dt>
+          <dd>{lastSeenLabel}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-foreground/70">Repetitions</dt>
+          <dd>{mistake.repetitions}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {mistake.retryPath && (
+          <Button variant="soft" tone="primary" size="sm" asChild>
+            <Link href={mistake.retryPath}>Retry exercise</Link>
+          </Button>
+        )}
+        <Button size="sm" variant="secondary" onClick={() => onReview(mistake)}>
+          Mark reviewed
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => onResolve(mistake.id)}>
+          Mark resolved
+        </Button>
       </div>
-      <Button
-        size="sm"
-        variant="secondary"
-        className="mt-3 rounded-ds"
-        onClick={() => onReview(mistake.id, mistake.repetitions)}
-      >
-        Mark reviewed
-      </Button>
     </Card>
   );
 };
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Today';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Today';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function formatSkill(skill: string): string {
+  return skill
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
 
 export default MistakeCard;

--- a/components/progress/TrendCharts.tsx
+++ b/components/progress/TrendCharts.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React, { useId, useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { formatWeekLabel, type SkillAverage, type SkillKey, type TrendPoint } from '@/lib/analytics/progress';
+
+const SKILL_ORDER: SkillKey[] = ['reading', 'listening', 'writing', 'speaking'];
+const COLOR_MAP: Record<SkillKey, string> = {
+  reading: 'var(--chart-reading)',
+  listening: 'var(--chart-listening)',
+  writing: 'var(--chart-writing)',
+  speaking: 'var(--chart-speaking)',
+};
+
+const numberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+
+export function TrendLineChart({ data }: { data: TrendPoint[] }) {
+  if (!data || data.length === 0) {
+    return <Fallback>No trend data yet</Fallback>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={320}>
+      <LineChart data={data} margin={{ top: 12, right: 24, left: 8, bottom: 12 }}>
+        <CartesianGrid stroke="var(--chart-grid)" strokeDasharray="4 4" />
+        <XAxis
+          dataKey="weekStart"
+          tickFormatter={(value) => formatWeekLabel(value).split('–')[0]}
+          tick={{ fill: 'var(--chart-axis)' }}
+        />
+        <YAxis
+          domain={[0, 9]}
+          tickFormatter={(value: number) => numberFormatter.format(value)}
+          tick={{ fill: 'var(--chart-axis)' }}
+        />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--chart-tooltip-bg)',
+            border: '1px solid var(--chart-tooltip-border)',
+            borderRadius: '12px',
+            color: 'var(--chart-tooltip-fg)',
+          }}
+          formatter={(value: number, label: SkillKey) => [numberFormatter.format(value), formatSkill(label)]}
+          labelFormatter={(value) => formatWeekLabel(String(value))}
+        />
+        <Legend formatter={(value) => formatSkill(value as string)} />
+        {SKILL_ORDER.map((skill) => (
+          <Line
+            key={skill}
+            type="monotone"
+            dataKey={skill}
+            stroke={COLOR_MAP[skill]}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function SkillAreaChart({ data }: { data: SkillAverage[] }) {
+  if (!data || data.length === 0) {
+    return <Fallback>No per-skill averages yet</Fallback>;
+  }
+
+  const gradientId = useId();
+
+  const chartData = useMemo(
+    () =>
+      data.map((entry) => ({
+        ...entry,
+        label: formatSkill(entry.skill),
+      })),
+    [data],
+  );
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <AreaChart data={chartData} margin={{ top: 12, right: 24, left: 8, bottom: 12 }}>
+        <defs>
+          <linearGradient id={`${gradientId}-fill`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--chart-area)" stopOpacity={0.6} />
+            <stop offset="95%" stopColor="var(--chart-area)" stopOpacity={0.05} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid stroke="var(--chart-grid)" strokeDasharray="4 4" />
+        <XAxis dataKey="label" tick={{ fill: 'var(--chart-axis)' }} />
+        <YAxis
+          domain={[0, 9]}
+          tickFormatter={(value: number) => numberFormatter.format(value)}
+          tick={{ fill: 'var(--chart-axis)' }}
+        />
+        <Tooltip
+          contentStyle={{
+            background: 'var(--chart-tooltip-bg)',
+            border: '1px solid var(--chart-tooltip-border)',
+            borderRadius: '12px',
+            color: 'var(--chart-tooltip-fg)',
+          }}
+          formatter={(value: number) => [numberFormatter.format(value), 'Average band']}
+        />
+        <Area
+          type="monotone"
+          dataKey="average"
+          stroke="var(--chart-area-stroke)"
+          fill={`url(#${gradientId}-fill)`}
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+function formatSkill(skill: string): string {
+  return skill
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+const Fallback: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="flex h-64 w-full items-center justify-center rounded-ds-xl border border-border/60 text-muted-foreground">
+    {children}
+  </div>
+);
+
+export default TrendLineChart;

--- a/components/settings/Accessibility.tsx
+++ b/components/settings/Accessibility.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { Card } from '@/components/design-system/Card';
+import { Toggle } from '@/components/design-system/Toggle';
+import { useHighContrast } from '@/context/HighContrastContext';
+
+function useStatusTimer(state: 'idle' | 'saving' | 'saved' | 'error') {
+  const [current, setCurrent] = useState(state);
+
+  useEffect(() => {
+    if (state === current) return;
+    setCurrent(state);
+    if (state === 'saved' || state === 'error') {
+      const id = window.setTimeout(() => setCurrent('idle'), 2000);
+      return () => window.clearTimeout(id);
+    }
+    return undefined;
+  }, [state, current]);
+
+  return current;
+}
+
+export const AccessibilitySettingsCard: React.FC = () => {
+  const { enabled, setEnabled } = useHighContrast();
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const displayStatus = useStatusTimer(status);
+
+  const handleToggle = async (next: boolean) => {
+    setStatus('saving');
+    try {
+      setEnabled(next);
+      setStatus('saved');
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  const statusLabel =
+    displayStatus === 'saving'
+      ? 'Saving…'
+      : displayStatus === 'saved'
+      ? 'Saved for this device'
+      : displayStatus === 'error'
+      ? 'Unable to save'
+      : null;
+
+  return (
+    <Card className="rounded-ds-2xl border border-border bg-card p-6 text-card-foreground">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <h2 className="text-h4 font-semibold text-foreground">Accessibility themes</h2>
+          <p className="text-small text-muted-foreground max-w-xl">
+            Enable the high-contrast palette to boost text legibility and focus rings. We remember this
+            preference in your browser.
+          </p>
+        </div>
+        <Toggle
+          checked={enabled}
+          onChange={handleToggle}
+          label="High-contrast mode"
+          hint="Applies an AA+ palette with bold focus outlines."
+        />
+      </div>
+      {statusLabel && (
+        <p className="mt-4 text-caption text-muted-foreground" role="status" aria-live="polite">
+          {statusLabel}
+        </p>
+      )}
+    </Card>
+  );
+};
+
+export default AccessibilitySettingsCard;

--- a/context/HighContrastContext.tsx
+++ b/context/HighContrastContext.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+type HighContrastContextValue = {
+  enabled: boolean;
+  setEnabled: (value: boolean) => void;
+  toggle: () => void;
+};
+
+const STORAGE_KEY = 'gramorx:preferences:high-contrast';
+
+const HighContrastContext = createContext<HighContrastContextValue | undefined>(undefined);
+HighContrastContext.displayName = 'HighContrastContext';
+
+function applyDocumentTheme(enabled: boolean) {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  if (enabled) {
+    root.setAttribute('data-theme', 'hc');
+  } else {
+    root.removeAttribute('data-theme');
+  }
+}
+
+export const HighContrastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [enabled, setEnabledState] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      const initial = stored === '1';
+      if (initial) applyDocumentTheme(true);
+      return initial;
+    } catch {
+      return false;
+    }
+  });
+
+  const setEnabled = (value: boolean) => {
+    setEnabledState((prev) => {
+      if (prev === value) return prev;
+      applyDocumentTheme(value);
+      try {
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
+        }
+      } catch {
+        // ignore storage errors
+      }
+      return value;
+    });
+  };
+
+  const toggle = () => setEnabled(!enabled);
+
+  const value = useMemo<HighContrastContextValue>(
+    () => ({ enabled, setEnabled, toggle }),
+    [enabled],
+  );
+
+  return <HighContrastContext.Provider value={value}>{children}</HighContrastContext.Provider>;
+};
+
+export function useHighContrast(): HighContrastContextValue {
+  const ctx = useContext(HighContrastContext);
+  if (!ctx) {
+    throw new Error('useHighContrast must be used within a HighContrastProvider');
+  }
+  return ctx;
+}

--- a/lib/analytics/progress.ts
+++ b/lib/analytics/progress.ts
@@ -1,0 +1,135 @@
+// lib/analytics/progress.ts
+// Helpers to aggregate progress analytics into weekly trends.
+
+export type SkillKey = 'reading' | 'listening' | 'writing' | 'speaking';
+
+export type BandRow = {
+  attempt_date: string;
+  skill: SkillKey | string;
+  band: number | null;
+};
+
+export type TrendPoint = {
+  weekStart: string;
+} & Partial<Record<SkillKey, number>>;
+
+export type SkillAverage = {
+  skill: SkillKey;
+  average: number;
+  delta: number;
+  samples: number;
+};
+
+export interface ProgressTrendPayload {
+  timeline: TrendPoint[];
+  perSkill: SkillAverage[];
+  totalAttempts: number;
+}
+
+const SKILLS: SkillKey[] = ['reading', 'listening', 'writing', 'speaking'];
+
+export function buildProgressTrends(rows: BandRow[]): ProgressTrendPayload {
+  if (!rows || rows.length === 0) {
+    return { timeline: [], perSkill: [], totalAttempts: 0 };
+  }
+
+  const weekMap = new Map<string, Map<SkillKey, { sum: number; count: number }>>();
+  const totals = new Map<SkillKey, { sum: number; count: number }>();
+
+  rows.forEach((row) => {
+    const skill = normalizeSkill(row.skill);
+    if (!skill) return;
+    const band = typeof row.band === 'number' ? row.band : null;
+    if (band == null || Number.isNaN(band)) return;
+
+    const key = weekStart(row.attempt_date);
+    if (!weekMap.has(key)) {
+      weekMap.set(key, new Map());
+    }
+    const weekEntry = weekMap.get(key)!;
+    const current = weekEntry.get(skill) ?? { sum: 0, count: 0 };
+    weekEntry.set(skill, { sum: current.sum + band, count: current.count + 1 });
+
+    const totalEntry = totals.get(skill) ?? { sum: 0, count: 0 };
+    totals.set(skill, { sum: totalEntry.sum + band, count: totalEntry.count + 1 });
+  });
+
+  const timeline = Array.from(weekMap.entries())
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([week, data]) => {
+      const point: TrendPoint = { weekStart: week };
+      SKILLS.forEach((skill) => {
+        const stats = data.get(skill);
+        if (stats && stats.count > 0) {
+          point[skill] = Number((stats.sum / stats.count).toFixed(2));
+        }
+      });
+      return point;
+    });
+
+  const perSkill = SKILLS.map((skill) => {
+    const total = totals.get(skill) ?? { sum: 0, count: 0 };
+    const average = total.count > 0 ? total.sum / total.count : 0;
+
+    const { current, previous } = weeklyAveragesForSkill(timeline, skill);
+    const delta = current.count > 0 && previous.count > 0
+      ? current.sum / current.count - previous.sum / previous.count
+      : 0;
+
+    return {
+      skill,
+      average: Number(average.toFixed(2)),
+      delta: Number(delta.toFixed(2)),
+      samples: total.count,
+    };
+  }).filter((entry) => entry.samples > 0);
+
+  return {
+    timeline,
+    perSkill,
+    totalAttempts: rows.length,
+  };
+}
+
+function normalizeSkill(skill: string | SkillKey): SkillKey | null {
+  const lower = skill?.toString().toLowerCase();
+  return SKILLS.includes(lower as SkillKey) ? (lower as SkillKey) : null;
+}
+
+function weekStart(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.slice(0, 10);
+
+  const utc = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const temp = new Date(utc);
+  const day = temp.getUTCDay();
+  const offset = (day + 6) % 7; // Monday = 0
+  temp.setUTCDate(temp.getUTCDate() - offset);
+  return temp.toISOString().slice(0, 10);
+}
+
+function weeklyAveragesForSkill(timeline: TrendPoint[], skill: SkillKey) {
+  const last = timeline[timeline.length - 1];
+  const prev = timeline.length > 1 ? timeline[timeline.length - 2] : undefined;
+
+  const current = extractStats(last, skill);
+  const previous = extractStats(prev, skill);
+
+  return { current, previous };
+}
+
+function extractStats(point: TrendPoint | undefined, skill: SkillKey) {
+  if (!point || point[skill] == null) {
+    return { sum: 0, count: 0 };
+  }
+  return { sum: point[skill] as number, count: 1 };
+}
+
+export function formatWeekLabel(isoWeekStart: string): string {
+  const date = new Date(isoWeekStart);
+  if (Number.isNaN(date.getTime())) return isoWeekStart;
+  const end = new Date(date);
+  end.setUTCDate(end.getUTCDate() + 6);
+  const fmt = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+  return `${fmt.format(date)} – ${fmt.format(end)}`;
+}

--- a/lib/mistakes.ts
+++ b/lib/mistakes.ts
@@ -1,0 +1,97 @@
+// lib/mistakes.ts
+// Client helpers for the Mistakes Book experience.
+
+export type MistakeRecord = {
+  id: string;
+  prompt: string;
+  correction: string | null;
+  skill: string;
+  repetitions: number;
+  nextReview: string | null;
+  createdAt: string;
+  lastSeenAt: string;
+  retryPath: string | null;
+};
+
+export type MistakePage = {
+  items: MistakeRecord[];
+  nextCursor: string | null;
+};
+
+function toQuery(params: Record<string, string | undefined>) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) search.set(key, value);
+  });
+  const query = search.toString();
+  return query ? `?${query}` : '';
+}
+
+export async function fetchMistakePage({
+  cursor,
+  limit,
+  signal,
+}: {
+  cursor?: string | null;
+  limit?: number;
+  signal?: AbortSignal;
+} = {}): Promise<MistakePage> {
+  const query = toQuery({
+    cursor: cursor ?? undefined,
+    limit: limit ? String(limit) : undefined,
+  });
+  const res = await fetch(`/api/mistakes${query}`, { signal });
+  if (!res.ok) {
+    throw new Error(`Failed to load mistakes: ${res.status}`);
+  }
+  return (await res.json()) as MistakePage;
+}
+
+export async function recordMistakeReview({
+  id,
+  repetitions,
+  nextReview,
+}: {
+  id: string;
+  repetitions: number;
+  nextReview: string;
+}): Promise<MistakeRecord> {
+  const res = await fetch('/api/mistakes', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      id,
+      repetitions,
+      next_review: nextReview,
+      last_seen_at: new Date().toISOString(),
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to update mistake ${id}`);
+  }
+  return (await res.json()) as MistakeRecord;
+}
+
+export async function resolveMistake(id: string): Promise<void> {
+  const res = await fetch('/api/mistakes', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, resolved: true }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to resolve mistake ${id}`);
+  }
+}
+
+export async function unresolveMistake(id: string): Promise<MistakeRecord | null> {
+  const res = await fetch('/api/mistakes', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, resolved: false }),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to restore mistake ${id}`);
+  }
+  const payload = (await res.json()) as { item: MistakeRecord | null };
+  return payload.item ?? null;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -50,6 +50,7 @@ import TeacherProfile from '@/components/teacher/TeacherProfile';
 
 import { Poppins, Roboto_Slab } from 'next/font/google';
 import { UserProvider, useUserContext } from '@/context/UserContext';
+import { HighContrastProvider } from '@/context/HighContrastContext';
 
 // ✅ NEW: global plan guard (client-side gating + ribbon)
 import GlobalPlanGuard from '@/components/GlobalPlanGuard';
@@ -418,36 +419,38 @@ function InnerApp({ Component, pageProps }: AppProps) {
 
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      {/* Load the compiled premium DS stylesheet globally */}
-      <Head>
-        <link rel="preload" href="/premium.css" as="style" />
-        <link rel="stylesheet" href="/premium.css" />
-      </Head>
+      <HighContrastProvider>
+        {/* Load the compiled premium DS stylesheet globally */}
+        <Head>
+          <link rel="preload" href="/premium.css" as="style" />
+          <link rel="stylesheet" href="/premium.css" />
+        </Head>
 
-      <div className={`${poppins.className} ${slab.className} min-h-[100dvh] bg-background text-foreground`}>
-        {/* ✅ NEW: Client-side plan guard + ribbon + route protection */}
-        <GlobalPlanGuard />
+        <div className={`${poppins.className} ${slab.className} min-h-[100dvh] bg-background text-foreground`}>
+          {/* ✅ NEW: Client-side plan guard + ribbon + route protection */}
+          <GlobalPlanGuard />
 
-        {forceLayoutOnAuthPage ? (
-          <Layout>
-            <ImpersonationBanner />
-            {nakedContent}
-          </Layout>
-        ) : showLayout ? (
-          <Layout>
-            <ImpersonationBanner />
-            {content}
-          </Layout>
-        ) : (
-          <>
-            <ImpersonationBanner />
-            {nakedContent}
-          </>
-        )}
-        <AuthAssistant />
-        <SidebarAI />
-        <UpgradeModal />
-      </div>
+          {forceLayoutOnAuthPage ? (
+            <Layout>
+              <ImpersonationBanner />
+              {nakedContent}
+            </Layout>
+          ) : showLayout ? (
+            <Layout>
+              <ImpersonationBanner />
+              {content}
+            </Layout>
+          ) : (
+            <>
+              <ImpersonationBanner />
+              {nakedContent}
+            </>
+          )}
+          <AuthAssistant />
+          <SidebarAI />
+          <UpgradeModal />
+        </div>
+      </HighContrastProvider>
     </ThemeProvider>
   );
 }

--- a/pages/account/index.tsx
+++ b/pages/account/index.tsx
@@ -118,19 +118,19 @@ export default function SettingsHubPage() {
             <div className="rounded-xl border border-border bg-card p-4">
               <h2 className="text-small font-medium text-foreground">Accessibility</h2>
               <p className="mt-1 text-small text-muted-foreground">
-                Keyboard checks, screen reader hints, and live region demo.
+                High contrast themes, keyboard checks, and screen reader hints.
               </p>
               <div className="mt-3">
                 <Button
                   variant="soft"
                   onClick={(e) => {
                     e.preventDefault();
-                    safePush("/accessibility");
+                    safePush("/settings/accessibility");
                   }}
                 >
                   Open Accessibility
                 </Button>
-                <Link href="/accessibility" prefetch={false} className="sr-only">
+                <Link href="/settings/accessibility" prefetch={false} className="sr-only">
                   Accessibility (link for SEO)
                 </Link>
               </div>

--- a/pages/api/mistakes/index.ts
+++ b/pages/api/mistakes/index.ts
@@ -1,38 +1,127 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
+
+type MistakeRow = {
+  id: string;
+  mistake: string;
+  correction: string | null;
+  type: string | null;
+  repetitions: number | null;
+  next_review: string | null;
+  retry_path: string | null;
+  created_at: string;
+  last_seen_at?: string | null;
+  resolved_at?: string | null;
+};
+
+type MistakePayload = {
+  id: string;
+  prompt: string;
+  correction: string | null;
+  skill: string;
+  repetitions: number;
+  nextReview: string | null;
+  retryPath: string | null;
+  createdAt: string;
+  lastSeenAt: string;
+  resolvedAt: string | null;
+};
+
+const FALLBACK_CODES = new Set(['42P01', '42703']);
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const supabase = createSupabaseServerClient({ req });
 
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
   if (req.method === 'GET') {
-    const { data, error } = await supabase
-      .from('mistakes_book')
-      .select('*')
+    const limit = Math.min(Number(req.query.limit) || 10, 50);
+    const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : null;
+    const since = new Date();
+    since.setDate(since.getDate() - 30);
+    const sinceIso = since.toISOString();
+
+    const selectCols =
+      'id,mistake,correction,type,repetitions,next_review,retry_path,created_at,last_seen_at,resolved_at';
+
+    let query = supabase
+      .from('mistake_review_queue')
+      .select(selectCols)
       .eq('user_id', user.id)
-      .order('next_review', { ascending: true });
-    if (error) return res.status(500).json({ error: error.message });
-    return res.status(200).json(data);
+      .is('resolved_at', null)
+      .gte('created_at', sinceIso)
+      .order('created_at', { ascending: false })
+      .limit(limit + 1);
+
+    if (cursor) {
+      query = query.lt('created_at', cursor);
+    }
+
+    let { data, error } = await query;
+    let rows = (data as MistakeRow[]) ?? [];
+
+    if (error && FALLBACK_CODES.has(error.code ?? '')) {
+      // Older databases might not have the view yet. Fall back to the raw table.
+      let fallback = supabase
+        .from('mistakes_book')
+        .select('id,mistake,correction,type,repetitions,next_review,retry_path,created_at,last_seen_at')
+        .eq('user_id', user.id)
+        .gte('created_at', sinceIso)
+        .order('created_at', { ascending: false })
+        .limit(limit + 1);
+      if (cursor) fallback = fallback.lt('created_at', cursor);
+
+      const fallbackResult = await fallback;
+      error = fallbackResult.error;
+      rows = (fallbackResult.data as MistakeRow[]) ?? [];
+
+      if (!error) {
+        const { data: resolvedData } = await supabase
+          .from('mistake_resolutions')
+          .select('mistake_id')
+          .eq('user_id', user.id);
+        if (resolvedData?.length) {
+          const resolvedIds = new Set(resolvedData.map((row: { mistake_id: string }) => row.mistake_id));
+          rows = rows.filter((row) => !resolvedIds.has(row.id));
+        }
+      }
+    }
+
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    const hasMore = rows.length > limit;
+    const trimmed = hasMore ? rows.slice(0, limit) : rows;
+    const items = trimmed.map(mapRow);
+    const nextCursor = hasMore ? trimmed[trimmed.length - 1]?.created_at ?? null : null;
+
+    return res.status(200).json({ items, nextCursor });
   }
 
   if (req.method === 'POST') {
-    const { mistake, correction, type } = req.body as {
-      mistake?: string; correction?: string; type?: string;
+    const { mistake, correction, type, retryPath } = req.body as {
+      mistake?: string;
+      correction?: string;
+      type?: string;
+      retryPath?: string | null;
     };
     if (!mistake) {
       return res.status(400).json({ error: 'Missing mistake' });
     }
     const { data, error } = await supabase
       .from('mistakes_book')
-      .insert({ user_id: user.id, mistake, correction, type })
+      .insert({ user_id: user.id, mistake, correction, type, retry_path: retryPath ?? null })
       .select()
       .single();
     if (error) return res.status(500).json({ error: error.message });
-    return res.status(201).json(data);
+    return res.status(201).json(mapRow(data as MistakeRow));
   }
 
   if (req.method === 'PUT') {
@@ -48,7 +137,47 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .select()
       .single();
     if (error) return res.status(500).json({ error: error.message });
-    return res.status(200).json(data);
+    return res.status(200).json(mapRow(data as MistakeRow));
+  }
+
+  if (req.method === 'PATCH') {
+    const { id, resolved } = req.body as { id?: string; resolved?: boolean };
+    if (!id) {
+      return res.status(400).json({ error: 'Missing id' });
+    }
+
+    if (resolved) {
+      const { error } = await supabase
+        .from('mistake_resolutions')
+        .upsert({ user_id: user.id, mistake_id: id, resolved_at: new Date().toISOString() });
+      if (error && error.code !== '23505') {
+        return res.status(500).json({ error: error.message });
+      }
+    } else {
+      const { error } = await supabase
+        .from('mistake_resolutions')
+        .delete()
+        .eq('user_id', user.id)
+        .eq('mistake_id', id);
+      if (error) {
+        return res.status(500).json({ error: error.message });
+      }
+    }
+
+    const { data, error } = await supabase
+      .from('mistake_review_queue')
+      .select(
+        'id,mistake,correction,type,repetitions,next_review,retry_path,created_at,last_seen_at,resolved_at',
+      )
+      .eq('user_id', user.id)
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    return res.status(200).json({ item: mapRow(data as MistakeRow | null) });
   }
 
   if (req.method === 'DELETE') {
@@ -65,6 +194,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(200).json({ success: true });
   }
 
-  res.setHeader('Allow', 'GET,POST,PUT,DELETE');
+  res.setHeader('Allow', 'GET,POST,PUT,PATCH,DELETE');
   return res.status(405).end('Method Not Allowed');
+}
+
+function mapRow(row: MistakeRow | null | undefined): MistakePayload | null {
+  if (!row) return null;
+  return {
+    id: row.id,
+    prompt: row.mistake,
+    correction: row.correction ?? null,
+    skill: row.type ?? 'general',
+    repetitions: row.repetitions ?? 0,
+    nextReview: row.next_review ?? null,
+    retryPath: row.retry_path ?? null,
+    createdAt: row.created_at,
+    lastSeenAt: row.last_seen_at ?? row.created_at,
+    resolvedAt: row.resolved_at ?? null,
+  };
 }

--- a/pages/api/progress/index.ts
+++ b/pages/api/progress/index.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { buildProgressTrends, type BandRow } from '@/lib/analytics/progress';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const supabase = createSupabaseServerClient({ req });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    return res.status(500).json({ error: authError.message });
+  }
+
+  if (!user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const weeks = Math.min(Number(req.query.weeks) || 12, 52);
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - weeks * 7);
+  const sinceIso = since.toISOString();
+
+  const { data, error } = await supabase
+    .from('progress_band_trajectory')
+    .select('attempt_date, skill, band')
+    .eq('user_id', user.id)
+    .gte('attempt_date', sinceIso)
+    .order('attempt_date', { ascending: true });
+
+  if (error) {
+    return res.status(500).json({ error: error.message });
+  }
+
+  const payload = buildProgressTrends(((data ?? []) as BandRow[]).map((row) => ({
+    attempt_date: row.attempt_date,
+    skill: row.skill,
+    band: typeof row.band === 'number' ? row.band : Number(row.band ?? 0),
+  })));
+
+  return res.status(200).json(payload);
+}

--- a/pages/mistakes/index.tsx
+++ b/pages/mistakes/index.tsx
@@ -1,103 +1,139 @@
-import React, { useEffect, useState } from 'react';
-import { Container } from '@/components/design-system/Container';
-import { Input } from '@/components/design-system/Input';
-import { Textarea } from '@/components/design-system/Textarea';
-import { Select } from '@/components/design-system/Select';
+'use client';
+
+import React, { useCallback, useMemo } from 'react';
+import useSWRInfinite from 'swr/infinite';
+
 import { Button } from '@/components/design-system/Button';
-import MistakeCard, { Mistake } from '@/components/mistakes/MistakeCard';
+import { Container } from '@/components/design-system/Container';
+import { EmptyState } from '@/components/design-system/EmptyState';
+import MistakeCard, { type Mistake } from '@/components/mistakes/MistakeCard';
+import {
+  fetchMistakePage,
+  recordMistakeReview,
+  resolveMistake,
+  type MistakePage,
+  type MistakeRecord,
+} from '@/lib/mistakes';
 import { scheduleReview } from '@/lib/spaced-repetition';
 
+const PAGE_SIZE = 10;
+
 export default function MistakesPage() {
-  const [mistakes, setMistakes] = useState<Mistake[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [form, setForm] = useState({ mistake: '', correction: '', type: 'grammar' });
+  const getKey = useCallback(
+    (index: number, previousPage: MistakePage | null) => {
+      if (previousPage && !previousPage.nextCursor) return null;
+      const cursor = index === 0 ? undefined : previousPage?.nextCursor ?? undefined;
+      return { cursor, limit: PAGE_SIZE } as const;
+    },
+    [],
+  );
 
-  useEffect(() => {
-    let active = true;
-    (async () => {
-      try {
-        const res = await fetch('/api/mistakes');
-        if (!active) return;
-        if (res.ok) {
-          const data = await res.json();
-          setMistakes(data as Mistake[]);
-        }
-      } finally {
-        if (active) setLoading(false);
-      }
-    })();
-    return () => { active = false; };
-  }, []);
+  const { data, error, size, setSize, mutate, isValidating } = useSWRInfinite<MistakePage>(
+    getKey,
+    ({ cursor, limit }) => fetchMistakePage({ cursor, limit }),
+    { revalidateFirstPage: false },
+  );
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!form.mistake) return;
-    const res = await fetch('/api/mistakes', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      setMistakes((m) => [data as Mistake, ...m]);
-      setForm({ mistake: '', correction: '', type: 'grammar' });
-    }
-  };
+  const pages = data ?? [];
+  const mistakes = useMemo(() => pages.flatMap((page) => page.items), [pages]);
+  const loadingInitial = !data && !error;
+  const hasMore = pages.length > 0 ? Boolean(pages[pages.length - 1]?.nextCursor) : true;
+  const loadingMore = isValidating && size > (data?.length ?? 0);
 
-  const handleReview = async (id: string, reps: number) => {
-    const next = scheduleReview(reps + 1).toISOString();
-    const res = await fetch('/api/mistakes', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id, repetitions: reps + 1, next_review: next }),
-    });
-    if (res.ok) {
-      setMistakes((arr) =>
-        arr.map((m) => (m.id === id ? { ...m, repetitions: reps + 1, next_review: next } : m)),
+  const handleReview = useCallback(
+    async (mistake: Mistake) => {
+      const nextReps = mistake.repetitions + 1;
+      const nextReview = scheduleReview(nextReps).toISOString();
+      const updated = await recordMistakeReview({
+        id: mistake.id,
+        repetitions: nextReps,
+        nextReview,
+      });
+
+      await mutate(
+        (pages) =>
+          pages?.map((page) => ({
+            ...page,
+            items: page.items.map((item) => (item.id === mistake.id ? mapToMistake(item, updated) : item)),
+          })) ?? null,
+        { revalidate: false },
       );
-    }
-  };
+    },
+    [mutate],
+  );
+
+  const handleResolve = useCallback(
+    async (id: string) => {
+      await resolveMistake(id);
+      await mutate(
+        (pages) =>
+          pages?.map((page) => ({
+            ...page,
+            items: page.items.filter((item) => item.id !== id),
+            nextCursor: page.nextCursor,
+          })) ?? null,
+        { revalidate: false },
+      );
+    },
+    [mutate],
+  );
 
   return (
     <Container className="py-10">
-      <h1 className="font-slab text-h2 mb-6">Mistakes Book</h1>
-      <form onSubmit={submit} className="grid gap-4 mb-8 max-w-xl">
-        <Input
-          label="Mistake"
-          value={form.mistake}
-          onChange={(e) => setForm({ ...form, mistake: e.target.value })}
-          required
-        />
-        <Textarea
-          label="Correction"
-          value={form.correction}
-          onChange={(e) => setForm({ ...form, correction: e.target.value })}
-        />
-        <div className="flex gap-2 items-end">
-          <Select
-            label="Type"
-            value={form.type}
-            onChange={(e) => setForm({ ...form, type: e.target.value })}
-            options={[
-              { value: 'grammar', label: 'Grammar' },
-              { value: 'vocab', label: 'Vocabulary' },
-            ]}
-            className="flex-1"
-          />
-          <Button type="submit" className="rounded-ds self-end">
-            Add
-          </Button>
+      <header className="mb-8 space-y-2">
+        <p className="text-caption uppercase tracking-[0.18em] text-muted-foreground">Spaced review</p>
+        <h1 className="font-slab text-h2 text-foreground">Mistakes Book</h1>
+        <p className="max-w-2xl text-body text-muted-foreground">
+          We track incorrect answers from the last 30 days and queue them for spaced review. Mark a
+          card reviewed after retrying, or resolve it once you&apos;re confident it&apos;s fixed.
+        </p>
+      </header>
+
+      {loadingInitial ? (
+        <p className="text-muted-foreground">Loading mistakes…</p>
+      ) : error ? (
+        <div className="rounded-ds-xl border border-danger/40 bg-danger/10 p-4 text-danger">
+          We couldn&apos;t load your mistakes right now. Please refresh.
         </div>
-      </form>
-      {loading ? (
-        <p>Loading...</p>
+      ) : mistakes.length === 0 ? (
+        <EmptyState
+          title="You&apos;re all caught up"
+          description="Incorrect answers from practice will appear here for review."
+          actionLabel="Start a mock test"
+          onAction={() => window.open('/mock-tests', '_self')}
+        />
       ) : (
-        <div className="grid gap-4">
-          {mistakes.map((m) => (
-            <MistakeCard key={m.id} mistake={m} onReview={handleReview} />
+        <div className="space-y-4">
+          {mistakes.map((mistake) => (
+            <MistakeCard
+              key={mistake.id}
+              mistake={mistake}
+              onReview={handleReview}
+              onResolve={handleResolve}
+            />
           ))}
+          {hasMore && (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="soft"
+                tone="default"
+                onClick={() => setSize((prev) => prev + 1)}
+                loading={loadingMore}
+                loadingText="Loading more"
+              >
+                Load more
+              </Button>
+            </div>
+          )}
         </div>
       )}
     </Container>
   );
+}
+
+function mapToMistake(prev: MistakeRecord, next: MistakeRecord): MistakeRecord {
+  return {
+    ...prev,
+    ...next,
+  };
 }

--- a/pages/progress/index.tsx
+++ b/pages/progress/index.tsx
@@ -1,175 +1,142 @@
-// pages/progress/index.tsx
-import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
-import Link from 'next/link';
-import { Container } from '@/components/design-system/Container';
-import { Card } from '@/components/design-system/Card';
+'use client';
+
+import React from 'react';
+import dynamic from 'next/dynamic';
+import useSWR from 'swr';
+
 import { Button } from '@/components/design-system/Button';
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { Card } from '@/components/design-system/Card';
+import { Container } from '@/components/design-system/Container';
+import { EmptyState } from '@/components/design-system/EmptyState';
+import type { ProgressTrendPayload, SkillAverage } from '@/lib/analytics/progress';
 
-type Skill = 'reading' | 'listening' | 'writing' | 'speaking';
+const TrendLineChart = dynamic(
+  () => import('@/components/progress/TrendCharts').then((mod) => mod.TrendLineChart),
+  { ssr: false, loading: () => <ChartSkeleton /> },
+);
+const SkillAreaChart = dynamic(
+  () => import('@/components/progress/TrendCharts').then((mod) => mod.SkillAreaChart),
+  { ssr: false, loading: () => <ChartSkeleton /> },
+);
 
-interface BandRow {
-  attempt_date: string; // ISO
-  skill: Skill;
-  band: number;
-}
+const fetcher = (url: string) => fetch(url).then((res) => {
+  if (!res.ok) throw new Error('Failed to load progress trends');
+  return res.json();
+});
 
-interface AccuracyRow {
-  question_type: string;
-  accuracy_pct: number;
-}
+const numberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
 
-interface TimeRow {
-  skill: Skill;
-  total_minutes: number;
-}
+export default function ProgressPage() {
+  const { data, error, isLoading } = useSWR<ProgressTrendPayload>('/api/progress', fetcher);
 
-type BandDay = { date: string } & Partial<Record<Skill, number>>;
-
-export default function Progress() {
-  const router = useRouter();
-  const [bandData, setBandData] = useState<BandDay[]>([]);
-  const [accuracyData, setAccuracyData] = useState<AccuracyRow[]>([]);
-  const [timeData, setTimeData] = useState<TimeRow[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let mounted = true;
-    (async () => {
-      const { data: { session } } = await supabaseBrowser.auth.getSession();
-      if (!session?.user) {
-        router.replace('/login');
-        return;
-      }
-      const uid = session.user.id;
-
-      const [{ data: bt }, { data: acc }, { data: tt }] = await Promise.all([
-        supabaseBrowser
-          .from('progress_band_trajectory')
-          .select('attempt_date,skill,band')
-          .eq('user_id', uid)
-          .order('attempt_date'),
-        supabaseBrowser
-          .from('progress_accuracy_per_type')
-          .select('question_type,accuracy_pct')
-          .eq('user_id', uid),
-        supabaseBrowser
-          .from('progress_time_spent')
-          .select('skill,total_minutes')
-          .eq('user_id', uid),
-      ]);
-
-      if (!mounted) return;
-      setBandData(groupBand((bt ?? []) as BandRow[]));
-      setAccuracyData((acc ?? []) as AccuracyRow[]);
-      setTimeData((tt ?? []) as TimeRow[]);
-      setLoading(false);
-    })();
-    return () => {
-      mounted = false;
-    };
-  }, [router]);
+  const timeline = data?.timeline ?? [];
+  const perSkill = data?.perSkill ?? [];
+  const totalAttempts = data?.totalAttempts ?? 0;
+  const hasData = timeline.length > 0 || perSkill.length > 0;
 
   const exportJSON = () => {
-    const blob = new Blob(
-      [JSON.stringify({ bandData, accuracyData, timeData }, null, 2)],
-      { type: 'application/json' }
-    );
+    if (!data) return;
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'progress.json';
-    a.click();
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'progress-trends.json';
+    anchor.click();
     URL.revokeObjectURL(url);
   };
 
   const exportCSV = () => {
+    if (!data) return;
     const lines: string[] = [];
-    lines.push('band_trajectory');
-    lines.push('date,reading,listening,writing,speaking');
-    bandData.forEach((row) => {
-      lines.push(
-        `${row.date || ''},${row.reading ?? ''},${row.listening ?? ''},${
-          row.writing ?? ''
-        },${row.speaking ?? ''}`
-      );
+    lines.push('timeline');
+    lines.push('week_start,reading,listening,writing,speaking');
+    data.timeline.forEach((point) => {
+      lines.push([
+        point.weekStart,
+        formatCsvValue(point.reading),
+        formatCsvValue(point.listening),
+        formatCsvValue(point.writing),
+        formatCsvValue(point.speaking),
+      ].join(','));
     });
     lines.push('');
-    lines.push('accuracy_per_question_type');
-    lines.push('question_type,accuracy_pct');
-    accuracyData.forEach((r) =>
-      lines.push(`${safeCsv(r.question_type)},${r.accuracy_pct}`)
-    );
-    lines.push('');
-    lines.push('time_spent');
-    lines.push('skill,total_minutes');
-    timeData.forEach((r) =>
-      lines.push(`${r.skill},${Math.round(r.total_minutes)}`)
-    );
+    lines.push('per_skill');
+    lines.push('skill,average,delta,samples');
+    data.perSkill.forEach((entry) => {
+      lines.push([
+        entry.skill,
+        entry.average.toFixed(2),
+        entry.delta.toFixed(2),
+        String(entry.samples),
+      ].join(','));
+    });
+
     const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'progress.csv';
-    a.click();
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'progress-trends.csv';
+    anchor.click();
     URL.revokeObjectURL(url);
   };
-
-  const hasAnyData =
-    bandData.length > 0 || accuracyData.length > 0 || timeData.length > 0;
 
   return (
     <section className="py-10">
       <Container>
-        <Card className="p-6 rounded-ds-2xl">
-          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-            <h1 className="font-slab text-h2">Progress</h1>
+        <Card className="rounded-ds-2xl border border-border bg-card p-6 text-card-foreground">
+          <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h1 className="font-slab text-h2 text-foreground">Progress trends</h1>
+              <p className="text-small text-muted-foreground">
+                Weekly band averages and per-skill momentum from your recent practice.
+              </p>
+            </div>
             <div className="flex gap-2">
-              <Button variant="secondary" onClick={exportCSV}>
+              <Button variant="secondary" onClick={exportCSV} disabled={!data}>
                 Export CSV
               </Button>
-              <Button variant="secondary" onClick={exportJSON}>
+              <Button variant="secondary" onClick={exportJSON} disabled={!data}>
                 Export JSON
               </Button>
             </div>
-          </div>
+          </header>
 
-          {loading ? (
-            <div className="rounded-xl border border-border p-4 text-small text-foreground/70">
-              Loading your analytics…
+          {isLoading ? (
+            <ChartSkeleton large />
+          ) : error ? (
+            <div className="rounded-ds-xl border border-danger/30 bg-danger/10 p-4 text-danger">
+              Unable to load progress trends. Please try again later.
             </div>
-          ) : !hasAnyData ? (
-            <EmptyState />
+          ) : !hasData ? (
+            <EmptyState
+              title="No progress yet"
+              description="Complete a mock or quick drill to start tracking your weekly trends."
+              actionLabel="Browse practice"
+              onAction={() => window.open('/learning', '_self')}
+            />
           ) : (
-            <>
-              <div className="mb-8">
-                <h2 className="font-slab text-h3 mb-2">Band trajectory</h2>
-                <BandChart data={bandData} />
-                <p className="mt-2 text-caption text-foreground/70">
-                  Tip: Complete a{' '}
-                  <Link
-                    href="/mock/listening/sample-001"
-                    className="underline underline-offset-4"
-                  >
-                    Listening mock
-                  </Link>{' '}
-                  today to update this graph.
-                </p>
-              </div>
+            <div className="space-y-10">
+              <section className="space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <h2 className="font-slab text-h3 text-foreground">Weekly band trend</h2>
+                  <span className="text-caption text-muted-foreground">
+                    Aggregated from {totalAttempts} recent attempts.
+                  </span>
+                </div>
+                <TrendLineChart data={timeline} />
+              </section>
 
-              <div className="mb-8">
-                <h2 className="font-slab text-h3 mb-2">
-                  Accuracy per question type
-                </h2>
-                <AccuracyChart data={accuracyData} />
-              </div>
-
-              <div>
-                <h2 className="font-slab text-h3 mb-2">Total time spent</h2>
-                <TimeChart data={timeData} />
-              </div>
-            </>
+              <section className="space-y-4">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <h2 className="font-slab text-h3 text-foreground">Per-skill averages</h2>
+                  <span className="text-caption text-muted-foreground">
+                    Change compares the latest week with the one before it.
+                  </span>
+                </div>
+                <SkillAreaChart data={perSkill} />
+                <SkillSummary data={perSkill} />
+              </section>
+            </div>
           )}
         </Card>
       </Container>
@@ -177,254 +144,65 @@ export default function Progress() {
   );
 }
 
-/* ---------- local EmptyState (DS tokens only) ---------- */
-function EmptyState() {
+function SkillSummary({ data }: { data: SkillAverage[] }) {
+  if (!data || data.length === 0) return null;
   return (
-    <div className="rounded-ds border border-border p-8 text-center bg-card text-card-foreground">
-      <h3 className="font-slab text-h4 mb-2">No progress yet</h3>
-      <p className="text-small text-foreground/70 mb-4">
-        Start a mock to see your band trajectory, accuracy and time charts here.
-      </p>
-      <div className="flex gap-2 justify-center">
-        <Link href="/listening" className="btn">
-          Start Listening
-        </Link>
-        <Link href="/reading" className="btn">
-          Start Reading
-        </Link>
-      </div>
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      {data.map((entry) => {
+        const trend = classifyDelta(entry.delta);
+        return (
+          <div
+            key={entry.skill}
+            className="rounded-ds-xl border border-border/60 bg-card/40 p-4"
+            aria-label={`${formatSkill(entry.skill)} average ${numberFormatter.format(entry.average)} band`}
+          >
+            <div className="text-caption uppercase tracking-[0.12em] text-muted-foreground">
+              {formatSkill(entry.skill)}
+            </div>
+            <div className="mt-1 text-h3 font-semibold text-foreground">
+              {numberFormatter.format(entry.average)}
+            </div>
+            <div
+              className={`text-caption ${
+                trend === 'up' ? 'text-success' : trend === 'down' ? 'text-danger' : 'text-muted-foreground'
+              }`}
+            >
+              {trend === 'flat'
+                ? 'No week-over-week change'
+                : `${trend === 'up' ? '+' : ''}${numberFormatter.format(entry.delta)} vs previous week`}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-/* ---------- helpers ---------- */
-
-function groupBand(rows: BandRow[]): BandDay[] {
-  const map = new Map<string, BandDay>();
-  rows.forEach((r) => {
-    const date = r.attempt_date.slice(0, 10);
-    const entry = map.get(date) || { date };
-    (entry as any)[r.skill] = r.band;
-    map.set(date, entry);
-  });
-  return Array.from(map.values());
+function classifyDelta(delta: number): 'up' | 'down' | 'flat' {
+  const threshold = 0.05;
+  if (delta > threshold) return 'up';
+  if (delta < -threshold) return 'down';
+  return 'flat';
 }
 
-function safeCsv(s: string) {
-  return /[,"\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+function formatSkill(skill: string): string {
+  return skill
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
 }
 
-/* ---------- charts (token-only colors) ---------- */
-/**
- * Notes:
- * - No hex/inline colors. Use token classes + currentColor.
- * - Axes: text-border → stroke="currentColor".
- * - Series tokens: reading=primary, listening=secondary, writing=accent, speaking=foreground.
- */
+function formatCsvValue(value: number | undefined): string {
+  return typeof value === 'number' && !Number.isNaN(value) ? value.toFixed(2) : '';
+}
 
-function BandChart({ data }: { data: BandDay[] }) {
-  const skills: Skill[] = ['reading', 'listening', 'writing', 'speaking'];
-  const seriesClass: Record<Skill, string> = {
-    reading: 'text-primary',
-    listening: 'text-secondary',
-    writing: 'text-accent',
-    speaking: 'text-foreground',
-  };
-
-  const width = 600;
-  const height = 220;
-  const n = Math.max(1, data.length - 1);
-  const pointsFor = (skill: Skill) =>
-    data
-      .map((d, i) => {
-        const x = (i / Math.max(1, n)) * width;
-        const band = Number((d as any)[skill] ?? 0);
-        const y = height - (Math.min(9, Math.max(0, band)) / 9) * height;
-        return `${x},${y}`;
-      })
-      .join(' ');
-
+function ChartSkeleton({ large = false }: { large?: boolean }) {
   return (
-    <svg
-      role="img"
-      aria-label="Band trajectory across skills"
-      width="100%"
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      className="rounded-ds border border-border"
-    >
-      {/* axes */}
-      <g className="text-border">
-        <line
-          x1={0}
-          y1={height}
-          x2={width}
-          y2={height}
-          stroke="currentColor"
-          strokeWidth={1}
-        />
-        <line
-          x1={0}
-          y1={0}
-          x2={0}
-          y2={height}
-          stroke="currentColor"
-          strokeWidth={1}
-        />
-      </g>
-
-      {/* series */}
-      {skills.map((s) => (
-        <polyline
-          key={s}
-          className={seriesClass[s]}
-          fill="none"
-          stroke="currentColor"
-          strokeWidth={2}
-          points={pointsFor(s)}
-        />
-      ))}
-
-      {/* legend */}
-      <g transform={`translate(8,8)`} className="text-foreground/80">
-        {skills.map((s, i) => (
-          <g key={s} transform={`translate(${i * 130},0)`}>
-            <line
-              x1={0}
-              y1={6}
-              x2={20}
-              y2={6}
-              className={seriesClass[s]}
-              stroke="currentColor"
-              strokeWidth={3}
-            />
-            <text x={26} y={10} fontSize={12} className="fill-current">
-              {cap(s)}
-            </text>
-          </g>
-        ))}
-      </g>
-    </svg>
+    <div className={`w-full ${large ? 'space-y-4' : ''}`}>
+      <div className="h-8 w-32 animate-pulse rounded bg-border/50" />
+      <div className="h-64 w-full animate-pulse rounded-ds-xl bg-border/30" />
+      {large && <div className="h-64 w-full animate-pulse rounded-ds-xl bg-border/20" />}
+    </div>
   );
 }
-
-function AccuracyChart({ data }: { data: AccuracyRow[] }) {
-  const width = 600;
-  const height = 220;
-  const gap = 10;
-  const barWidth = data.length ? width / data.length - gap : 0;
-
-  return (
-    <svg
-      role="img"
-      aria-label="Accuracy per question type"
-      width="100%"
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      className="rounded-ds border border-border"
-    >
-      {/* axis */}
-      <g className="text-border">
-        <line
-          x1={0}
-          y1={height - 1}
-          x2={width}
-          y2={height - 1}
-          stroke="currentColor"
-          strokeWidth={1}
-        />
-      </g>
-
-      {/* bars */}
-      {data.map((d, i) => {
-        const h = (Math.max(0, Math.min(100, d.accuracy_pct)) / 100) * (height - 20);
-        const x = i * (barWidth + gap) + gap / 2;
-        const y = height - 1 - h;
-        return (
-          <g key={d.question_type}>
-            <rect
-              x={x}
-              y={y}
-              width={barWidth}
-              height={h}
-              className="text-primary"
-              fill="currentColor"
-              rx={6}
-            />
-            <text
-              x={x + barWidth / 2}
-              y={height - 5}
-              textAnchor="middle"
-              fontSize={11}
-              className="fill-current text-foreground/70"
-            >
-              {d.question_type}
-            </text>
-          </g>
-        );
-      })}
-    </svg>
-  );
-}
-
-function TimeChart({ data }: { data: TimeRow[] }) {
-  const width = 600;
-  const rowH = 32;
-  const height = Math.max(1, data.length) * rowH + 8;
-  const max = Math.max(...data.map((d) => d.total_minutes), 1);
-
-  const barClass: Record<Skill, string> = {
-    reading: 'text-primary',
-    listening: 'text-secondary',
-    writing: 'text-accent',
-    speaking: 'text-foreground',
-  };
-
-  return (
-    <svg
-      role="img"
-      aria-label="Total time spent per skill"
-      width="100%"
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      className="rounded-ds border border-border"
-    >
-      {data.map((d, i) => {
-        const barW = (d.total_minutes / max) * (width - 120);
-        const y = i * rowH + 8;
-        return (
-          <g key={d.skill}>
-            <text
-              x={0}
-              y={y + 16}
-              fontSize={12}
-              className="fill-current text-foreground/70"
-            >
-              {cap(d.skill)}
-            </text>
-            <rect
-              x={100}
-              y={y}
-              width={barW}
-              height={20}
-              className={barClass[d.skill]}
-              fill="currentColor"
-              rx={8}
-            />
-            <text
-              x={100 + barW + 8}
-              y={y + 15}
-              fontSize={12}
-              className="fill-current text-foreground/80"
-            >
-              {`${Math.round(d.total_minutes)} min`}
-            </text>
-          </g>
-        );
-      })}
-    </svg>
-  );
-}
-
-/* ---------- small utils ---------- */
-const cap = (s: string) => s.slice(0, 1).toUpperCase() + s.slice(1);

--- a/pages/settings/accessibility.tsx
+++ b/pages/settings/accessibility.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Head from 'next/head';
+import React from 'react';
+
+import { Container } from '@/components/design-system/Container';
+import AccessibilitySettingsCard from '@/components/settings/Accessibility';
+
+export default function AccessibilitySettingsPage() {
+  return (
+    <>
+      <Head>
+        <title>Accessibility · Settings · GramorX</title>
+        <meta
+          name="description"
+          content="Toggle the high-contrast theme to boost legibility and focus visibility."
+        />
+      </Head>
+
+      <div className="py-6">
+        <Container className="space-y-6">
+          <header className="space-y-1">
+            <h1 className="text-h2 font-bold text-foreground">Accessibility</h1>
+            <p className="text-small text-muted-foreground">
+              Adjust contrast for the interface and preview focus visibility.
+            </p>
+          </header>
+
+          <AccessibilitySettingsCard />
+        </Container>
+      </div>
+    </>
+  );
+}

--- a/styles/themes/index.css
+++ b/styles/themes/index.css
@@ -29,6 +29,20 @@
   --gx-muted-foreground: 180 180 200;
 }
 
+[data-theme='hc'] {
+  --gx-background: 0 0 0;
+  --gx-foreground: 255 255 255;
+  --gx-card:       0 0 0;
+  --gx-card-foreground: 255 255 255;
+  --gx-popover:    0 0 0;
+  --gx-popover-foreground: 255 255 255;
+  --gx-border:     255 255 255;
+  --gx-input:      255 255 255;
+  --gx-ring:       255 209 0;
+  --gx-muted:      30 30 30;
+  --gx-muted-foreground: 220 220 220;
+}
+
 /* Optional seasonal themes override selectively */
 @import './spring.css';
 @import './summer.css';

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -54,11 +54,54 @@
   /* Fonts */
   --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial;
   --font-display: "Roboto Slab", Georgia, Cambria, "Times New Roman", Times, serif;
+
+  /* Chart tokens */
+  --chart-reading: rgb(var(--color-primary) / 1);
+  --chart-listening: rgb(var(--color-secondary) / 1);
+  --chart-writing: rgb(var(--color-accent) / 1);
+  --chart-speaking: rgb(var(--color-foreground) / 1);
+  --chart-grid: rgb(var(--gx-border) / 0.35);
+  --chart-axis: rgb(var(--gx-muted-foreground) / 1);
+  --chart-tooltip-bg: rgb(var(--gx-card) / 1);
+  --chart-tooltip-border: rgb(var(--gx-border) / 0.6);
+  --chart-tooltip-fg: rgb(var(--gx-card-foreground) / 1);
+  --chart-area: rgb(var(--color-primary) / 1);
+  --chart-area-stroke: rgb(var(--color-primaryDark) / 1);
 }
 
 .dark {
   --color-background: var(--color-darker);
   --color-foreground: 255 255 255;
+}
+
+[data-theme='hc'] {
+  --color-background: 0 0 0;
+  --color-foreground: 255 255 255;
+  --color-primary: 255 209 0;
+  --color-primaryDark: 255 170 0;
+  --color-secondary: 0 255 255;
+  --color-accent: 255 105 180;
+  --color-success: 144 238 144;
+  --color-warning: 255 140 0;
+  --color-danger: 255 69 0;
+  --color-lightBg: 0 0 0;
+  --color-lightText: 255 255 255;
+  --color-grayish: 220 220 220;
+  --color-lightCard: 0 0 0;
+  --color-lightBorder: 255 255 255;
+  --color-mutedText: 200 200 200;
+
+  --chart-reading: #ffea00;
+  --chart-listening: #00ffff;
+  --chart-writing: #ff69b4;
+  --chart-speaking: #ffffff;
+  --chart-grid: rgba(255, 255, 255, 0.4);
+  --chart-axis: rgba(255, 255, 255, 0.85);
+  --chart-tooltip-bg: rgba(0, 0, 0, 0.95);
+  --chart-tooltip-border: rgba(255, 255, 255, 0.7);
+  --chart-tooltip-fg: rgba(255, 255, 255, 0.95);
+  --chart-area: rgba(255, 234, 0, 1);
+  --chart-area-stroke: rgba(255, 214, 0, 1);
 }
 
 /* NOTE:

--- a/supabase/migrations/20251002_mistakes_review_queue.sql
+++ b/supabase/migrations/20251002_mistakes_review_queue.sql
@@ -1,0 +1,46 @@
+-- supabase/migrations/20251002_mistakes_review_queue.sql
+-- Enhancements for mistakes book MVP: persistence metadata + resolution tracking + view for review queue.
+
+-- Add optional columns for retry paths and ensure created_at lookups are fast.
+alter table public.mistakes_book
+  add column if not exists retry_path text,
+  add column if not exists last_seen_at timestamptz;
+
+update public.mistakes_book
+set last_seen_at = coalesce(last_seen_at, created_at)
+where last_seen_at is null;
+
+create index if not exists idx_mistakes_book_user_created
+  on public.mistakes_book (user_id, created_at desc);
+
+-- Resolution table keeps track of items the learner dismissed from the queue.
+create table if not exists public.mistake_resolutions (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  mistake_id uuid not null references public.mistakes_book(id) on delete cascade,
+  resolved_at timestamptz not null default now(),
+  primary key (user_id, mistake_id)
+);
+
+create index if not exists idx_mistake_resolutions_user
+  on public.mistake_resolutions (user_id, resolved_at desc);
+
+-- Expose a view that joins the base table with resolution metadata for easy querying.
+create or replace view public.mistake_review_queue as
+select
+  m.id,
+  m.user_id,
+  m.mistake,
+  m.correction,
+  coalesce(nullif(m.type, ''), 'general') as type,
+  coalesce(m.repetitions, 0) as repetitions,
+  m.next_review,
+  m.retry_path,
+  coalesce(m.last_seen_at, m.created_at) as last_seen_at,
+  m.created_at,
+  r.resolved_at
+from public.mistakes_book m
+left join public.mistake_resolutions r
+  on r.mistake_id = m.id and r.user_id = m.user_id;
+
+comment on view public.mistake_review_queue is
+  'Mistakes needing review with resolution metadata. Filter resolved_at IS NULL for active queue.';


### PR DESCRIPTION
## Summary
- replace the Mistakes book page with a paginated review queue driven by the new `/api/mistakes` contract and supporting resolution tracking
- introduce server-backed progress trend analytics with Recharts visualisations for weekly bands and per-skill averages
- add a high-contrast accessibility theme with settings UI, persisted preference handling, and refreshed design tokens

## Testing
- npm run lint *(fails: next binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6614e876483219ad64c42ce750ba6