### PR TITLE
Fix mixed logged-in header appearing on login page

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -307,7 +307,9 @@ function InnerApp({ Component, pageProps }: AppProps) {
 
   // route config
   const routeConfiguration = useRouteConfiguration(pathname);
-  const forceLayoutOnAuthPage = routeConfiguration.isAuthPage && !!user;
+  // Keep auth pages chrome-free even when a stale client-side user object exists.
+  // This prevents a mixed UI state (logged-in header + login form) while redirecting.
+  const forceLayoutOnAuthPage = false;
 
   // access guard
   useRouteAccessCheck(pathname, role);


### PR DESCRIPTION
### Motivation
- Prevent auth pages rendering with the main app chrome (logged-in header) while the email/password form is still shown during transient client auth/session transitions.

### Description
- Stop forcing the main layout on auth routes by setting `forceLayoutOnAuthPage` to `false` in `pages/_app.tsx` and add a clarifying comment to explain the change.

### Testing
- Attempted to lint the modified file via `npm run -s lint -- --file pages/_app.tsx`, but the runner failed in this environment because `next` is not available in PATH; lint could not complete.
- Attempted a Playwright navigation/screenshot to `http://127.0.0.1:3000/login/email`, but the local dev server was not running so the page navigation failed with `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0c874ef988328b257bc9502513015)