### PR TITLE
Add AI-powered 4-step onboarding, Supabase onboarding table, and plan-generation API

### DIFF
--- a/components/onboarding/AIRoadmapLoadingScreen.tsx
+++ b/components/onboarding/AIRoadmapLoadingScreen.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+type AIRoadmapLoadingScreenProps = {
+  headline?: string;
+  messages?: string[];
+  rotateMs?: number;
+  error?: string | null;
+  onRetry?: () => void;
+};
+
+const DEFAULT_MESSAGES = [
+  'Analyzing band gap...',
+  'Structuring vocabulary roadmap...',
+  'Designing writing correction cycle...',
+  'Optimizing study intensity...',
+];
+
+export function AIRoadmapLoadingScreen({
+  headline = 'Your AI Mentor is building your roadmap...',
+  messages = DEFAULT_MESSAGES,
+  rotateMs = 2000,
+  error = null,
+  onRetry,
+}: AIRoadmapLoadingScreenProps) {
+  const [index, setIndex] = useState(0);
+
+  const safeMessages = useMemo(() => {
+    if (!messages.length) {
+      return DEFAULT_MESSAGES;
+    }
+
+    return messages;
+  }, [messages]);
+
+  useEffect(() => {
+    if (error) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setIndex((prev) => (prev + 1) % safeMessages.length);
+    }, rotateMs);
+
+    return () => window.clearInterval(interval);
+  }, [error, rotateMs, safeMessages.length]);
+
+  return (
+    <main className="relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-slate-950 px-6 py-10 text-white">
+      <motion.div
+        className="absolute -left-20 -top-24 h-72 w-72 rounded-full bg-blue-600/30 blur-3xl"
+        animate={{ scale: [1, 1.12, 1], opacity: [0.35, 0.6, 0.35] }}
+        transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
+      />
+      <motion.div
+        className="absolute -bottom-24 -right-16 h-72 w-72 rounded-full bg-fuchsia-500/30 blur-3xl"
+        animate={{ scale: [1.05, 1, 1.05], opacity: [0.3, 0.55, 0.3] }}
+        transition={{ duration: 4.5, repeat: Infinity, ease: 'easeInOut' }}
+      />
+
+      <div className="relative z-10 w-full max-w-2xl rounded-3xl border border-white/15 bg-white/5 p-10 text-center shadow-2xl backdrop-blur-xl">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-white/30 bg-white/10">
+          <motion.div
+            className="h-10 w-10 rounded-full border-4 border-blue-300/30 border-t-blue-300"
+            animate={{ rotate: 360 }}
+            transition={{ duration: 1.1, repeat: Infinity, ease: 'linear' }}
+          />
+        </div>
+
+        <h1 className="text-balance text-2xl font-semibold md:text-3xl">{headline}</h1>
+
+        {!error ? (
+          <AnimatePresence mode="wait">
+            <motion.p
+              key={`${safeMessages[index]}-${index}`}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.35 }}
+              className="mt-6 text-lg text-blue-100"
+            >
+              {safeMessages[index]}
+            </motion.p>
+          </AnimatePresence>
+        ) : (
+          <div className="mt-6 rounded-xl border border-red-300/30 bg-red-500/10 p-4">
+            <p className="text-red-100">{error}</p>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="mt-4 rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-400"
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/lib/onboarding/aiStudyPlan.ts
+++ b/lib/onboarding/aiStudyPlan.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const learningStyleSchema = z.enum(['Video', 'Practice Tests', 'Flashcards', 'Mixed']);
+export const skillNameSchema = z.enum(['Reading', 'Writing', 'Listening', 'Speaking']);
 
 export const onboardingPayloadSchema = z.object({
   targetBand: z.number().min(5).max(9),
@@ -13,60 +14,139 @@ export const onboardingPayloadSchema = z.object({
 });
 
 export type OnboardingPayload = z.infer<typeof onboardingPayloadSchema>;
+export type SkillName = z.infer<typeof skillNameSchema>;
+
+export const weeklyPlanItemSchema = z.object({
+  week: z.number().int().min(1),
+  focus: z.string().min(1),
+  tasks: z.array(z.string().min(1)).min(1),
+});
 
 export const studyPlanSchema = z.object({
   duration_weeks: z.number().int().min(1),
-  daily_hours: z.number().min(0.5),
-  weekly_plan: z.array(
-    z.object({
-      week: z.number().int().min(1),
-      focus: z.string().min(1),
-      tasks: z.array(z.string().min(1)).min(1),
-    }),
-  ).min(1),
-  priority_skill: z.enum(['Reading', 'Writing', 'Listening', 'Speaking']),
+  daily_hours: z.number().int().min(1).max(4),
+  weekly_plan: z.array(weeklyPlanItemSchema).min(1),
+  priority_skill: skillNameSchema,
 });
 
 export type StudyPlan = z.infer<typeof studyPlanSchema>;
 
-const skillMap: Record<'Reading' | 'Writing' | 'Listening' | 'Speaking', keyof OnboardingPayload> = {
+const skillMap: Record<SkillName, keyof OnboardingPayload> = {
   Reading: 'readingLevel',
   Writing: 'writingLevel',
   Listening: 'listeningLevel',
   Speaking: 'speakingLevel',
 };
 
-export function weakestSkill(input: OnboardingPayload): 'Reading' | 'Writing' | 'Listening' | 'Speaking' {
-  return (Object.keys(skillMap) as Array<keyof typeof skillMap>).reduce((lowest, skill) => {
+export function daysUntilExam(examDate: string): number {
+  const examTs = new Date(examDate).getTime();
+  const todayTs = Date.now();
+  if (Number.isNaN(examTs)) {
+    return 30;
+  }
+
+  return Math.max(1, Math.ceil((examTs - todayTs) / 86_400_000));
+}
+
+export function calculateDailyHours(examDate: string): 1 | 2 | 4 {
+  const days = daysUntilExam(examDate);
+  if (days < 30) {
+    return 4;
+  }
+
+  if (days < 90) {
+    return 2;
+  }
+
+  return 1;
+}
+
+export function weakestSkill(input: OnboardingPayload): SkillName {
+  return (Object.keys(skillMap) as SkillName[]).reduce((lowest, skill) => {
     const levelKey = skillMap[skill];
     const lowKey = skillMap[lowest];
     return input[levelKey] < input[lowKey] ? skill : lowest;
   }, 'Reading');
 }
 
+function fallbackFocusForWeek(week: number, priority: SkillName, input: OnboardingPayload): string {
+  if (week <= 2) {
+    return `${priority} priority sprint + IELTS core strategies`;
+  }
+
+  if (input.targetBand >= 7.5 && calculateDailyHours(input.examDate) >= 2) {
+    return 'Timed exam strategy + high-band response frameworks';
+  }
+
+  return 'Foundation strengthening + integrated skills practice';
+}
+
 export function buildFallbackPlan(input: OnboardingPayload): StudyPlan {
-  const targetDate = new Date(input.examDate);
-  const daysRemaining = Math.max(7, Math.ceil((targetDate.getTime() - Date.now()) / 86_400_000));
+  const daysRemaining = daysUntilExam(input.examDate);
   const durationWeeks = Math.max(2, Math.min(24, Math.ceil(daysRemaining / 7)));
-  const urgencyMultiplier = input.targetBand >= 7.5 && durationWeeks <= 8 ? 1.25 : 1;
-  const baselineHours = input.targetBand >= 7 ? 2.5 : 1.5;
-  const dailyHours = Number((baselineHours * urgencyMultiplier).toFixed(1));
+  const dailyHours = calculateDailyHours(input.examDate);
   const priority = weakestSkill(input);
 
-  const weeklyPlan = Array.from({ length: Math.min(durationWeeks, 8) }, (_, index) => ({
-    week: index + 1,
-    focus: index < 2 ? `${priority} foundation + Vocabulary` : `Integrated strategy + Timed practice`,
-    tasks: [
-      `Complete ${priority} focused drills (45 min)`,
-      `Take one timed mini-test and review mistakes`,
-      `Do ${input.learningStyle} learning block + vocabulary revision`,
-    ],
-  }));
+  const weeklyPlan = Array.from({ length: Math.min(durationWeeks, 12) }, (_, index) => {
+    const week = index + 1;
+
+    return {
+      week,
+      focus: fallbackFocusForWeek(week, priority, input),
+      tasks: [
+        `Complete ${priority} focused drills (${dailyHours * 25} mins)`,
+        week <= 2
+          ? `Daily ${priority} correction journal + targeted feedback`
+          : 'Take one timed mini-test and review mistakes',
+        `Do a ${input.learningStyle} learning block + vocabulary revision`,
+      ],
+    };
+  });
 
   return {
     duration_weeks: durationWeeks,
     daily_hours: dailyHours,
     weekly_plan: weeklyPlan,
+    priority_skill: priority,
+  };
+}
+
+export function normalizeStudyPlan(input: OnboardingPayload, candidate: unknown): StudyPlan {
+  const priority = weakestSkill(input);
+  const enforcedDailyHours = calculateDailyHours(input.examDate);
+  const fallback = buildFallbackPlan(input);
+
+  const parsed = studyPlanSchema.safeParse(candidate);
+  if (!parsed.success) {
+    return fallback;
+  }
+
+  const weeks = parsed.data.weekly_plan.length > 0 ? parsed.data.weekly_plan : fallback.weekly_plan;
+  const firstWeek = weeks[0] ?? fallback.weekly_plan[0];
+  const secondWeek = weeks[1] ?? {
+    ...firstWeek,
+    week: 2,
+  };
+
+  const forcedFirstTwo = [
+    {
+      ...firstWeek,
+      week: 1,
+      focus: `${priority} priority sprint: ${firstWeek.focus}`,
+    },
+    {
+      ...secondWeek,
+      week: 2,
+      focus: `${priority} priority sprint: ${secondWeek.focus}`,
+    },
+  ];
+
+  const rest = weeks.slice(2).map((item, idx) => ({ ...item, week: idx + 3 }));
+
+  return {
+    duration_weeks: Math.max(parsed.data.duration_weeks, 2),
+    daily_hours: enforcedDailyHours,
+    weekly_plan: [...forcedFirstTwo, ...rest],
     priority_skill: priority,
   };
 }

--- a/lib/onboarding/aiStudyPlan.ts
+++ b/lib/onboarding/aiStudyPlan.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+export const learningStyleSchema = z.enum(['Video', 'Practice Tests', 'Flashcards', 'Mixed']);
+
+export const onboardingPayloadSchema = z.object({
+  targetBand: z.number().min(5).max(9),
+  examDate: z.string().date(),
+  readingLevel: z.number().int().min(1).max(5),
+  writingLevel: z.number().int().min(1).max(5),
+  listeningLevel: z.number().int().min(1).max(5),
+  speakingLevel: z.number().int().min(1).max(5),
+  learningStyle: learningStyleSchema,
+});
+
+export type OnboardingPayload = z.infer<typeof onboardingPayloadSchema>;
+
+export const studyPlanSchema = z.object({
+  duration_weeks: z.number().int().min(1),
+  daily_hours: z.number().min(0.5),
+  weekly_plan: z.array(
+    z.object({
+      week: z.number().int().min(1),
+      focus: z.string().min(1),
+      tasks: z.array(z.string().min(1)).min(1),
+    }),
+  ).min(1),
+  priority_skill: z.enum(['Reading', 'Writing', 'Listening', 'Speaking']),
+});
+
+export type StudyPlan = z.infer<typeof studyPlanSchema>;
+
+const skillMap: Record<'Reading' | 'Writing' | 'Listening' | 'Speaking', keyof OnboardingPayload> = {
+  Reading: 'readingLevel',
+  Writing: 'writingLevel',
+  Listening: 'listeningLevel',
+  Speaking: 'speakingLevel',
+};
+
+export function weakestSkill(input: OnboardingPayload): 'Reading' | 'Writing' | 'Listening' | 'Speaking' {
+  return (Object.keys(skillMap) as Array<keyof typeof skillMap>).reduce((lowest, skill) => {
+    const levelKey = skillMap[skill];
+    const lowKey = skillMap[lowest];
+    return input[levelKey] < input[lowKey] ? skill : lowest;
+  }, 'Reading');
+}
+
+export function buildFallbackPlan(input: OnboardingPayload): StudyPlan {
+  const targetDate = new Date(input.examDate);
+  const daysRemaining = Math.max(7, Math.ceil((targetDate.getTime() - Date.now()) / 86_400_000));
+  const durationWeeks = Math.max(2, Math.min(24, Math.ceil(daysRemaining / 7)));
+  const urgencyMultiplier = input.targetBand >= 7.5 && durationWeeks <= 8 ? 1.25 : 1;
+  const baselineHours = input.targetBand >= 7 ? 2.5 : 1.5;
+  const dailyHours = Number((baselineHours * urgencyMultiplier).toFixed(1));
+  const priority = weakestSkill(input);
+
+  const weeklyPlan = Array.from({ length: Math.min(durationWeeks, 8) }, (_, index) => ({
+    week: index + 1,
+    focus: index < 2 ? `${priority} foundation + Vocabulary` : `Integrated strategy + Timed practice`,
+    tasks: [
+      `Complete ${priority} focused drills (45 min)`,
+      `Take one timed mini-test and review mistakes`,
+      `Do ${input.learningStyle} learning block + vocabulary revision`,
+    ],
+  }));
+
+  return {
+    duration_weeks: durationWeeks,
+    daily_hours: dailyHours,
+    weekly_plan: weeklyPlan,
+    priority_skill: priority,
+  };
+}

--- a/pages/api/ai/generate-plan.ts
+++ b/pages/api/ai/generate-plan.ts
@@ -1,0 +1,113 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import OpenAI from 'openai';
+import { getServerClient } from '@/lib/supabaseServer';
+import {
+  buildFallbackPlan,
+  onboardingPayloadSchema,
+  studyPlanSchema,
+  weakestSkill,
+  type OnboardingPayload,
+  type StudyPlan,
+} from '@/lib/onboarding/aiStudyPlan';
+
+type ResponseBody =
+  | { plan: StudyPlan }
+  | { error: string };
+
+function buildPrompt(payload: OnboardingPayload): string {
+  const priority = weakestSkill(payload);
+  return [
+    'You are an IELTS strategist. Return ONLY valid JSON.',
+    'Generate a personalized study plan with this exact schema:',
+    '{ duration_weeks:number, daily_hours:number, weekly_plan:[{week:number, focus:string, tasks:string[]}], priority_skill:"Reading"|"Writing"|"Listening"|"Speaking" }',
+    'Planning logic requirements:',
+    '- If target band is high and deadline is short, make strategy/timed-practice heavy.',
+    '- If target band is low and timeline is long, make foundation/concept heavy.',
+    '- Prioritize weakest skill first.',
+    '- Keep tasks practical and IELTS specific.',
+    `Student profile: ${JSON.stringify(payload)}`,
+    `Weakest skill inferred: ${priority}`,
+  ].join('\n');
+}
+
+async function generateWithOpenAI(payload: OnboardingPayload): Promise<StudyPlan> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return buildFallbackPlan(payload);
+  }
+
+  const client = new OpenAI({ apiKey });
+  const completion = await client.chat.completions.create({
+    model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini',
+    temperature: 0.3,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: 'You create concise, realistic IELTS study plans in JSON.' },
+      { role: 'user', content: buildPrompt(payload) },
+    ],
+  });
+
+  const text = completion.choices[0]?.message?.content;
+  if (!text) {
+    return buildFallbackPlan(payload);
+  }
+
+  const parsed = JSON.parse(text) as unknown;
+  const validated = studyPlanSchema.safeParse(parsed);
+  if (!validated.success) {
+    return buildFallbackPlan(payload);
+  }
+
+  return validated.data;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseBody>) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const supabase = getServerClient(req, res);
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const parsedInput = onboardingPayloadSchema.safeParse(req.body);
+  if (!parsedInput.success) {
+    return res.status(400).json({ error: 'Invalid onboarding payload' });
+  }
+
+  try {
+    const input = parsedInput.data;
+    const plan = await generateWithOpenAI(input);
+
+    const { error: upsertError } = await supabase.from('user_onboarding').upsert(
+      {
+        user_id: user.id,
+        target_band: input.targetBand,
+        exam_date: input.examDate,
+        reading_level: input.readingLevel,
+        writing_level: input.writingLevel,
+        listening_level: input.listeningLevel,
+        speaking_level: input.speakingLevel,
+        learning_style: input.learningStyle,
+        generated_plan: plan,
+      },
+      { onConflict: 'user_id' },
+    );
+
+    if (upsertError) {
+      return res.status(500).json({ error: 'Failed to save onboarding data' });
+    }
+
+    return res.status(200).json({ plan });
+  } catch (error) {
+    console.error('[generate-plan] failed', error);
+    return res.status(500).json({ error: 'Failed to generate AI study plan' });
+  }
+}

--- a/pages/api/ai/generate-plan.ts
+++ b/pages/api/ai/generate-plan.ts
@@ -1,79 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import OpenAI from 'openai';
 import { getServerClient } from '@/lib/supabaseServer';
 import {
-  buildFallbackPlan,
-  calculateDailyHours,
-  normalizeStudyPlan,
+  buildRuleBasedPlan,
   onboardingPayloadSchema,
-  weakestSkill,
-  type OnboardingPayload,
+  studyPlanSchema,
   type StudyPlan,
 } from '@/lib/onboarding/aiStudyPlan';
 
 type ResponseBody = { plan: StudyPlan } | { error: string };
-
-function buildPrompt(payload: OnboardingPayload): string {
-  const priority = weakestSkill(payload);
-  const dailyHours = calculateDailyHours(payload.examDate);
-
-  return [
-    'You are an IELTS strategist. Return ONLY valid JSON.',
-    'Output schema must be exactly:',
-    '{"duration_weeks":number,"daily_hours":number,"weekly_plan":[{"week":number,"focus":string,"tasks":[string]}],"priority_skill":"Reading"|"Writing"|"Listening"|"Speaking"}',
-    'Hard constraints:',
-    `- daily_hours MUST be ${dailyHours}`,
-    `- priority_skill MUST be "${priority}"`,
-    `- first 2 weeks MUST prioritize ${priority}`,
-    '- If target band high + short deadline: strategy heavy.',
-    '- If lower band + longer timeline: foundation heavy.',
-    '- Use practical IELTS-focused tasks only.',
-    `Student profile JSON: ${JSON.stringify(payload)}`,
-  ].join('\n');
-}
-
-function safeJsonParse(text: string): unknown | null {
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return null;
-  }
-}
-
-async function generateWithOpenAI(payload: OnboardingPayload): Promise<StudyPlan> {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    return buildFallbackPlan(payload);
-  }
-
-  try {
-    const client = new OpenAI({ apiKey });
-    const completion = await client.chat.completions.create({
-      model: process.env.OPENAI_MODEL ?? 'gpt-4o-mini',
-      temperature: 0.2,
-      response_format: { type: 'json_object' },
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You create realistic IELTS plans and must return strict JSON with no extra prose.',
-        },
-        { role: 'user', content: buildPrompt(payload) },
-      ],
-    });
-
-    const text = completion.choices[0]?.message?.content ?? '';
-    const parsed = safeJsonParse(text);
-    if (!parsed) {
-      return buildFallbackPlan(payload);
-    }
-
-    return normalizeStudyPlan(payload, parsed);
-  } catch (error) {
-    console.error('[generate-plan] openai error', error);
-    return buildFallbackPlan(payload);
-  }
-}
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseBody>) {
   if (req.method !== 'POST') {
@@ -98,7 +32,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   try {
     const input = parsedInput.data;
-    const plan = await generateWithOpenAI(input);
+
+    // Deterministic rule-based output (no OpenAI usage).
+    const generated = buildRuleBasedPlan(input);
+    const validated = studyPlanSchema.safeParse(generated);
+    if (!validated.success) {
+      return res.status(500).json({ error: 'Failed to build a valid study plan' });
+    }
+
+    const plan = validated.data;
 
     const { error: upsertError } = await supabase.from('user_onboarding').upsert(
       {
@@ -123,6 +65,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return res.status(200).json({ plan });
   } catch (error) {
     console.error('[generate-plan] failed', error);
-    return res.status(500).json({ error: 'Failed to generate AI study plan' });
+    return res.status(500).json({ error: 'Failed to generate study plan' });
   }
 }

--- a/pages/api/internal/auth/state.ts
+++ b/pages/api/internal/auth/state.ts
@@ -33,8 +33,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   const { data: profile } = await supabase
     .from('profiles')
-    .select('role,onboarding_complete')
+    .select('role')
     .or(`user_id.eq.${user.id},id.eq.${user.id}`)
+    .maybeSingle();
+
+  const { data: onboardingRow } = await supabase
+    .from('user_onboarding')
+    .select('id')
+    .eq('user_id', user.id)
     .maybeSingle();
 
   const role =
@@ -43,9 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     ((user.user_metadata as any)?.role as string | undefined) ??
     null;
 
-  const onboardingComplete =
-    profile?.onboarding_complete === true ||
-    (user.user_metadata as Record<string, unknown> | undefined)?.onboarding_complete === true;
+  const onboardingComplete = Boolean(onboardingRow?.id);
 
   return res.status(200).json({
     authenticated: true,

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,389 +1,162 @@
-import { useState, useEffect } from 'react';
-import { GetServerSideProps } from 'next';
-import { getServerClient } from '@/lib/supabaseServer';
-import DashboardLayout from '@/components/layouts/DashboardLayout';
-import { Card } from '@/components/design-system/Card';
-import { Button } from '@/components/design-system/Button';
-import { Progress } from '@/components/design-system/Progress';
-import { StreakPanel } from '@/components/dashboard/StreakPanel';
-import { TodayTasks } from '@/components/dashboard/TodayTasks';
-import { SkillProgress } from '@/components/dashboard/SkillProgress';
-import { NextTaskCard } from '@/components/reco/NextTaskCard';
-import { AIInsights } from '@/components/dashboard/AIInsights';
-import { PlanDashboard } from '@/components/study-plan/PlanDashboard';
+import { useMemo, useState } from 'react';
+import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
+import DashboardLayout from '@/components/layouts/DashboardLayout';
+import { getServerClient } from '@/lib/supabaseServer';
+import { Button } from '@/components/design-system/Button';
+import { type OnboardingPayload, type StudyPlan, onboardingPayloadSchema } from '@/lib/onboarding/aiStudyPlan';
+
+type OnboardingRecord = {
+  target_band: number;
+  exam_date: string;
+  reading_level: number;
+  writing_level: number;
+  listening_level: number;
+  speaking_level: number;
+  learning_style: OnboardingPayload['learningStyle'];
+  generated_plan: StudyPlan | null;
+};
 
 interface DashboardProps {
-  user: any;
-  profile: any;
-  studyPlan: any;
-  streak: number;
-  nextTask: any;
-  todayTasks: any[];
-  skillProgress: any;
+  userEmail: string;
+  onboarding: OnboardingRecord;
 }
 
-export default function Dashboard({
-  user,
-  profile,
-  studyPlan,
-  streak,
-  nextTask,
-  todayTasks,
-  skillProgress
-}: DashboardProps) {
+export default function Dashboard({ userEmail, onboarding }: DashboardProps) {
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isReplanning, setIsReplanning] = useState(false);
+  const studyPlan = onboarding.generated_plan;
 
-  // Check if user needs to complete onboarding
-  if (profile?.onboarding_step < 6) {
-    return (
-      <DashboardLayout>
-        <div className="max-w-4xl mx-auto py-12 px-4">
-          <Card className="p-8 text-center">
-            <h1 className="text-3xl font-bold mb-4">Complete Your Profile Setup</h1>
-            <p className="text-gray-600 mb-8">
-              You're almost there! Complete the onboarding process to get your personalized study plan.
-            </p>
+  const firstTask = useMemo(() => studyPlan?.weekly_plan?.[0]?.tasks?.[0] ?? 'Complete your first diagnostic task.', [studyPlan]);
 
-            <div className="mb-8">
-              <div className="flex justify-between mb-2">
-                <span>Onboarding Progress</span>
-                <span>{Math.round((profile.onboarding_step / 6) * 100)}%</span>
-              </div>
-              <Progress value={(profile.onboarding_step / 6) * 100} className="h-2" />
-            </div>
+  const skillMeters = [
+    { label: 'Reading', value: onboarding.reading_level },
+    { label: 'Writing', value: onboarding.writing_level },
+    { label: 'Listening', value: onboarding.listening_level },
+    { label: 'Speaking', value: onboarding.speaking_level },
+  ];
 
-            <div className="space-y-4">
-              <StepStatus
-                step={1}
-                currentStep={profile.onboarding_step}
-                title="Set Target Band"
-                href="/onboarding/target-band"
-              />
-              <StepStatus
-                step={2}
-                currentStep={profile.onboarding_step}
-                title="Set Exam Date"
-                href="/onboarding/exam-date"
-              />
-              <StepStatus
-                step={3}
-                currentStep={profile.onboarding_step}
-                title="Baseline Assessment"
-                href="/onboarding/baseline"
-              />
-              <StepStatus
-                step={4}
-                currentStep={profile.onboarding_step}
-                title="Learning Vibe"
-                href="/onboarding/vibe"
-              />
-              <StepStatus
-                step={5}
-                currentStep={profile.onboarding_step}
-                title="Review & Confirm"
-                href="/onboarding/review"
-              />
-              <StepStatus
-                step={6}
-                currentStep={profile.onboarding_step}
-                title="Generate Study Plan"
-                href="/onboarding/thinking"
-                isLast
-              />
-            </div>
+  const handleReadjust = async () => {
+    setIsReplanning(true);
+    try {
+      const payload: OnboardingPayload = {
+        targetBand: onboarding.target_band,
+        examDate: onboarding.exam_date,
+        readingLevel: onboarding.reading_level,
+        writingLevel: onboarding.writing_level,
+        listeningLevel: onboarding.listening_level,
+        speakingLevel: onboarding.speaking_level,
+        learningStyle: onboarding.learning_style,
+      };
 
-            <Button
-              onClick={() => router.push(getNextOnboardingStep(profile.onboarding_step))}
-              className="mt-8"
-              size="lg"
-            >
-              Continue Onboarding
-            </Button>
-          </Card>
-        </div>
-      </DashboardLayout>
-    );
-  }
+      const validation = onboardingPayloadSchema.safeParse(payload);
+      if (!validation.success) {
+        throw new Error('Invalid saved onboarding data.');
+      }
 
-  // Check if study plan exists
-  if (!studyPlan) {
-    return (
-      <DashboardLayout>
-        <div className="max-w-4xl mx-auto py-12 px-4">
-          <Card className="p-8 text-center">
-            <h1 className="text-3xl font-bold mb-4">Welcome to Gramor X!</h1>
-            <p className="text-gray-600 mb-8">
-              Your study plan is being generated. This might take a few moments.
-            </p>
+      const response = await fetch('/api/ai/generate-plan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
 
-            <div className="mb-8">
-              <div className="animate-pulse flex space-x-4">
-                <div className="flex-1 space-y-4 py-1">
-                  <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-                  <div className="space-y-2">
-                    <div className="h-4 bg-gray-200 rounded"></div>
-                    <div className="h-4 bg-gray-200 rounded w-5/6"></div>
-                  </div>
-                </div>
-              </div>
-            </div>
+      if (!response.ok) {
+        throw new Error('Unable to re-adjust plan right now.');
+      }
 
-            <Button
-              onClick={() => router.push('/onboarding/thinking')}
-              variant="outline"
-            >
-              Check Generation Status
-            </Button>
-          </Card>
-        </div>
-      </DashboardLayout>
-    );
-  }
+      await router.replace('/dashboard');
+    } catch (error) {
+      console.error(error);
+      alert(error instanceof Error ? error.message : 'Failed to re-adjust plan.');
+    } finally {
+      setIsReplanning(false);
+    }
+  };
 
   return (
     <DashboardLayout>
-      <div className="space-y-6">
-        {/* Header Section */}
-        <div className="flex justify-between items-center">
-          <div>
-            <h1 className="text-3xl font-bold">Welcome back, {user.email?.split('@')[0]}!</h1>
-            <p className="text-gray-600">
-              Target Band: {profile.target_band} • Exam in {calculateDaysUntilExam(profile.exam_date)} days
-            </p>
+      <div className="mx-auto max-w-6xl space-y-6 px-4 py-8">
+        <header className="rounded-xl border bg-white p-6">
+          <p className="text-sm text-gray-500">{userEmail}</p>
+          <h1 className="text-3xl font-bold">Your AI Study Plan is Ready</h1>
+          <p className="mt-2 text-gray-600">Priority skill: {studyPlan?.priority_skill ?? 'N/A'}</p>
+        </header>
+
+        <section className="rounded-xl border bg-white p-6">
+          <h2 className="mb-3 text-xl font-semibold">Timeline Strip</h2>
+          <div className="flex gap-3 overflow-x-auto pb-2">
+            {studyPlan?.weekly_plan?.map((item) => (
+              <article key={item.week} className="min-w-56 rounded-lg border bg-gray-50 p-3">
+                <p className="text-xs text-gray-500">Week {item.week}</p>
+                <p className="font-semibold">{item.focus}</p>
+              </article>
+            ))}
           </div>
-          <StreakPanel streak={streak} />
-        </div>
+        </section>
 
-        {/* Main Grid Layout */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left Column - Main Content */}
-          <div className="lg:col-span-2 space-y-6">
-            {/* Next Task Card */}
-            {nextTask && (
-              <NextTaskCard task={nextTask} />
-            )}
+        <section className="grid gap-6 md:grid-cols-2">
+          <article className="rounded-xl border bg-white p-6">
+            <h3 className="text-lg font-semibold">Today&apos;s Task</h3>
+            <p className="mt-3 text-gray-700">{firstTask}</p>
+            <Button className="mt-5" onClick={() => router.push('/practice')}>
+              Start First Lesson
+            </Button>
+          </article>
 
-            {/* Study Plan Dashboard */}
-            <PlanDashboard studyPlan={studyPlan} />
-
-            {/* Today's Tasks */}
-            <TodayTasks tasks={todayTasks} />
-
-            {/* Skill Progress */}
-            <SkillProgress progress={skillProgress} />
-          </div>
-
-          {/* Right Column - Sidebar */}
-          <div className="space-y-6">
-            {/* AI Insights */}
-            <AIInsights userId={user.id} />
-
-            {/* Quick Actions */}
-            <Card className="p-4">
-              <h3 className="font-semibold mb-3">Quick Actions</h3>
-              <div className="space-y-2">
-                <Button
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => router.push('/practice/reading')}
-                >
-                  📖 Reading Practice
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => router.push('/practice/listening')}
-                >
-                  🎧 Listening Practice
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => router.push('/practice/writing')}
-                >
-                  ✍️ Writing Practice
-                </Button>
-                <Button
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => router.push('/practice/speaking')}
-                >
-                  🎤 Speaking Practice
-                </Button>
-              </div>
-            </Card>
-
-            {/* Study Progress Overview */}
-            <Card className="p-4">
-              <h3 className="font-semibold mb-3">Weekly Progress</h3>
-              <div className="space-y-3">
-                <div>
-                  <div className="flex justify-between text-sm mb-1">
-                    <span>Tasks Completed</span>
-                    <span>8/12</span>
+          <article className="rounded-xl border bg-white p-6">
+            <h3 className="mb-4 text-lg font-semibold">Skill Progress Meters</h3>
+            <div className="space-y-3">
+              {skillMeters.map((skill) => (
+                <div key={skill.label}>
+                  <div className="mb-1 flex justify-between text-sm">
+                    <span>{skill.label}</span>
+                    <span>{skill.value}/5</span>
                   </div>
-                  <Progress value={66} className="h-2" />
-                </div>
-                <div>
-                  <div className="flex justify-between text-sm mb-1">
-                    <span>Study Time</span>
-                    <span>5.5/10 hrs</span>
+                  <div className="h-2 rounded-full bg-gray-200">
+                    <div className="h-2 rounded-full bg-blue-600" style={{ width: `${(skill.value / 5) * 100}%` }} />
                   </div>
-                  <Progress value={55} className="h-2" />
                 </div>
-              </div>
-            </Card>
+              ))}
+            </div>
+          </article>
+        </section>
 
-            {/* Upcoming Deadlines */}
-            <Card className="p-4">
-              <h3 className="font-semibold mb-3">Upcoming</h3>
-              <div className="space-y-2">
-                <div className="text-sm p-2 bg-yellow-50 rounded">
-                  <div className="font-medium">Mock Test</div>
-                  <div className="text-gray-600">In 3 days</div>
-                </div>
-                <div className="text-sm p-2 bg-blue-50 rounded">
-                  <div className="font-medium">Writing Assignment</div>
-                  <div className="text-gray-600">Tomorrow</div>
-                </div>
-              </div>
-            </Card>
-          </div>
+        <div>
+          <Button variant="outline" onClick={handleReadjust} disabled={isReplanning}>
+            {isReplanning ? 'Re-adjusting…' : 'AI Re-adjust Plan'}
+          </Button>
         </div>
       </div>
     </DashboardLayout>
   );
 }
 
-// Helper Components
-function StepStatus({ step, currentStep, title, href, isLast = false }: any) {
-  const isCompleted = currentStep > step;
-  const isCurrent = currentStep === step;
-
-  return (
-    <Link href={href} className="block">
-      <div className={`flex items-center p-3 rounded-lg border transition-colors ${
-        isCompleted ? 'bg-green-50 border-green-200' :
-        isCurrent ? 'bg-blue-50 border-blue-200' :
-        'bg-gray-50 border-gray-200'
-      }`}>
-        <div className={`w-8 h-8 rounded-full flex items-center justify-center mr-3 ${
-          isCompleted ? 'bg-green-500 text-white' :
-          isCurrent ? 'bg-blue-500 text-white' :
-          'bg-gray-300 text-gray-600'
-        }`}>
-          {isCompleted ? '✓' : step}
-        </div>
-        <div className="flex-1 text-left">
-          <div className="font-medium">{title}</div>
-          {isCurrent && <div className="text-sm text-blue-600">In Progress</div>}
-          {isCompleted && !isLast && <div className="text-sm text-green-600">Completed</div>}
-        </div>
-        {!isCompleted && !isCurrent && (
-          <div className="text-sm text-gray-400">Locked</div>
-        )}
-      </div>
-    </Link>
-  );
-}
-
-// Helper Functions
-function getNextOnboardingStep(step: number): string {
-  const steps = [
-    '/onboarding/target-band',
-    '/onboarding/exam-date',
-    '/onboarding/baseline',
-    '/onboarding/vibe',
-    '/onboarding/review',
-    '/onboarding/thinking'
-  ];
-  return steps[Math.min(step - 1, steps.length - 1)];
-}
-
-function calculateDaysUntilExam(examDate: string): number {
-  const exam = new Date(examDate);
-  const today = new Date();
-  const diffTime = exam.getTime() - today.getTime();
-  return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-}
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
+export const getServerSideProps: GetServerSideProps<DashboardProps> = async (context) => {
   const supabase = getServerClient(context);
-
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   if (!user) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false,
-      },
-    };
+    return { redirect: { destination: '/login?next=/dashboard', permanent: false } };
   }
 
-  // Get user profile
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('*')
+  const { data: onboarding } = await supabase
+    .from('user_onboarding')
+    .select(
+      'target_band,exam_date,reading_level,writing_level,listening_level,speaking_level,learning_style,generated_plan',
+    )
     .eq('user_id', user.id)
-    .single();
+    .maybeSingle();
 
-  // Get study plan
-  const { data: studyPlan } = await supabase
-    .from('study_plans')
-    .select('*')
-    .eq('user_id', user.id)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .single();
-
-  // Get streak data
-  const { data: streakData } = await supabase
-    .from('streaks')
-    .select('current_streak')
-    .eq('user_id', user.id)
-    .single();
-
-  // Get next task
-  const { data: nextTask } = await supabase
-    .from('next_tasks')
-    .select('*')
-    .eq('user_id', user.id)
-    .single();
-
-  // Get today's tasks
-  const today = new Date().toISOString().split('T')[0];
-  const { data: todayTasks } = await supabase
-    .from('tasks')
-    .select('*')
-    .eq('user_id', user.id)
-    .eq('scheduled_date', today)
-    .order('created_at');
-
-  // Get skill progress
-  const { data: skillProgress } = await supabase
-    .from('skill_progress')
-    .select('*')
-    .eq('user_id', user.id)
-    .single();
+  if (!onboarding) {
+    return { redirect: { destination: '/onboarding', permanent: false } };
+  }
 
   return {
     props: {
-      user,
-      profile: profile || { onboarding_step: 1 },
-      studyPlan,
-      streak: streakData?.current_streak || 0,
-      nextTask: nextTask || null,
-      todayTasks: todayTasks || [],
-      skillProgress: skillProgress || {
-        reading: 0,
-        writing: 0,
-        listening: 0,
-        speaking: 0
-      }
+      userEmail: user.email ?? 'Learner',
+      onboarding: onboarding as OnboardingRecord,
     },
   };
 };

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -1,206 +1,212 @@
-import type { NextPage } from 'next';
+import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
-import { StepShell } from '@/components/onboarding/StepShell';
-import { cn } from '@/lib/utils';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useMemo, useState } from 'react';
+import { getServerClient } from '@/lib/supabaseServer';
+import { onboardingPayloadSchema, type OnboardingPayload } from '@/lib/onboarding/aiStudyPlan';
 
-type OnboardingStepId = 'goal' | 'timeline' | 'baseline' | 'vibe';
+type Step = 1 | 2 | 3 | 4;
 
-const ONBOARDING_STEPS: { id: OnboardingStepId; label: string }[] = [
-  { id: 'goal', label: 'Your goal' },
-  { id: 'timeline', label: 'Timeline' },
-  { id: 'baseline', label: 'Your level' },
-  { id: 'vibe', label: 'Learning style' },
+const BANDS = [5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0];
+const LEARNING_STYLES: OnboardingPayload['learningStyle'][] = [
+  'Video',
+  'Practice Tests',
+  'Flashcards',
+  'Mixed',
 ];
 
-const GoalPage: NextPage = () => {
+const initialState: OnboardingPayload = {
+  targetBand: 6.5,
+  examDate: '',
+  readingLevel: 3,
+  writingLevel: 3,
+  listeningLevel: 3,
+  speakingLevel: 3,
+  learningStyle: 'Mixed',
+};
+
+export default function OnboardingPage() {
   const router = useRouter();
-  const [band, setBand] = useState<number | null>(null);
-  const [submitting, setSubmitting] = useState(false);
+  const [step, setStep] = useState<Step>(1);
+  const [form, setForm] = useState<OnboardingPayload>(initialState);
   const [error, setError] = useState<string | null>(null);
 
-  const currentIndex = 0; // first step
+  const canNext = useMemo(() => {
+    if (step === 2) return Boolean(form.examDate);
+    return true;
+  }, [form.examDate, step]);
 
-  async function handleContinue() {
-    if (!band) {
-      setError('Please select your target band score.');
+  const update = <K extends keyof OnboardingPayload>(key: K, value: OnboardingPayload[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const next = () => {
+    if (!canNext) {
+      setError('Please complete this step to continue.');
       return;
     }
 
-    setSubmitting(true);
     setError(null);
-
-    try {
-      // Save to backend
-      const res = await fetch('/api/onboarding/goal', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ targetBand: band }),
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to save');
+    if (step === 4) {
+      const validated = onboardingPayloadSchema.safeParse(form);
+      if (!validated.success) {
+        setError('Please review your responses before continuing.');
+        return;
       }
 
-      // Move to next step
-      await router.push('/onboarding/timeline');
-    } catch (err) {
-      console.error(err);
-      setError(err instanceof Error ? err.message : 'Something went wrong. Please try again.');
-    } finally {
-      setSubmitting(false);
+      sessionStorage.setItem('gramorx:onboarding-input', JSON.stringify(validated.data));
+      void router.push('/onboarding/thinking');
+      return;
     }
-  }
 
-  function handleBack() {
-    router.back();
-  }
-
-  const hint = 'Your target band determines the difficulty and focus of your AI study plan.';
-
-  // Helper function to get band description
-  const getBandDescription = (score: number): string => {
-    if (score < 5) return 'Limited user';
-    if (score < 6) return 'Modest user';
-    if (score < 7) return 'Competent user';
-    if (score < 8) return 'Good user';
-    if (score < 9) return 'Very good user';
-    return 'Expert user';
+    setStep((prev) => (prev + 1) as Step);
   };
 
-  // Common band scores with descriptions
-  const bandScores = [
-    { value: 4.0, label: '4.0', description: 'Limited' },
-    { value: 4.5, label: '4.5', description: 'Limited+' },
-    { value: 5.0, label: '5.0', description: 'Modest' },
-    { value: 5.5, label: '5.5', description: 'Modest+' },
-    { value: 6.0, label: '6.0', description: 'Competent' },
-    { value: 6.5, label: '6.5', description: 'Competent+' },
-    { value: 7.0, label: '7.0', description: 'Good' },
-    { value: 7.5, label: '7.5', description: 'Good+' },
-    { value: 8.0, label: '8.0', description: 'Very Good' },
-    { value: 8.5, label: '8.5', description: 'Very Good+' },
-    { value: 9.0, label: '9.0', description: 'Expert' },
-  ];
+  const back = () => {
+    if (step === 1) return;
+    setStep((prev) => (prev - 1) as Step);
+  };
 
   return (
-    <StepShell
-      step={currentIndex + 1}
-      total={ONBOARDING_STEPS.length}
-      title="What band score are you aiming for?"
-      subtitle="We'll tailor your plan to help you reach this goal."
-      hint={hint}
-      onNext={handleContinue}
-      onBack={handleBack}
-      nextDisabled={submitting || !band}
-      nextLabel={submitting ? 'Saving...' : 'Continue'}
-    >
-      <div className="space-y-6">
-        {/* Band selector grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
-          {bandScores.map(({ value, label, description }) => (
-            <button
-              key={value}
-              onClick={() => setBand(value)}
-              className={cn(
-                'group relative flex flex-col items-center p-4 rounded-xl border-2 transition-all',
-                band === value
-                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-950/20 shadow-md'
-                  : 'border-gray-200 dark:border-gray-700 hover:border-blue-300 dark:hover:border-blue-700 hover:bg-gray-50 dark:hover:bg-gray-800/50'
-              )}
-            >
-              <span className={cn(
-                'text-2xl font-bold',
-                band === value ? 'text-blue-600 dark:text-blue-400' : 'text-gray-900 dark:text-gray-100'
-              )}>
-                {label}
-              </span>
-              <span className={cn(
-                'text-xs mt-1',
-                band === value ? 'text-blue-500' : 'text-gray-500 dark:text-gray-400'
-              )}>
-                {description}
-              </span>
-
-              {/* Selected indicator */}
-              {band === value && (
-                <div className="absolute -top-2 -right-2 w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center">
-                  <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                </div>
-              )}
-            </button>
-          ))}
-        </div>
-
-        {/* Selected band info */}
-        {band && (
-          <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-950/20 rounded-lg border border-blue-200 dark:border-blue-800">
-            <div className="flex items-start space-x-3">
-              <div className="flex-shrink-0">
-                <div className="w-10 h-10 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-lg">
-                  {band}
-                </div>
-              </div>
-              <div>
-                <h4 className="font-semibold text-blue-900 dark:text-blue-300">
-                  {getBandDescription(band)} (Band {band})
-                </h4>
-                <p className="text-sm text-blue-700 dark:text-blue-400 mt-1">
-                  {band === 9.0 ? 'You\'re aiming for perfection!' :
-                   band >= 7.5 ? 'Great choice for university admissions.' :
-                   band >= 6.5 ? 'Good target for undergraduate programs.' :
-                   'A solid foundation to build upon.'}
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {error && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
-            <p className="text-sm text-red-600">{error}</p>
-          </div>
-        )}
-
-        <p className="text-center text-xs text-gray-500 dark:text-gray-400">
-          You can always adjust this later in your profile settings.
-        </p>
-
-        {/* Quick tips */}
-        <div className="mt-8 grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <TipCard
-            icon="🎯"
-            title="Be Realistic"
-            description="Choose a score that challenges you but is achievable"
-          />
-          <TipCard
-            icon="📚"
-            title="Check Requirements"
-            description="Research what your target universities require"
-          />
-          <TipCard
-            icon="📈"
-            title="Consider Your Timeline"
-            description="Higher scores may need more preparation time"
-          />
-        </div>
+    <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-4 py-10">
+      <div className="mb-8 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">GramorX AI Onboarding</h1>
+        <p className="text-sm text-gray-500">Step {step} / 4</p>
       </div>
-    </StepShell>
-  );
-};
 
-// Tip Card Component
-function TipCard({ icon, title, description }: { icon: string; title: string; description: string }) {
-  return (
-    <div className="p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
-      <div className="text-2xl mb-2">{icon}</div>
-      <h4 className="font-medium text-sm mb-1">{title}</h4>
-      <p className="text-xs text-gray-600 dark:text-gray-400">{description}</p>
-    </div>
+      <div className="mb-8 h-2 rounded-full bg-gray-200">
+        <div className="h-full rounded-full bg-blue-600 transition-all" style={{ width: `${(step / 4) * 100}%` }} />
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.section
+          key={step}
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -20 }}
+          transition={{ duration: 0.25 }}
+          className="rounded-xl border bg-white p-6 shadow-sm"
+        >
+          {step === 1 && (
+            <section>
+              <h2 className="text-xl font-semibold">Choose your target IELTS band</h2>
+              <div className="mt-4 grid grid-cols-3 gap-3">
+                {BANDS.map((band) => (
+                  <button
+                    key={band}
+                    type="button"
+                    onClick={() => update('targetBand', band)}
+                    className={`rounded-lg border px-4 py-3 font-semibold transition ${
+                      form.targetBand === band ? 'border-blue-600 bg-blue-50 text-blue-700' : 'hover:border-gray-400'
+                    }`}
+                  >
+                    {band.toFixed(1)}
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {step === 2 && (
+            <section>
+              <h2 className="text-xl font-semibold">When is your IELTS exam?</h2>
+              <input
+                type="date"
+                className="mt-4 w-full rounded-lg border px-4 py-3"
+                value={form.examDate}
+                min={new Date().toISOString().split('T')[0]}
+                onChange={(e) => update('examDate', e.target.value)}
+              />
+            </section>
+          )}
+
+          {step === 3 && (
+            <section>
+              <h2 className="text-xl font-semibold">Rate your current skills (1-5)</h2>
+              <div className="mt-5 space-y-4">
+                {([
+                  ['readingLevel', 'Reading'],
+                  ['writingLevel', 'Writing'],
+                  ['listeningLevel', 'Listening'],
+                  ['speakingLevel', 'Speaking'],
+                ] as const).map(([key, label]) => (
+                  <div key={key} className="flex items-center justify-between gap-3">
+                    <span className="w-24 font-medium">{label}</span>
+                    <div className="flex gap-2">
+                      {[1, 2, 3, 4, 5].map((value) => (
+                        <button
+                          key={value}
+                          type="button"
+                          onClick={() => update(key, value)}
+                          className={`h-9 w-9 rounded-full border text-sm ${
+                            form[key] === value ? 'border-blue-600 bg-blue-600 text-white' : 'hover:border-gray-400'
+                          }`}
+                        >
+                          {value}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {step === 4 && (
+            <section>
+              <h2 className="text-xl font-semibold">Select your preferred learning style</h2>
+              <div className="mt-4 grid grid-cols-2 gap-3">
+                {LEARNING_STYLES.map((style) => (
+                  <button
+                    key={style}
+                    type="button"
+                    onClick={() => update('learningStyle', style)}
+                    className={`rounded-lg border p-4 text-left font-medium ${
+                      form.learningStyle === style ? 'border-blue-600 bg-blue-50 text-blue-700' : 'hover:border-gray-400'
+                    }`}
+                  >
+                    {style}
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+        </motion.section>
+      </AnimatePresence>
+
+      {error && <p className="mt-4 text-sm text-red-600">{error}</p>}
+
+      <div className="mt-6 flex justify-between">
+        <button type="button" onClick={back} className="rounded-md border px-4 py-2" disabled={step === 1}>
+          Back
+        </button>
+        <button type="button" onClick={next} className="rounded-md bg-blue-600 px-4 py-2 text-white">
+          {step === 4 ? 'Generate Plan' : 'Continue'}
+        </button>
+      </div>
+    </main>
   );
 }
 
-export default GoalPage;
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const supabase = getServerClient(context);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { redirect: { destination: '/login?next=/onboarding', permanent: false } };
+  }
+
+  const { data: existing } = await supabase
+    .from('user_onboarding')
+    .select('id')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (existing) {
+    return { redirect: { destination: '/dashboard', permanent: false } };
+  }
+
+  return { props: {} };
+};

--- a/pages/onboarding/thinking.tsx
+++ b/pages/onboarding/thinking.tsx
@@ -1,241 +1,84 @@
-import { useState, useEffect } from 'react';
-import { GetServerSideProps } from 'next';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
-import { getServerClient } from '@/lib/supabaseServer';
-import { StepShell } from '@/components/onboarding/StepShell';
-import { Card } from '@/components/design-system/Card';
-import { Progress } from '@/components/design-system/Progress';
-import { Button } from '@/components/design-system/Button';
+import { onboardingPayloadSchema, type OnboardingPayload } from '@/lib/onboarding/aiStudyPlan';
 
-interface ThinkingPageProps {
-  userId: string;
-}
+const THINKING_LINES = [
+  'Analyzing your target score…',
+  'Calculating optimal study hours…',
+  'Structuring writing improvement path…',
+];
 
-export default function ThinkingPage({ userId }: ThinkingPageProps) {
+export default function ThinkingPage() {
   const router = useRouter();
-  const [status, setStatus] = useState<'generating' | 'completed' | 'failed'>('generating');
-  const [progress, setProgress] = useState(0);
-  const [message, setMessage] = useState('Analyzing your profile...');
+  const [lineIndex, setLineIndex] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
+  const activeLine = useMemo(() => THINKING_LINES[lineIndex % THINKING_LINES.length], [lineIndex]);
+
   useEffect(() => {
-    let interval: NodeJS.Timeout;
-    let timeout: NodeJS.Timeout;
+    const raw = sessionStorage.getItem('gramorx:onboarding-input');
+    if (!raw) {
+      void router.replace('/onboarding');
+      return;
+    }
 
-    const checkStatus = async () => {
+    const parse = onboardingPayloadSchema.safeParse(JSON.parse(raw) as OnboardingPayload);
+    if (!parse.success) {
+      sessionStorage.removeItem('gramorx:onboarding-input');
+      void router.replace('/onboarding');
+      return;
+    }
+
+    const interval = window.setInterval(() => setLineIndex((prev) => prev + 1), 1500);
+    const startedAt = Date.now();
+
+    const run = async () => {
       try {
-        const response = await fetch('/api/onboarding/thinking-status');
-        const data = await response.json();
+        const response = await fetch('/api/ai/generate-plan', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(parse.data),
+        });
 
-        if (response.ok) {
-          setStatus(data.status);
-          setProgress(data.progress);
-          setMessage(data.message);
-
-          if (data.status === 'completed') {
-            timeout = setTimeout(() => {
-              router.push('/dashboard');
-            }, 2000);
-          } else if (data.status === 'failed') {
-            setError('Failed to generate study plan. Please try again.');
-          }
+        if (!response.ok) {
+          throw new Error('Failed to generate plan.');
         }
+
+        const elapsed = Date.now() - startedAt;
+        const minDelay = Math.max(0, 5000 - elapsed);
+        await new Promise((resolve) => setTimeout(resolve, minDelay));
+        sessionStorage.removeItem('gramorx:onboarding-input');
+        void router.replace('/dashboard');
       } catch (err) {
-        // Silent
+        setError(err instanceof Error ? err.message : 'Failed to generate plan.');
       }
     };
 
-    checkStatus();
-    interval = setInterval(checkStatus, 3000);
-
-    return () => {
-      clearInterval(interval);
-      if (timeout) clearTimeout(timeout);
-    };
+    void run();
+    return () => window.clearInterval(interval);
   }, [router]);
 
-  const handleRetry = async () => {
-    setError(null);
-    setStatus('generating');
-    setProgress(0);
-    setMessage('Restarting generation...');
-
-    try {
-      const response = await fetch('/api/onboarding/complete', {
-        method: 'POST',
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to restart generation');
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to restart');
-      setStatus('failed');
-    }
-  };
-
   return (
-    <StepShell
-      title="Creating Your Study Plan"
-      description="Our AI is analyzing your profile and creating a personalized study plan"
-      currentStep={5}
-      totalSteps={5}
-    >
-      <div className="max-w-md mx-auto text-center">
-        <Card className="p-8">
-          {status === 'generating' && (
-            <div className="relative">
-              <div className="w-24 h-24 mx-auto">
-                <div className="absolute inset-0 rounded-full border-4 border-blue-200"></div>
-                <div
-                  className="absolute inset-0 rounded-full border-4 border-blue-600 border-t-transparent animate-spin"
-                  style={{ animationDuration: '1.5s' }}
-                ></div>
-              </div>
-              <div className="mt-4 text-5xl">🤔</div>
-            </div>
-          )}
-          {status === 'completed' && (
-            <div className="text-5xl mb-4">✅</div>
-          )}
-          {status === 'failed' && (
-            <div className="text-5xl mb-4">❌</div>
-          )}
+    <main className="mx-auto flex min-h-screen w-full max-w-2xl flex-col items-center justify-center px-6 text-center">
+      <div className="w-full rounded-2xl border bg-white p-10 shadow-sm">
+        <div className="mx-auto mb-6 h-14 w-14 animate-spin rounded-full border-4 border-blue-200 border-t-blue-600" />
+        <h1 className="text-2xl font-bold">Generating your AI study plan</h1>
+        <p className="mt-4 text-lg text-gray-700">{activeLine}</p>
+        <p className="mt-3 text-sm text-gray-500">Please keep this tab open while we personalize your roadmap.</p>
 
-          <h2 className="text-xl font-bold mb-2">{message}</h2>
-          <Progress value={progress} className="mt-4" />
-
-          <div className="mt-6 space-y-4">
-            <StepIndicator
-              label="Gathering your info"
-              completed={progress >= 25}
-              active={progress < 25}
-            />
-            <StepIndicator
-              label="Analyzing skills"
-              completed={progress >= 50}
-              active={progress >= 25 && progress < 50}
-            />
-            <StepIndicator
-              label="Building plan"
-              completed={progress >= 75}
-              active={progress >= 50 && progress < 75}
-            />
-            <StepIndicator
-              label="Finalizing your plan"
-              completed={progress >= 100}
-              active={progress >= 75 && progress < 100}
-            />
-          </div>
-
-          {status === 'failed' && error && (
-            <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-red-600 text-sm">{error}</p>
-            </div>
-          )}
-
-          <div className="mt-6 space-x-3">
-            {status === 'failed' && (
-              <Button onClick={handleRetry}>
-                Try Again
-              </Button>
-            )}
-            {status === 'completed' && (
-              <Button onClick={() => router.push('/dashboard')}>
-                Go to Dashboard
-              </Button>
-            )}
-            {status === 'generating' && (
-              <Button variant="outline" disabled>
-                Generating...
-              </Button>
-            )}
-          </div>
-        </Card>
-
-        {status === 'generating' && (
-          <div className="mt-6 text-sm text-gray-600 animate-pulse">
-            <FunFact />
+        {error && (
+          <div className="mt-6 rounded-md border border-red-200 bg-red-50 p-3 text-red-700">
+            <p>{error}</p>
+            <button
+              type="button"
+              className="mt-3 rounded-md bg-red-600 px-3 py-2 text-sm text-white"
+              onClick={() => window.location.reload()}
+            >
+              Retry
+            </button>
           </div>
         )}
       </div>
-    </StepShell>
+    </main>
   );
 }
-
-// Helper Components (completed from truncated)
-function StepIndicator({ label, completed, active }: { label: string; completed: boolean; active: boolean }) {
-  return (
-    <div className="flex items-center">
-      <div className={`w-5 h-5 rounded-full mr-2 flex items-center justify-center ${
-        completed ? 'bg-green-500' :
-        active ? 'bg-blue-500 animate-pulse' :
-        'bg-gray-200'
-      }`}>
-        {completed && (
-          <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-          </svg>
-        )}
-      </div>
-      <span className={active ? 'font-medium' : ''}>{label}</span>
-    </div>
-  );
-}
-
-function FunFact() {
-  const facts = [
-    "Did you know? Consistent daily practice improves retention by 50%!",
-    "Students who follow a structured plan improve 2x faster.",
-    "The best time to study is when you're most alert - morning or evening?",
-    "Regular breaks actually help your brain consolidate learning.",
-    "You're joining 10,000+ students who improved their scores!",
-  ];
-
-  const [fact, setFact] = useState(facts[0]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setFact(facts[Math.floor(Math.random() * facts.length)]);
-    }, 5000);
-    return () => clearInterval(interval);
-  }, []);
-
-  return <p>💡 {fact}</p>;
-}
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const supabase = getServerClient(context);
-
-  const { data: { user } } = await supabase.auth.getUser();
-
-  if (!user) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false,
-      },
-    };
-  }
-
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('onboarding_step')
-    .eq('user_id', user.id)
-    .single();
-
-  if (!profile || profile.onboarding_step < 5) {
-    return {
-      redirect: {
-        destination: '/onboarding/review',
-        permanent: false,
-      },
-    };
-  }
-
-  return {
-    props: {
-      userId: user.id,
-    },
-  };
-};

--- a/supabase/migrations/20260225090000_user_onboarding.sql
+++ b/supabase/migrations/20260225090000_user_onboarding.sql
@@ -1,0 +1,37 @@
+create table if not exists public.user_onboarding (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references auth.users(id) on delete cascade,
+  target_band numeric(2,1) not null check (target_band >= 5.0 and target_band <= 9.0),
+  exam_date date not null,
+  reading_level int not null check (reading_level between 1 and 5),
+  writing_level int not null check (writing_level between 1 and 5),
+  listening_level int not null check (listening_level between 1 and 5),
+  speaking_level int not null check (speaking_level between 1 and 5),
+  learning_style text not null,
+  generated_plan jsonb,
+  created_at timestamptz not null default now()
+);
+
+alter table public.user_onboarding enable row level security;
+
+drop policy if exists "user_onboarding_select_own" on public.user_onboarding;
+create policy "user_onboarding_select_own"
+  on public.user_onboarding
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+drop policy if exists "user_onboarding_insert_own" on public.user_onboarding;
+create policy "user_onboarding_insert_own"
+  on public.user_onboarding
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+drop policy if exists "user_onboarding_update_own" on public.user_onboarding;
+create policy "user_onboarding_update_own"
+  on public.user_onboarding
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/supabase/migrations/20260225113000_user_onboarding_owner_rls.sql
+++ b/supabase/migrations/20260225113000_user_onboarding_owner_rls.sql
@@ -1,0 +1,61 @@
+-- Create/ensure onboarding table with owner-only access controls.
+
+create table if not exists public.user_onboarding (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  target_band numeric(2,1) not null check (target_band >= 5.0 and target_band <= 9.0),
+  exam_date date not null,
+  reading_level int not null check (reading_level between 1 and 5),
+  writing_level int not null check (writing_level between 1 and 5),
+  listening_level int not null check (listening_level between 1 and 5),
+  speaking_level int not null check (speaking_level between 1 and 5),
+  learning_style text not null,
+  generated_plan jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- Ensure one onboarding record per user.
+create unique index if not exists user_onboarding_user_id_key on public.user_onboarding (user_id);
+
+-- Ensure proper FK relationship to auth.users.
+alter table public.user_onboarding
+  drop constraint if exists user_onboarding_user_id_fkey;
+
+alter table public.user_onboarding
+  add constraint user_onboarding_user_id_fkey
+  foreign key (user_id)
+  references auth.users(id)
+  on delete cascade;
+
+-- Enable row-level security.
+alter table public.user_onboarding enable row level security;
+
+-- Owner-only policies.
+drop policy if exists "user_onboarding_select_own" on public.user_onboarding;
+create policy "user_onboarding_select_own"
+  on public.user_onboarding
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+drop policy if exists "user_onboarding_insert_own" on public.user_onboarding;
+create policy "user_onboarding_insert_own"
+  on public.user_onboarding
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+drop policy if exists "user_onboarding_update_own" on public.user_onboarding;
+create policy "user_onboarding_update_own"
+  on public.user_onboarding
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+drop policy if exists "user_onboarding_delete_own" on public.user_onboarding;
+create policy "user_onboarding_delete_own"
+  on public.user_onboarding
+  for delete
+  to authenticated
+  using (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation
- Provide a lightweight 4-step micro-survey immediately after first login to capture target band, exam date, self-rated skills and learning style so a personalized plan can be generated. 
- Persist onboarding state and the AI-generated plan in Supabase so middleware and UI can reliably detect completion and show the dashboard. 
- Create a robust server-side AI generation endpoint with validation and a safe fallback so the product can produce structured study plans even when the OpenAI API is unavailable.

### Description
- Added a Supabase migration `supabase/migrations/20260225090000_user_onboarding.sql` which creates `public.user_onboarding` with the requested fields, timestamps and owner-scoped RLS policies. 
- Introduced typed onboarding and study-plan schemas and helpers in `lib/onboarding/aiStudyPlan.ts` (`zod` schemas, `weakestSkill`, and `buildFallbackPlan`) used for validation and fallback plan generation. 
- Implemented `POST /api/ai/generate-plan` at `pages/api/ai/generate-plan.ts` which validates incoming payloads, builds a structured OpenAI prompt, parses/validates JSON responses, falls back to local logic when necessary, and upserts the result into `user_onboarding.generated_plan`. 
- Updated `pages/api/internal/auth/state.ts` to consider the presence of a `user_onboarding` row when computing `onboardingComplete`, so middleware routing can redirect new users to `/onboarding`. 
- Replaced onboarding UI with a four-screen animated flow at `pages/onboarding/index.tsx` (band selection, exam date, 1–5 skill grid, learning style) that stores validated input to sessionStorage and navigates to the thinking screen. 
- Implemented a thinking/loading screen at `pages/onboarding/thinking.tsx` which runs the generation call, shows rotating status lines, enforces a minimum 5s wait, and redirects to `/dashboard` on success. 
- Updated `pages/dashboard/index.tsx` to surface the AI Study Plan (headline, timeline strip, today’s task, skill progress meters, and a button `AI Re-adjust Plan` that re-runs the generator using saved onboarding data). 

### Testing
- Ran `git diff --check` to verify no whitespace/diff issues and it passed. 
- Attempted linting with `npm run lint` but it could not run in this environment because the `next` binary was unavailable (`sh: 1: next: not found`). 
- Attempted dependency installs (`npm install` / `npm ci`) but environment dependency/lockfile issues prevented a clean install, so full local build and runtime tests were not executed. 
- Tried a Playwright screenshot against `http://localhost:3000/onboarding` but the local app server was not running in this environment (result: `ERR_EMPTY_RESPONSE`), so end-to-end UI verification should be run in a developer environment or CI that can install deps and start the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2ef234888328b72841d13ff5b3fb)