### PR TITLE
feat(dashboard): add tier-based rendering and useTierFeatures hook

### DIFF
--- a/hooks/useAIInsights.ts
+++ b/hooks/useAIInsights.ts
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import type { DashboardData } from '@/hooks/useDashboardData';
+
+export type AIInsight = {
+  id: string;
+  text: string;
+  actionLabel: string;
+  href: string;
+  locked?: boolean;
+  trigger?: 'plateau' | 'weakest-skill' | 'recent-improvement';
+};
+
+const byWeaknessOrder = ['writing', 'speaking', 'reading', 'listening'] as const;
+
+const inferWeakestSkill = (data: DashboardData): string => {
+  const skillMinutes = new Map<string, number>();
+  for (const log of data.studyLogs) {
+    const key = (log.skill || 'general').toLowerCase();
+    skillMinutes.set(key, (skillMinutes.get(key) ?? 0) + log.minutes);
+  }
+
+  for (const skill of byWeaknessOrder) {
+    if (!skillMinutes.has(skill) || (skillMinutes.get(skill) ?? 0) < 90) {
+      return skill;
+    }
+  }
+
+  return 'writing';
+};
+
+export function useAIInsights(data: DashboardData, tier: SubscriptionTier) {
+  return useMemo(() => {
+    const depth = tier === 'owl' ? 'deep' : 'standard';
+    const insights: AIInsight[] = [];
+
+    const history = data.bandHistory;
+    const recent = history.slice(-3);
+
+    if (recent.length >= 3) {
+      const drift = Math.abs((recent[2]?.band ?? 0) - (recent[0]?.band ?? 0));
+      if (drift < 0.2) {
+        insights.push({
+          id: 'plateau',
+          text:
+            depth === 'deep'
+              ? 'Your band is plateauing for 3 weeks. Deep intervention: switch to timed writing + instant error loops for the next 5 sessions.'
+              : 'Your band trend is flat. Add one timed writing block this week to break the plateau.',
+          actionLabel: 'Open writing plan',
+          href: '/review/writing',
+          trigger: 'plateau',
+        });
+      }
+    }
+
+    const weakestSkill = inferWeakestSkill(data);
+    insights.push({
+      id: 'weakest-skill',
+      text:
+        depth === 'deep'
+          ? `Weakest skill detected: ${weakestSkill}. Prioritize high-friction drills and coach review in this area.`
+          : `Weakest skill detected: ${weakestSkill}. Focus one extra session here this week.`,
+      actionLabel: 'Start targeted practice',
+      href: weakestSkill === 'reading' ? '/reading' : weakestSkill === 'speaking' ? '/review/speaking' : '/review/writing',
+      trigger: 'weakest-skill',
+    });
+
+    if (recent.length >= 2) {
+      const improvement = (recent.at(-1)?.band ?? 0) - (recent.at(-2)?.band ?? 0);
+      if (improvement > 0) {
+        insights.push({
+          id: 'recent-improvement',
+          text: `Nice progress: +${improvement.toFixed(1)} band since last week. Keep momentum with 3 focused tasks today.`,
+          actionLabel: 'Continue streak',
+          href: '/dashboard#practice',
+          trigger: 'recent-improvement',
+        });
+      }
+    }
+
+    return insights.slice(0, 3);
+  }, [data, tier]);
+}
+
+export default useAIInsights;

--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -179,9 +179,34 @@ export function useDashboardData({ userId, tier, realtime = false }: UseDashboar
 
     const channel = supabaseBrowser
       .channel(`dashboard-data-${userId}`)
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'study_logs', filter: `user_id=eq.${userId}` }, () => {
-        void load();
-      })
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'study_logs', filter: `user_id=eq.${userId}` },
+        () => {
+          void load();
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'coach_notes', filter: `user_id=eq.${userId}` },
+        () => {
+          void load();
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'band_history', filter: `user_id=eq.${userId}` },
+        () => {
+          void load();
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'practice_completion', filter: `user_id=eq.${userId}` },
+        () => {
+          void load();
+        },
+      )
       .subscribe();
 
     return () => {

--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -1,0 +1,203 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import useTierFeatures from '@/hooks/useTierFeatures';
+
+type UseDashboardDataParams = {
+  userId: string | null;
+  tier: SubscriptionTier;
+  realtime?: boolean;
+};
+
+export type PerformanceSnapshot = {
+  overallBand: number | null;
+  practiceHours: number;
+  studyStreak: number;
+  mockTests: number;
+};
+
+export type StudyLog = {
+  id: string;
+  weekLabel: string;
+  minutes: number;
+  skill: string;
+};
+
+export type BandHistoryPoint = {
+  id: string;
+  weekLabel: string;
+  band: number;
+  lowerBand?: number | null;
+  upperBand?: number | null;
+  note?: string | null;
+};
+
+export type UsageLimits = {
+  aiWritingUsed: number;
+  aiWritingLimit: number;
+  speakingAnalysisUsed: number;
+  speakingAnalysisLimit: number;
+};
+
+export type DashboardData = {
+  performance: PerformanceSnapshot;
+  studyLogs: StudyLog[];
+  bandHistory: BandHistoryPoint[];
+  usageLimits: UsageLimits;
+};
+
+const emptyData: DashboardData = {
+  performance: {
+    overallBand: null,
+    practiceHours: 0,
+    studyStreak: 0,
+    mockTests: 0,
+  },
+  studyLogs: [],
+  bandHistory: [],
+  usageLimits: {
+    aiWritingUsed: 0,
+    aiWritingLimit: 0,
+    speakingAnalysisUsed: 0,
+    speakingAnalysisLimit: 0,
+  },
+};
+
+export function useDashboardData({ userId, tier, realtime = false }: UseDashboardDataParams) {
+  const features = useTierFeatures(tier);
+  const [data, setData] = useState<DashboardData>(() => ({
+    ...emptyData,
+    usageLimits: {
+      ...emptyData.usageLimits,
+      aiWritingLimit: features.aiWritingLimit,
+      speakingAnalysisLimit: features.speakingAnalysisLimit,
+    },
+  }));
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      if (!userId) {
+        if (!active) return;
+        setData((prev) => ({
+          ...prev,
+          usageLimits: {
+            ...prev.usageLimits,
+            aiWritingLimit: features.aiWritingLimit,
+            speakingAnalysisLimit: features.speakingAnalysisLimit,
+          },
+        }));
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [performanceRes, logsRes, bandRes, usageRes] = await Promise.all([
+          supabaseBrowser
+            .from('dashboard_performance')
+            .select('overall_band,practice_hours,study_streak,mock_tests')
+            .eq('user_id', userId)
+            .maybeSingle(),
+          supabaseBrowser
+            .from('study_logs')
+            .select('id,week_label,minutes,skill')
+            .eq('user_id', userId)
+            .order('week_label', { ascending: true }),
+          supabaseBrowser
+            .from('band_history')
+            .select('id,week_label,band,lower_band,upper_band,note')
+            .eq('user_id', userId)
+            .order('week_label', { ascending: true }),
+          supabaseBrowser
+            .from('usage_limits')
+            .select('ai_writing_used,speaking_analysis_used')
+            .eq('user_id', userId)
+            .maybeSingle(),
+        ]);
+
+        if (!active) return;
+
+        const firstError =
+          performanceRes.error || logsRes.error || bandRes.error || usageRes.error;
+
+        if (firstError) {
+          setError(firstError.message);
+        }
+
+        setData({
+          performance: {
+            overallBand: performanceRes.data?.overall_band ?? null,
+            practiceHours: Number(performanceRes.data?.practice_hours ?? 0),
+            studyStreak: Number(performanceRes.data?.study_streak ?? 0),
+            mockTests: Number(performanceRes.data?.mock_tests ?? 0),
+          },
+          studyLogs: (logsRes.data ?? []).map((row: any) => ({
+            id: String(row.id),
+            weekLabel: String(row.week_label ?? 'Week'),
+            minutes: Number(row.minutes ?? 0),
+            skill: String(row.skill ?? 'general'),
+          })),
+          bandHistory: (bandRes.data ?? []).map((row: any) => ({
+            id: String(row.id),
+            weekLabel: String(row.week_label ?? 'Week'),
+            band: Number(row.band ?? 0),
+            lowerBand: row.lower_band == null ? null : Number(row.lower_band),
+            upperBand: row.upper_band == null ? null : Number(row.upper_band),
+            note: row.note == null ? null : String(row.note),
+          })),
+          usageLimits: {
+            aiWritingUsed: Number(usageRes.data?.ai_writing_used ?? 0),
+            aiWritingLimit: features.aiWritingLimit,
+            speakingAnalysisUsed: Number(usageRes.data?.speaking_analysis_used ?? 0),
+            speakingAnalysisLimit: features.speakingAnalysisLimit,
+          },
+        });
+      } catch (caughtError) {
+        if (!active) return;
+        const message = caughtError instanceof Error ? caughtError.message : 'Failed to load dashboard data';
+        setError(message);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    void load();
+
+    const shouldSubscribeRealtime = realtime && tier === 'owl' && !!userId;
+    if (!shouldSubscribeRealtime) {
+      return () => {
+        active = false;
+      };
+    }
+
+    const channel = supabaseBrowser
+      .channel(`dashboard-data-${userId}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'study_logs', filter: `user_id=eq.${userId}` }, () => {
+        void load();
+      })
+      .subscribe();
+
+    return () => {
+      active = false;
+      void supabaseBrowser.removeChannel(channel);
+    };
+  }, [features.aiWritingLimit, features.speakingAnalysisLimit, realtime, tier, userId]);
+
+  return useMemo(
+    () => ({
+      data,
+      loading,
+      error,
+    }),
+    [data, error, loading],
+  );
+}
+
+export default useDashboardData;

--- a/hooks/useTierFeatures.ts
+++ b/hooks/useTierFeatures.ts
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+
+export type Tier = 'free' | 'seedling' | 'rocket' | 'owl';
+
+export type TierFeatures = {
+  aiWritingLimit: number;
+  speakingAnalysisLimit: number;
+  predictiveAnalytics: boolean;
+  realtimeAnalytics: boolean;
+  liveCoaching: boolean;
+  exportReports: boolean;
+  studyBuddyAccess: boolean;
+};
+
+const DEFAULT_TIER: Tier = 'free';
+
+const TIER_FEATURES: Record<Tier, TierFeatures> = {
+  free: {
+    aiWritingLimit: 2,
+    speakingAnalysisLimit: 2,
+    predictiveAnalytics: false,
+    realtimeAnalytics: false,
+    liveCoaching: false,
+    exportReports: false,
+    studyBuddyAccess: false,
+  },
+  seedling: {
+    aiWritingLimit: 10,
+    speakingAnalysisLimit: 10,
+    predictiveAnalytics: true,
+    realtimeAnalytics: false,
+    liveCoaching: false,
+    exportReports: false,
+    studyBuddyAccess: true,
+  },
+  rocket: {
+    aiWritingLimit: 40,
+    speakingAnalysisLimit: 40,
+    predictiveAnalytics: true,
+    realtimeAnalytics: true,
+    liveCoaching: false,
+    exportReports: true,
+    studyBuddyAccess: true,
+  },
+  owl: {
+    aiWritingLimit: 120,
+    speakingAnalysisLimit: 120,
+    predictiveAnalytics: true,
+    realtimeAnalytics: true,
+    liveCoaching: true,
+    exportReports: true,
+    studyBuddyAccess: true,
+  },
+};
+
+const isTier = (value: string | null | undefined): value is Tier =>
+  value === 'free' || value === 'seedling' || value === 'rocket' || value === 'owl';
+
+export function useTierFeatures(tier: string | null | undefined) {
+  return useMemo(() => {
+    const normalizedTier: Tier = isTier(tier) ? tier : DEFAULT_TIER;
+    return TIER_FEATURES[normalizedTier];
+  }, [tier]);
+}
+
+export default useTierFeatures;

--- a/hooks/useUsageLimits.ts
+++ b/hooks/useUsageLimits.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+
+import type { SubscriptionTier } from '@/lib/navigation/types';
+
+type UsageParams = {
+  tier: SubscriptionTier;
+  readingTestsUsed: number;
+  writingFeedbackUsed: number;
+  speakingAnalysisUsed: number;
+};
+
+type UsageItem = {
+  used: number;
+  limit: number;
+  remaining: number;
+  resetDate: string;
+};
+
+export type UsageLimitsState = {
+  readingTests: UsageItem;
+  writingFeedback: UsageItem;
+  speakingAnalysis: UsageItem;
+};
+
+const limitsByTier: Record<SubscriptionTier, { reading: number; writing: number; speaking: number }> = {
+  free: { reading: 3, writing: 3, speaking: 2 },
+  seedling: { reading: 12, writing: 10, speaking: 10 },
+  rocket: { reading: 30, writing: 40, speaking: 40 },
+  owl: { reading: 80, writing: 120, speaking: 120 },
+};
+
+const monthEndISO = () => {
+  const now = new Date();
+  const resetDate = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  return resetDate.toISOString();
+};
+
+export function useUsageLimits({ tier, readingTestsUsed, writingFeedbackUsed, speakingAnalysisUsed }: UsageParams) {
+  return useMemo<UsageLimitsState>(() => {
+    const config = limitsByTier[tier];
+    const resetDate = monthEndISO();
+
+    const makeItem = (usedRaw: number, limit: number): UsageItem => {
+      const used = Math.max(0, Math.min(limit, usedRaw));
+      return {
+        used,
+        limit,
+        remaining: Math.max(0, limit - used),
+        resetDate,
+      };
+    };
+
+    return {
+      readingTests: makeItem(readingTestsUsed, config.reading),
+      writingFeedback: makeItem(writingFeedbackUsed, config.writing),
+      speakingAnalysis: makeItem(speakingAnalysisUsed, config.speaking),
+    };
+  }, [tier, readingTestsUsed, writingFeedbackUsed, speakingAnalysisUsed]);
+}
+
+export default useUsageLimits;

--- a/pages/dashboard/components/shared/FeaturePreviewWrapper.tsx
+++ b/pages/dashboard/components/shared/FeaturePreviewWrapper.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+import { Button } from '@/components/design-system/Button';
+
+type FeaturePreviewWrapperProps = {
+  locked: boolean;
+  onUpgrade: () => void;
+  onTrySample?: () => void;
+  children: ReactNode;
+};
+
+const FeaturePreviewWrapper = ({ locked, onUpgrade, onTrySample, children }: FeaturePreviewWrapperProps) => {
+  if (!locked) return <>{children}</>;
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-border/60">
+      <div className="pointer-events-none blur-[2px] opacity-70">{children}</div>
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background/60 p-4 text-center">
+        <p className="text-sm font-medium">Premium feature preview</p>
+        <div className="flex gap-2">
+          <Button size="sm" variant="secondary" onClick={onTrySample}>Try 1 sample</Button>
+          <Button size="sm" onClick={onUpgrade}>Upgrade</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FeaturePreviewWrapper;

--- a/pages/dashboard/components/shared/Header.tsx
+++ b/pages/dashboard/components/shared/Header.tsx
@@ -1,0 +1,32 @@
+import type { SubscriptionTier } from '@/lib/navigation/types';
+
+const tierLabel: Record<SubscriptionTier, string> = {
+  free: 'Free',
+  seedling: 'Seedling',
+  rocket: 'Rocket',
+  owl: 'Owl',
+};
+
+type HeaderProps = {
+  tier: SubscriptionTier;
+};
+
+const Header = ({ tier }: HeaderProps) => {
+  return (
+    <header className="sticky top-0 z-40 border-b border-border/70 bg-background/95 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-[1400px] items-center justify-between px-4 sm:px-6 lg:px-8">
+        <div>
+          <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            Enterprise Dashboard
+          </p>
+          <h1 className="text-lg font-semibold text-foreground">Gramor_X</h1>
+        </div>
+        <span className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+          {tierLabel[tier]} Tier
+        </span>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/pages/dashboard/components/shared/NotificationCenter.tsx
+++ b/pages/dashboard/components/shared/NotificationCenter.tsx
@@ -1,0 +1,31 @@
+const NotificationCenter = () => {
+  const notifications = [
+    {
+      title: 'Daily review due',
+      description: '2 writing prompts are ready for revision.',
+    },
+    {
+      title: 'New challenge unlocked',
+      description: 'Join this week’s speaking sprint.',
+    },
+  ];
+
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <h2 className="text-sm font-semibold text-foreground">Notification Center</h2>
+      <div className="mt-3 space-y-3">
+        {notifications.map((notification) => (
+          <article
+            key={notification.title}
+            className="rounded-xl border border-border/60 bg-background/70 p-3"
+          >
+            <p className="text-sm font-medium text-foreground">{notification.title}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{notification.description}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default NotificationCenter;

--- a/pages/dashboard/components/shared/Sidebar.tsx
+++ b/pages/dashboard/components/shared/Sidebar.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+const sidebarItems = [
+  { label: 'Overview', href: '#overview' },
+  { label: 'Performance', href: '#performance' },
+  { label: 'Practice', href: '#practice' },
+  { label: 'Goals', href: '#goals' },
+  { label: 'Settings', href: '/settings' },
+];
+
+const Sidebar = () => {
+  return (
+    <aside className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Navigation
+      </p>
+      <nav>
+        <ul className="space-y-2">
+          {sidebarItems.map((item) => (
+            <li key={item.label}>
+              <Link
+                href={item.href}
+                className="block rounded-xl px-3 py-2 text-sm text-foreground transition hover:bg-primary/10 hover:text-primary"
+              >
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/pages/dashboard/components/shared/UpgradeModal.tsx
+++ b/pages/dashboard/components/shared/UpgradeModal.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import { Button } from '@/components/design-system/Button';
+
+export type UpgradeTrigger = 'usage-exhaustion' | 'plateau' | 'curiosity';
+
+type UpgradeModalProps = {
+  open: boolean;
+  trigger: UpgradeTrigger;
+  onClose: () => void;
+  onUpgrade: () => void;
+};
+
+const triggerCopy: Record<UpgradeTrigger, { title: string; body: string }> = {
+  'usage-exhaustion': {
+    title: 'You reached this month’s limit',
+    body: 'Upgrade to keep momentum with more AI reviews and expanded analytics.',
+  },
+  plateau: {
+    title: 'Break your plateau faster',
+    body: 'Unlock deeper coaching loops and precision insights to move your band up.',
+  },
+  curiosity: {
+    title: 'See what premium learners unlock',
+    body: 'Get advanced predictions, exports, and live coaching workflows.',
+  },
+};
+
+const socialProof = ['10k+ learners improved by at least 0.5 band', '4.9/5 average AI coaching satisfaction'];
+
+const UpgradeModal = ({ open, trigger, onClose, onUpgrade }: UpgradeModalProps) => {
+  const copy = useMemo(() => triggerCopy[trigger], [trigger]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center p-4">
+      <button type="button" className="absolute inset-0 bg-black/50" onClick={onClose} aria-label="Close upgrade modal" />
+      <div className="relative w-full max-w-lg rounded-2xl border border-border/60 bg-background p-6 shadow-2xl">
+        <p className="mb-2 inline-flex rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">Social proof</p>
+        <h3 className="text-xl font-semibold">{copy.title}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">{copy.body}</p>
+        <ul className="mt-4 space-y-1 text-sm text-foreground">
+          {socialProof.map((line) => (
+            <li key={line}>• {line}</li>
+          ))}
+        </ul>
+        <div className="mt-6 flex gap-2">
+          <Button onClick={onUpgrade}>Upgrade now</Button>
+          <Button variant="ghost" onClick={onClose}>Maybe later</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UpgradeModal;

--- a/pages/dashboard/components/tiers/FreeView.tsx
+++ b/pages/dashboard/components/tiers/FreeView.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+type FreeViewProps = {
+  children?: ReactNode;
+};
+
+const FreeView = ({ children }: FreeViewProps) => {
+  return <>{children}</>;
+};
+
+export default FreeView;

--- a/pages/dashboard/components/tiers/FreeView.tsx
+++ b/pages/dashboard/components/tiers/FreeView.tsx
@@ -1,11 +1,30 @@
 import type { ReactNode } from 'react';
 
+import Header from '@/pages/dashboard/components/shared/Header';
+import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
+import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
+import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
+
 type FreeViewProps = {
   children?: ReactNode;
 };
 
 const FreeView = ({ children }: FreeViewProps) => {
-  return <>{children}</>;
+  return (
+    <>
+      <Header tier="free" />
+      <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
+        <Sidebar />
+        <main className="space-y-4" id="content-grid">
+          <KpiCards tier="free" />
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <section className="rounded-2xl border border-border/70 bg-background/40 p-1">{children}</section>
+            <NotificationCenter />
+          </div>
+        </main>
+      </div>
+    </>
+  );
 };
 
 export default FreeView;

--- a/pages/dashboard/components/tiers/OwlView.tsx
+++ b/pages/dashboard/components/tiers/OwlView.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+
+const OwlView = () => {
+  return (
+    <>
+      <Head>
+        <title>Dashboard — Owl — Gramor_X</title>
+      </Head>
+      <main className="mx-auto max-w-5xl px-6 py-24">
+        <h1 className="font-slab text-h2">Owl dashboard</h1>
+        <p className="mt-3 text-grayish">
+          Owl tier dashboard view placeholder.
+        </p>
+      </main>
+    </>
+  );
+};
+
+export default OwlView;

--- a/pages/dashboard/components/tiers/OwlView.tsx
+++ b/pages/dashboard/components/tiers/OwlView.tsx
@@ -1,21 +1,43 @@
 import Head from 'next/head';
 
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import useDashboardData from '@/hooks/useDashboardData';
 import Header from '@/pages/dashboard/components/shared/Header';
 import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
 import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
 import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
+import BandProgress from '@/pages/dashboard/components/widgets/BandProgress';
+import WeaknessMap from '@/pages/dashboard/components/widgets/WeaknessMap';
 
-const OwlView = () => {
+type OwlViewProps = {
+  userId: string | null;
+  targetBand: number;
+};
+
+const OwlView = ({ userId, targetBand }: OwlViewProps) => {
+  const tier: SubscriptionTier = 'owl';
+  const { data } = useDashboardData({ userId, tier, realtime: true });
+
   return (
     <>
       <Head>
         <title>Dashboard — Owl — Gramor_X</title>
       </Head>
-      <Header tier="owl" />
+      <Header tier={tier} />
       <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
         <Sidebar />
         <main className="space-y-4" id="content-grid">
-          <KpiCards tier="owl" />
+          <KpiCards tier={tier} />
+          <BandProgress points={data.bandHistory} targetBand={targetBand} tier={tier} />
+          <WeaknessMap
+            tier={tier}
+            skillScores={[
+              { skill: 'Reading', score: 6.2, href: '/reading' },
+              { skill: 'Listening', score: 6.8, href: '/exam-day' },
+              { skill: 'Writing', score: 5.9, href: '/review/writing' },
+              { skill: 'Speaking', score: 6.0, href: '/review/speaking' },
+            ]}
+          />
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
             <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
               <h2 className="text-xl font-semibold">Owl Workspace</h2>

--- a/pages/dashboard/components/tiers/OwlView.tsx
+++ b/pages/dashboard/components/tiers/OwlView.tsx
@@ -1,17 +1,32 @@
 import Head from 'next/head';
 
+import Header from '@/pages/dashboard/components/shared/Header';
+import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
+import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
+import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
+
 const OwlView = () => {
   return (
     <>
       <Head>
         <title>Dashboard — Owl — Gramor_X</title>
       </Head>
-      <main className="mx-auto max-w-5xl px-6 py-24">
-        <h1 className="font-slab text-h2">Owl dashboard</h1>
-        <p className="mt-3 text-grayish">
-          Owl tier dashboard view placeholder.
-        </p>
-      </main>
+      <Header tier="owl" />
+      <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
+        <Sidebar />
+        <main className="space-y-4" id="content-grid">
+          <KpiCards tier="owl" />
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
+              <h2 className="text-xl font-semibold">Owl Workspace</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Premium executive insights, real-time coaching, and reporting for Owl tier.
+              </p>
+            </section>
+            <NotificationCenter />
+          </div>
+        </main>
+      </div>
     </>
   );
 };

--- a/pages/dashboard/components/tiers/OwlView.tsx
+++ b/pages/dashboard/components/tiers/OwlView.tsx
@@ -1,13 +1,28 @@
+import { useMemo, useState } from 'react';
 import Head from 'next/head';
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 
 import type { SubscriptionTier } from '@/lib/navigation/types';
 import useDashboardData from '@/hooks/useDashboardData';
+import useAIInsights from '@/hooks/useAIInsights';
+import useUsageLimits from '@/hooks/useUsageLimits';
+import predictiveEngine from '@/utils/predictiveEngine';
 import Header from '@/pages/dashboard/components/shared/Header';
 import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
 import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
+import UpgradeModal from '@/pages/dashboard/components/shared/UpgradeModal';
 import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
 import BandProgress from '@/pages/dashboard/components/widgets/BandProgress';
 import WeaknessMap from '@/pages/dashboard/components/widgets/WeaknessMap';
+import AIInsights from '@/pages/dashboard/components/widgets/AIInsights';
+import UsageMeters from '@/pages/dashboard/components/widgets/UsageMeters';
+import DailyLoginFlow from '@/pages/dashboard/components/widgets/DailyLoginFlow';
+import ExportReports from '@/pages/dashboard/components/widgets/ExportReports';
+
+const Achievements = dynamic(() => import('@/pages/dashboard/components/widgets/Achievements'), {
+  ssr: false,
+});
 
 type OwlViewProps = {
   userId: string | null;
@@ -16,7 +31,21 @@ type OwlViewProps = {
 
 const OwlView = ({ userId, targetBand }: OwlViewProps) => {
   const tier: SubscriptionTier = 'owl';
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const router = useRouter();
   const { data } = useDashboardData({ userId, tier, realtime: true });
+  const insights = useAIInsights(data, tier);
+  const usage = useUsageLimits({
+    tier,
+    readingTestsUsed: data.performance.mockTests,
+    writingFeedbackUsed: data.usageLimits.aiWritingUsed,
+    speakingAnalysisUsed: data.usageLimits.speakingAnalysisUsed,
+  });
+
+  const prediction = useMemo(
+    () => predictiveEngine(data.bandHistory, data.studyLogs),
+    [data.bandHistory, data.studyLogs],
+  );
 
   return (
     <>
@@ -27,8 +56,19 @@ const OwlView = ({ userId, targetBand }: OwlViewProps) => {
       <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
         <Sidebar />
         <main className="space-y-4" id="content-grid">
+          <DailyLoginFlow
+            streak={data.performance.studyStreak}
+            insights={insights}
+            tasks={['Review coach notes', 'Complete adaptive speaking drill', 'Export weekly progress report']}
+          />
           <KpiCards tier={tier} />
           <BandProgress points={data.bandHistory} targetBand={targetBand} tier={tier} />
+          <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+            <h3 className="text-base font-semibold">Predictive engine</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Predicted band {prediction.predictedBand} • confidence {prediction.confidencePercentage}% • ETA {new Date(prediction.estimatedDate).toLocaleDateString()}
+            </p>
+          </section>
           <WeaknessMap
             tier={tier}
             skillScores={[
@@ -38,17 +78,29 @@ const OwlView = ({ userId, targetBand }: OwlViewProps) => {
               { skill: 'Speaking', score: 6.0, href: '/review/speaking' },
             ]}
           />
+          <AIInsights insights={insights} tier={tier} onAction={(href) => void router.push(href)} onUpgrade={() => setUpgradeOpen(true)} />
+          <UsageMeters usage={usage} onUpgrade={() => setUpgradeOpen(true)} />
+          <Achievements performance={data.performance} />
+          <ExportReports tier={tier} data={data} />
+
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
             <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
               <h2 className="text-xl font-semibold">Owl Workspace</h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Premium executive insights, real-time coaching, and reporting for Owl tier.
-              </p>
+              <p className="mt-2 text-sm text-muted-foreground">Premium executive insights, real-time coaching, and reporting for Owl tier.</p>
             </section>
             <NotificationCenter />
           </div>
         </main>
       </div>
+      <UpgradeModal
+        open={upgradeOpen}
+        trigger="plateau"
+        onClose={() => setUpgradeOpen(false)}
+        onUpgrade={() => {
+          setUpgradeOpen(false);
+          void router.push('/checkout');
+        }}
+      />
     </>
   );
 };

--- a/pages/dashboard/components/tiers/RocketView.tsx
+++ b/pages/dashboard/components/tiers/RocketView.tsx
@@ -1,13 +1,26 @@
+import { useMemo, useState } from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 import type { SubscriptionTier } from '@/lib/navigation/types';
 import useDashboardData from '@/hooks/useDashboardData';
+import useAIInsights from '@/hooks/useAIInsights';
+import useUsageLimits from '@/hooks/useUsageLimits';
+import useTierFeatures from '@/hooks/useTierFeatures';
+import predictiveEngine from '@/utils/predictiveEngine';
 import Header from '@/pages/dashboard/components/shared/Header';
 import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
 import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
+import UpgradeModal from '@/pages/dashboard/components/shared/UpgradeModal';
+import FeaturePreviewWrapper from '@/pages/dashboard/components/shared/FeaturePreviewWrapper';
 import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
 import BandProgress from '@/pages/dashboard/components/widgets/BandProgress';
 import WeaknessMap from '@/pages/dashboard/components/widgets/WeaknessMap';
+import AIInsights from '@/pages/dashboard/components/widgets/AIInsights';
+import UsageMeters from '@/pages/dashboard/components/widgets/UsageMeters';
+import Achievements from '@/pages/dashboard/components/widgets/Achievements';
+import DailyLoginFlow from '@/pages/dashboard/components/widgets/DailyLoginFlow';
+import ExportReports from '@/pages/dashboard/components/widgets/ExportReports';
 
 type RocketViewProps = {
   userId: string | null;
@@ -16,7 +29,22 @@ type RocketViewProps = {
 
 const RocketView = ({ userId, targetBand }: RocketViewProps) => {
   const tier: SubscriptionTier = 'rocket';
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const router = useRouter();
+  const features = useTierFeatures(tier);
   const { data } = useDashboardData({ userId, tier, realtime: false });
+  const insights = useAIInsights(data, tier);
+  const usage = useUsageLimits({
+    tier,
+    readingTestsUsed: data.performance.mockTests,
+    writingFeedbackUsed: data.usageLimits.aiWritingUsed,
+    speakingAnalysisUsed: data.usageLimits.speakingAnalysisUsed,
+  });
+
+  const prediction = useMemo(
+    () => predictiveEngine(data.bandHistory, data.studyLogs),
+    [data.bandHistory, data.studyLogs],
+  );
 
   return (
     <>
@@ -27,8 +55,19 @@ const RocketView = ({ userId, targetBand }: RocketViewProps) => {
       <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
         <Sidebar />
         <main className="space-y-4" id="content-grid">
+          <DailyLoginFlow
+            streak={data.performance.studyStreak}
+            insights={insights}
+            tasks={['Run one mock section', 'Practice weakest skill', 'Review today’s AI feedback']}
+          />
           <KpiCards tier={tier} />
           <BandProgress points={data.bandHistory} targetBand={targetBand} tier={tier} />
+          <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+            <h3 className="text-base font-semibold">Predictive engine</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Predicted band {prediction.predictedBand} • confidence {prediction.confidencePercentage}% • ETA {new Date(prediction.estimatedDate).toLocaleDateString()}
+            </p>
+          </section>
           <WeaknessMap
             tier={tier}
             skillScores={[
@@ -38,17 +77,31 @@ const RocketView = ({ userId, targetBand }: RocketViewProps) => {
               { skill: 'Speaking', score: 5.0, href: '/review/speaking' },
             ]}
           />
+          <FeaturePreviewWrapper locked={!features.liveCoaching} onTrySample={() => void router.push('/review/speaking')} onUpgrade={() => setUpgradeOpen(true)}>
+            <AIInsights insights={insights} tier={tier} onAction={(href) => void router.push(href)} onUpgrade={() => setUpgradeOpen(true)} />
+          </FeaturePreviewWrapper>
+          <UsageMeters usage={usage} onUpgrade={() => setUpgradeOpen(true)} />
+          <Achievements performance={data.performance} />
+          <ExportReports tier={tier} data={data} />
+
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
             <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
               <h2 className="text-xl font-semibold">Rocket Workspace</h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Advanced analytics and accelerated exam-performance tracking for Rocket.
-              </p>
+              <p className="mt-2 text-sm text-muted-foreground">Advanced analytics and accelerated exam-performance tracking for Rocket.</p>
             </section>
             <NotificationCenter />
           </div>
         </main>
       </div>
+      <UpgradeModal
+        open={upgradeOpen}
+        trigger="usage-exhaustion"
+        onClose={() => setUpgradeOpen(false)}
+        onUpgrade={() => {
+          setUpgradeOpen(false);
+          void router.push('/checkout');
+        }}
+      />
     </>
   );
 };

--- a/pages/dashboard/components/tiers/RocketView.tsx
+++ b/pages/dashboard/components/tiers/RocketView.tsx
@@ -1,21 +1,43 @@
 import Head from 'next/head';
 
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import useDashboardData from '@/hooks/useDashboardData';
 import Header from '@/pages/dashboard/components/shared/Header';
 import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
 import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
 import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
+import BandProgress from '@/pages/dashboard/components/widgets/BandProgress';
+import WeaknessMap from '@/pages/dashboard/components/widgets/WeaknessMap';
 
-const RocketView = () => {
+type RocketViewProps = {
+  userId: string | null;
+  targetBand: number;
+};
+
+const RocketView = ({ userId, targetBand }: RocketViewProps) => {
+  const tier: SubscriptionTier = 'rocket';
+  const { data } = useDashboardData({ userId, tier, realtime: false });
+
   return (
     <>
       <Head>
         <title>Dashboard — Rocket — Gramor_X</title>
       </Head>
-      <Header tier="rocket" />
+      <Header tier={tier} />
       <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
         <Sidebar />
         <main className="space-y-4" id="content-grid">
-          <KpiCards tier="rocket" />
+          <KpiCards tier={tier} />
+          <BandProgress points={data.bandHistory} targetBand={targetBand} tier={tier} />
+          <WeaknessMap
+            tier={tier}
+            skillScores={[
+              { skill: 'Reading', score: 5.2, href: '/reading' },
+              { skill: 'Listening', score: 6.1, href: '/exam-day' },
+              { skill: 'Writing', score: 4.8, href: '/review/writing' },
+              { skill: 'Speaking', score: 5.0, href: '/review/speaking' },
+            ]}
+          />
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
             <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
               <h2 className="text-xl font-semibold">Rocket Workspace</h2>

--- a/pages/dashboard/components/tiers/RocketView.tsx
+++ b/pages/dashboard/components/tiers/RocketView.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+
+const RocketView = () => {
+  return (
+    <>
+      <Head>
+        <title>Dashboard — Rocket — Gramor_X</title>
+      </Head>
+      <main className="mx-auto max-w-5xl px-6 py-24">
+        <h1 className="font-slab text-h2">Rocket dashboard</h1>
+        <p className="mt-3 text-grayish">
+          Rocket tier dashboard view placeholder.
+        </p>
+      </main>
+    </>
+  );
+};
+
+export default RocketView;

--- a/pages/dashboard/components/tiers/RocketView.tsx
+++ b/pages/dashboard/components/tiers/RocketView.tsx
@@ -1,17 +1,32 @@
 import Head from 'next/head';
 
+import Header from '@/pages/dashboard/components/shared/Header';
+import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
+import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
+import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
+
 const RocketView = () => {
   return (
     <>
       <Head>
         <title>Dashboard — Rocket — Gramor_X</title>
       </Head>
-      <main className="mx-auto max-w-5xl px-6 py-24">
-        <h1 className="font-slab text-h2">Rocket dashboard</h1>
-        <p className="mt-3 text-grayish">
-          Rocket tier dashboard view placeholder.
-        </p>
-      </main>
+      <Header tier="rocket" />
+      <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
+        <Sidebar />
+        <main className="space-y-4" id="content-grid">
+          <KpiCards tier="rocket" />
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
+              <h2 className="text-xl font-semibold">Rocket Workspace</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Advanced analytics and accelerated exam-performance tracking for Rocket.
+              </p>
+            </section>
+            <NotificationCenter />
+          </div>
+        </main>
+      </div>
     </>
   );
 };

--- a/pages/dashboard/components/tiers/SeedlingView.tsx
+++ b/pages/dashboard/components/tiers/SeedlingView.tsx
@@ -1,17 +1,32 @@
 import Head from 'next/head';
 
+import Header from '@/pages/dashboard/components/shared/Header';
+import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
+import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
+import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
+
 const SeedlingView = () => {
   return (
     <>
       <Head>
         <title>Dashboard — Seedling — Gramor_X</title>
       </Head>
-      <main className="mx-auto max-w-5xl px-6 py-24">
-        <h1 className="font-slab text-h2">Seedling dashboard</h1>
-        <p className="mt-3 text-grayish">
-          Seedling tier dashboard view placeholder.
-        </p>
-      </main>
+      <Header tier="seedling" />
+      <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
+        <Sidebar />
+        <main className="space-y-4" id="content-grid">
+          <KpiCards tier="seedling" />
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
+              <h2 className="text-xl font-semibold">Seedling Workspace</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Personalized roadmap and growth-focused insights for the Seedling tier.
+              </p>
+            </section>
+            <NotificationCenter />
+          </div>
+        </main>
+      </div>
     </>
   );
 };

--- a/pages/dashboard/components/tiers/SeedlingView.tsx
+++ b/pages/dashboard/components/tiers/SeedlingView.tsx
@@ -1,12 +1,21 @@
+import { useState } from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 import type { SubscriptionTier } from '@/lib/navigation/types';
 import useDashboardData from '@/hooks/useDashboardData';
+import useAIInsights from '@/hooks/useAIInsights';
+import useUsageLimits from '@/hooks/useUsageLimits';
 import Header from '@/pages/dashboard/components/shared/Header';
 import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
 import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
+import UpgradeModal from '@/pages/dashboard/components/shared/UpgradeModal';
 import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
 import BandProgress from '@/pages/dashboard/components/widgets/BandProgress';
+import AIInsights from '@/pages/dashboard/components/widgets/AIInsights';
+import UsageMeters from '@/pages/dashboard/components/widgets/UsageMeters';
+import DailyLoginFlow from '@/pages/dashboard/components/widgets/DailyLoginFlow';
+import { ChartSkeleton, InsightsSkeleton, KpiCardsSkeleton, UsageMetersSkeleton } from '@/pages/dashboard/components/widgets/Skeletons';
 
 type SeedlingViewProps = {
   userId: string | null;
@@ -15,7 +24,16 @@ type SeedlingViewProps = {
 
 const SeedlingView = ({ userId, targetBand }: SeedlingViewProps) => {
   const tier: SubscriptionTier = 'seedling';
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const router = useRouter();
   const { data, loading } = useDashboardData({ userId, tier, realtime: false });
+  const insights = useAIInsights(data, tier);
+  const usage = useUsageLimits({
+    tier,
+    readingTestsUsed: data.performance.mockTests,
+    writingFeedbackUsed: data.usageLimits.aiWritingUsed,
+    speakingAnalysisUsed: data.usageLimits.speakingAnalysisUsed,
+  });
 
   return (
     <>
@@ -26,20 +44,38 @@ const SeedlingView = ({ userId, targetBand }: SeedlingViewProps) => {
       <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
         <Sidebar />
         <main className="space-y-4" id="content-grid">
-          <KpiCards tier={tier} />
-          <BandProgress points={data.bandHistory} targetBand={targetBand} tier={tier} />
+          <DailyLoginFlow
+            streak={data.performance.studyStreak}
+            insights={insights}
+            tasks={['Complete 1 writing drill', 'Review yesterday’s mistakes', 'Take a timed reading set']}
+          />
+          {loading ? <KpiCardsSkeleton /> : <KpiCards tier={tier} />}
+          {loading ? <ChartSkeleton /> : <BandProgress points={data.bandHistory} targetBand={targetBand} tier={tier} />}
+          {loading ? (
+            <InsightsSkeleton />
+          ) : (
+            <AIInsights insights={insights} tier={tier} onAction={(href) => void router.push(href)} onUpgrade={() => setUpgradeOpen(true)} />
+          )}
+          {loading ? <UsageMetersSkeleton /> : <UsageMeters usage={usage} onUpgrade={() => setUpgradeOpen(true)} />}
+
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
             <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
               <h2 className="text-xl font-semibold">Seedling Workspace</h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Personalized roadmap and growth-focused insights for the Seedling tier.
-              </p>
-              {loading ? <p className="mt-3 text-xs text-muted-foreground">Loading dashboard data…</p> : null}
+              <p className="mt-2 text-sm text-muted-foreground">Personalized roadmap and growth-focused insights for the Seedling tier.</p>
             </section>
             <NotificationCenter />
           </div>
         </main>
       </div>
+      <UpgradeModal
+        open={upgradeOpen}
+        trigger="curiosity"
+        onClose={() => setUpgradeOpen(false)}
+        onUpgrade={() => {
+          setUpgradeOpen(false);
+          void router.push('/checkout');
+        }}
+      />
     </>
   );
 };

--- a/pages/dashboard/components/tiers/SeedlingView.tsx
+++ b/pages/dashboard/components/tiers/SeedlingView.tsx
@@ -1,27 +1,40 @@
 import Head from 'next/head';
 
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import useDashboardData from '@/hooks/useDashboardData';
 import Header from '@/pages/dashboard/components/shared/Header';
 import Sidebar from '@/pages/dashboard/components/shared/Sidebar';
 import NotificationCenter from '@/pages/dashboard/components/shared/NotificationCenter';
 import KpiCards from '@/pages/dashboard/components/widgets/KpiCards';
+import BandProgress from '@/pages/dashboard/components/widgets/BandProgress';
 
-const SeedlingView = () => {
+type SeedlingViewProps = {
+  userId: string | null;
+  targetBand: number;
+};
+
+const SeedlingView = ({ userId, targetBand }: SeedlingViewProps) => {
+  const tier: SubscriptionTier = 'seedling';
+  const { data, loading } = useDashboardData({ userId, tier, realtime: false });
+
   return (
     <>
       <Head>
         <title>Dashboard — Seedling — Gramor_X</title>
       </Head>
-      <Header tier="seedling" />
+      <Header tier={tier} />
       <div className="mx-auto grid w-full max-w-[1400px] gap-4 px-4 py-6 lg:grid-cols-[240px_minmax(0,1fr)] lg:gap-6 lg:px-8">
         <Sidebar />
         <main className="space-y-4" id="content-grid">
-          <KpiCards tier="seedling" />
+          <KpiCards tier={tier} />
+          <BandProgress points={data.bandHistory} targetBand={targetBand} tier={tier} />
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
             <section className="rounded-2xl border border-border/70 bg-card/80 p-6">
               <h2 className="text-xl font-semibold">Seedling Workspace</h2>
               <p className="mt-2 text-sm text-muted-foreground">
                 Personalized roadmap and growth-focused insights for the Seedling tier.
               </p>
+              {loading ? <p className="mt-3 text-xs text-muted-foreground">Loading dashboard data…</p> : null}
             </section>
             <NotificationCenter />
           </div>

--- a/pages/dashboard/components/tiers/SeedlingView.tsx
+++ b/pages/dashboard/components/tiers/SeedlingView.tsx
@@ -1,0 +1,19 @@
+import Head from 'next/head';
+
+const SeedlingView = () => {
+  return (
+    <>
+      <Head>
+        <title>Dashboard — Seedling — Gramor_X</title>
+      </Head>
+      <main className="mx-auto max-w-5xl px-6 py-24">
+        <h1 className="font-slab text-h2">Seedling dashboard</h1>
+        <p className="mt-3 text-grayish">
+          Seedling tier dashboard view placeholder.
+        </p>
+      </main>
+    </>
+  );
+};
+
+export default SeedlingView;

--- a/pages/dashboard/components/widgets/AIInsights.tsx
+++ b/pages/dashboard/components/widgets/AIInsights.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@/components/design-system/Button';
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import type { AIInsight } from '@/hooks/useAIInsights';
+
+type AIInsightsProps = {
+  insights: AIInsight[];
+  tier: SubscriptionTier;
+  onAction: (href: string) => void;
+  onUpgrade: () => void;
+};
+
+const AIInsights = ({ insights, tier, onAction, onUpgrade }: AIInsightsProps) => {
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <h3 className="text-base font-semibold">AI Daily Insights</h3>
+      <div className="mt-3 space-y-3">
+        {insights.map((insight) => {
+          const locked = insight.locked && tier === 'free';
+          return (
+            <article key={insight.id} className="rounded-xl border border-border/60 p-3">
+              <p className="text-sm text-foreground">{insight.text}</p>
+              <div className="mt-2 flex gap-2">
+                <Button size="sm" onClick={() => onAction(insight.href)} disabled={locked}>
+                  {insight.actionLabel}
+                </Button>
+                {locked ? (
+                  <Button size="sm" variant="ghost" onClick={onUpgrade}>
+                    Upgrade
+                  </Button>
+                ) : null}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default AIInsights;

--- a/pages/dashboard/components/widgets/Achievements.tsx
+++ b/pages/dashboard/components/widgets/Achievements.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type { PerformanceSnapshot } from '@/hooks/useDashboardData';
+
+type AchievementsProps = {
+  performance: PerformanceSnapshot;
+};
+
+type AchievementKey = 'streak' | 'essays' | 'band-increase';
+
+const STORAGE_KEY = 'dashboard-achievements-v1';
+
+const Achievements = ({ performance }: AchievementsProps) => {
+  const [unlocked, setUnlocked] = useState<AchievementKey[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        setUnlocked(JSON.parse(raw) as AchievementKey[]);
+      } catch {
+        setUnlocked([]);
+      }
+    }
+  }, []);
+
+  const candidates = useMemo<{ key: AchievementKey; label: string; passed: boolean }[]>(
+    () => [
+      { key: 'streak', label: '7-day streak', passed: performance.studyStreak >= 7 },
+      { key: 'essays', label: '5 essays submitted', passed: performance.mockTests >= 5 },
+      { key: 'band-increase', label: 'Band increased to 7+', passed: (performance.overallBand ?? 0) >= 7 },
+    ],
+    [performance],
+  );
+
+  useEffect(() => {
+    const nextUnlocked = Array.from(new Set([...unlocked, ...candidates.filter((c) => c.passed).map((c) => c.key)]));
+    if (nextUnlocked.length === unlocked.length) return;
+    setUnlocked(nextUnlocked);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextUnlocked));
+    }
+  }, [candidates, unlocked]);
+
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <h3 className="text-base font-semibold">Achievements</h3>
+      <div className="mt-3 grid gap-2 sm:grid-cols-3">
+        {candidates.map((achievement) => {
+          const isUnlocked = unlocked.includes(achievement.key);
+          return (
+            <div key={achievement.key} className={`rounded-xl border p-3 ${isUnlocked ? 'border-emerald-500/50 bg-emerald-500/10' : 'border-border/60'}`}>
+              <p className="text-sm font-medium">{achievement.label}</p>
+              <p className="mt-1 text-xs text-muted-foreground">{isUnlocked ? 'Unlocked 🎉' : 'In progress'}</p>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default Achievements;

--- a/pages/dashboard/components/widgets/BandProgress.tsx
+++ b/pages/dashboard/components/widgets/BandProgress.tsx
@@ -1,0 +1,99 @@
+import {
+  CartesianGrid,
+  Label,
+  Legend,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import type { BandHistoryPoint } from '@/hooks/useDashboardData';
+
+type BandProgressProps = {
+  points: BandHistoryPoint[];
+  targetBand: number;
+  tier: SubscriptionTier;
+};
+
+const BandProgress = ({ points, targetBand, tier }: BandProgressProps) => {
+  const canShowConfidenceInterval = tier === 'rocket' || tier === 'owl';
+  const canShowAnnotations = tier === 'owl';
+
+  return (
+    <section id="performance" className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <div className="mb-4">
+        <h3 className="text-base font-semibold text-foreground">Band Progress</h3>
+        <p className="text-xs text-muted-foreground">Weekly trajectory against your target band.</p>
+      </div>
+      <div className="h-72 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={points} margin={{ top: 12, right: 24, left: 8, bottom: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.25)" />
+            <XAxis dataKey="weekLabel" tick={{ fontSize: 12 }} />
+            <YAxis domain={[0, 9]} tick={{ fontSize: 12 }} />
+            <Tooltip
+              formatter={(value: number) => [`Band ${value.toFixed(1)}`, 'Score']}
+              labelFormatter={(label) => `Week: ${String(label)}`}
+            />
+            <Legend />
+            <ReferenceLine y={targetBand} stroke="#f97316" strokeDasharray="4 4">
+              <Label value={`Target ${targetBand.toFixed(1)}`} position="insideTopRight" />
+            </ReferenceLine>
+
+            {canShowConfidenceInterval && (
+              <>
+                <Line
+                  type="monotone"
+                  dataKey="upperBand"
+                  stroke="#93c5fd"
+                  strokeDasharray="4 4"
+                  dot={false}
+                  name="Upper confidence"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="lowerBand"
+                  stroke="#93c5fd"
+                  strokeDasharray="4 4"
+                  dot={false}
+                  name="Lower confidence"
+                />
+              </>
+            )}
+
+            <Line
+              type="monotone"
+              dataKey="band"
+              stroke="#6366f1"
+              strokeWidth={3}
+              dot={{ r: 4 }}
+              activeDot={{ r: 6 }}
+              name="Band"
+            />
+
+            {canShowAnnotations &&
+              points
+                .filter((point) => point.note)
+                .map((point) => (
+                  <ReferenceLine
+                    key={`annotation-${point.id}`}
+                    x={point.weekLabel}
+                    stroke="#22c55e"
+                    strokeDasharray="2 2"
+                  >
+                    <Label value={point.note as string} position="top" fontSize={10} />
+                  </ReferenceLine>
+                ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+};
+
+export default BandProgress;

--- a/pages/dashboard/components/widgets/BandProgress.tsx
+++ b/pages/dashboard/components/widgets/BandProgress.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import {
   CartesianGrid,
   Label,
@@ -96,4 +97,4 @@ const BandProgress = ({ points, targetBand, tier }: BandProgressProps) => {
   );
 };
 
-export default BandProgress;
+export default memo(BandProgress);

--- a/pages/dashboard/components/widgets/DailyLoginFlow.tsx
+++ b/pages/dashboard/components/widgets/DailyLoginFlow.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import type { AIInsight } from '@/hooks/useAIInsights';
+
+type DailyLoginFlowProps = {
+  streak: number;
+  insights: AIInsight[];
+  tasks: string[];
+};
+
+const DailyLoginFlow = ({ streak, insights, tasks }: DailyLoginFlowProps) => {
+  const [show, setShow] = useState(false);
+
+  const todayKey = useMemo(() => new Date().toISOString().slice(0, 10), []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const key = `dashboard-daily-login-${todayKey}`;
+    const seen = window.localStorage.getItem(key);
+    if (!seen) {
+      setShow(true);
+      window.localStorage.setItem(key, '1');
+    }
+  }, [todayKey]);
+
+  if (!show) return null;
+
+  return (
+    <div className="rounded-2xl border border-primary/40 bg-primary/5 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-base font-semibold">Welcome back 👋</h3>
+          <p className="mt-1 text-sm text-muted-foreground">You are on a {streak}-day streak.</p>
+          {insights[0] ? <p className="mt-2 text-sm">AI insight: {insights[0].text}</p> : null}
+          <ul className="mt-3 list-disc pl-5 text-sm">
+            {tasks.slice(0, 3).map((task) => (
+              <li key={task}>{task}</li>
+            ))}
+          </ul>
+        </div>
+        <button type="button" onClick={() => setShow(false)} className="text-sm text-muted-foreground underline">
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DailyLoginFlow;

--- a/pages/dashboard/components/widgets/ExportReports.tsx
+++ b/pages/dashboard/components/widgets/ExportReports.tsx
@@ -1,0 +1,65 @@
+import type { DashboardData } from '@/hooks/useDashboardData';
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import { Button } from '@/components/design-system/Button';
+
+type ExportReportsProps = {
+  tier: SubscriptionTier;
+  data: DashboardData;
+};
+
+const downloadFile = (filename: string, content: BlobPart, type: string) => {
+  if (typeof window === 'undefined') return;
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+const ExportReports = ({ tier, data }: ExportReportsProps) => {
+  const exportPdf = () => {
+    const lines = [
+      'Dashboard Report',
+      `Overall band: ${data.performance.overallBand ?? 'N/A'}`,
+      `Practice hours: ${data.performance.practiceHours}`,
+      `Study streak: ${data.performance.studyStreak}`,
+      `Mock tests: ${data.performance.mockTests}`,
+    ];
+    downloadFile('dashboard-report.pdf', lines.join('\n'), 'application/pdf');
+  };
+
+  const exportCsv = () => {
+    const header = 'weekLabel,band\n';
+    const rows = data.bandHistory.map((point) => `${point.weekLabel},${point.band}`).join('\n');
+    downloadFile('dashboard-band-history.csv', `${header}${rows}`, 'text/csv;charset=utf-8;');
+  };
+
+  const callApi = async () => {
+    await fetch('/api/dashboard/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ bandHistory: data.bandHistory }),
+    }).catch(() => {});
+  };
+
+  if (tier === 'free' || tier === 'seedling') return null;
+
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <h3 className="text-base font-semibold">Export reports</h3>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button size="sm" onClick={exportPdf}>Export PDF</Button>
+        {tier === 'owl' ? (
+          <>
+            <Button size="sm" variant="secondary" onClick={exportCsv}>Export CSV</Button>
+            <Button size="sm" variant="ghost" onClick={callApi}>Send to API</Button>
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+};
+
+export default ExportReports;

--- a/pages/dashboard/components/widgets/KpiCards.tsx
+++ b/pages/dashboard/components/widgets/KpiCards.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 
 import type { SubscriptionTier } from '@/lib/navigation/types';
 import useTierFeatures from '@/hooks/useTierFeatures';
@@ -75,4 +75,4 @@ const KpiCards = ({ tier }: KpiCardsProps) => {
   );
 };
 
-export default KpiCards;
+export default memo(KpiCards);

--- a/pages/dashboard/components/widgets/KpiCards.tsx
+++ b/pages/dashboard/components/widgets/KpiCards.tsx
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+
+import type { SubscriptionTier } from '@/lib/navigation/types';
+import useTierFeatures from '@/hooks/useTierFeatures';
+
+type KpiCardsProps = {
+  tier: SubscriptionTier;
+};
+
+type KpiMetric = {
+  id: 'overallBand' | 'studyStreak' | 'practiceHours' | 'mockTests';
+  label: string;
+  value: string;
+  delta: string;
+  trend: 'up' | 'down';
+  visible: boolean;
+};
+
+const KpiCards = ({ tier }: KpiCardsProps) => {
+  const features = useTierFeatures(tier);
+
+  const metrics = useMemo<KpiMetric[]>(() => {
+    return [
+      {
+        id: 'overallBand',
+        label: 'Overall Band',
+        value: features.predictiveAnalytics ? '7.5' : '6.5',
+        delta: features.predictiveAnalytics ? '+0.3 this month' : '+0.1 this month',
+        trend: 'up',
+        visible: true,
+      },
+      {
+        id: 'studyStreak',
+        label: 'Study Streak',
+        value: '12 days',
+        delta: '+2 days this week',
+        trend: 'up',
+        visible: true,
+      },
+      {
+        id: 'practiceHours',
+        label: 'Practice Hours',
+        value: features.realtimeAnalytics ? '28h' : '14h',
+        delta: features.realtimeAnalytics ? '+5h this week' : '+2h this week',
+        trend: 'up',
+        visible: true,
+      },
+      {
+        id: 'mockTests',
+        label: 'Mock Tests',
+        value: features.exportReports ? '9 completed' : '4 completed',
+        delta: features.exportReports ? '+3 this month' : '+1 this month',
+        trend: 'up',
+        visible: tier !== 'free' || features.studyBuddyAccess,
+      },
+    ];
+  }, [features, tier]);
+
+  return (
+    <section id="overview" className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {metrics.filter((metric) => metric.visible).map((metric) => (
+        <article
+          key={metric.id}
+          className="rounded-2xl border border-border/70 bg-card/90 p-4 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-xl"
+        >
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">{metric.label}</p>
+          <p className="mt-2 text-2xl font-semibold text-foreground">{metric.value}</p>
+          <div className="mt-3 inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-2 py-1 text-xs font-medium text-emerald-600">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-500" />
+            {metric.trend === 'up' ? '▲' : '▼'} {metric.delta}
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+};
+
+export default KpiCards;

--- a/pages/dashboard/components/widgets/Skeletons.tsx
+++ b/pages/dashboard/components/widgets/Skeletons.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 export const KpiCardsSkeleton = () => (
   <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
     {[0, 1, 2, 3].map((idx) => (
@@ -11,3 +13,7 @@ export const ChartSkeleton = () => <div className="h-72 animate-pulse rounded-2x
 export const InsightsSkeleton = () => <div className="h-24 animate-pulse rounded-2xl bg-muted/50" />;
 
 export const UsageMetersSkeleton = () => <div className="h-40 animate-pulse rounded-2xl bg-muted/50" />;
+
+const SkeletonsPageFallback = (): JSX.Element => <div className="p-6">Dashboard skeleton widgets.</div>;
+
+export default SkeletonsPageFallback;

--- a/pages/dashboard/components/widgets/Skeletons.tsx
+++ b/pages/dashboard/components/widgets/Skeletons.tsx
@@ -1,0 +1,13 @@
+export const KpiCardsSkeleton = () => (
+  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+    {[0, 1, 2, 3].map((idx) => (
+      <div key={idx} className="h-28 animate-pulse rounded-2xl bg-muted/50" />
+    ))}
+  </div>
+);
+
+export const ChartSkeleton = () => <div className="h-72 animate-pulse rounded-2xl bg-muted/50" />;
+
+export const InsightsSkeleton = () => <div className="h-24 animate-pulse rounded-2xl bg-muted/50" />;
+
+export const UsageMetersSkeleton = () => <div className="h-40 animate-pulse rounded-2xl bg-muted/50" />;

--- a/pages/dashboard/components/widgets/UsageMeters.tsx
+++ b/pages/dashboard/components/widgets/UsageMeters.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+
+import type { UsageLimitsState } from '@/hooks/useUsageLimits';
+
+type UsageMetersProps = {
+  usage: UsageLimitsState;
+  onUpgrade: () => void;
+};
+
+const getResetCountdown = (iso: string) => {
+  const diff = new Date(iso).getTime() - Date.now();
+  const days = Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
+  return `${days} day${days === 1 ? '' : 's'}`;
+};
+
+const UsageMeters = ({ usage, onUpgrade }: UsageMetersProps) => {
+  const items = useMemo(
+    () => [
+      { label: 'Reading tests', data: usage.readingTests },
+      { label: 'Writing feedback', data: usage.writingFeedback },
+      { label: 'Speaking analysis', data: usage.speakingAnalysis },
+    ],
+    [usage],
+  );
+
+  return (
+    <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <h3 className="text-base font-semibold">Monthly usage</h3>
+      <div className="mt-3 space-y-4">
+        {items.map((item) => {
+          const pct = Math.round((item.data.used / Math.max(1, item.data.limit)) * 100);
+          const exhausted = item.data.remaining <= 0;
+          return (
+            <div key={item.label}>
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span>{item.label}</span>
+                <span className="text-muted-foreground">{item.data.used} of {item.data.limit} used</span>
+              </div>
+              <div className="h-2 rounded-full bg-muted">
+                <div className={`h-2 rounded-full ${exhausted ? 'bg-orange-500' : 'bg-primary'}`} style={{ width: `${pct}%` }} />
+              </div>
+              <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
+                <span>Resets in {getResetCountdown(item.data.resetDate)}</span>
+                {exhausted ? (
+                  <button type="button" className="text-primary underline" onClick={onUpgrade}>
+                    Upgrade
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default UsageMeters;

--- a/pages/dashboard/components/widgets/WeaknessMap.tsx
+++ b/pages/dashboard/components/widgets/WeaknessMap.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+
+import type { SubscriptionTier } from '@/lib/navigation/types';
+
+type SkillScore = {
+  skill: string;
+  score: number;
+  href: string;
+};
+
+type WeaknessMapProps = {
+  tier: SubscriptionTier;
+  skillScores: SkillScore[];
+};
+
+const scoreClass = (score: number) => {
+  if (score <= 3) return 'bg-red-500/80';
+  if (score <= 5) return 'bg-orange-500/80';
+  if (score <= 7) return 'bg-yellow-500/80';
+  return 'bg-emerald-500/80';
+};
+
+const WeaknessMap = ({ tier, skillScores }: WeaknessMapProps) => {
+  if (tier !== 'rocket' && tier !== 'owl') {
+    return null;
+  }
+
+  return (
+    <section id="practice" className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+      <div className="mb-4">
+        <h3 className="text-base font-semibold text-foreground">Weakness Heatmap</h3>
+        <p className="text-xs text-muted-foreground">
+          Click a block to jump to targeted practice.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {skillScores.map((item) => (
+          <Link
+            key={item.skill}
+            href={item.href}
+            className="group rounded-xl border border-border/60 bg-background/60 p-3 transition hover:-translate-y-1 hover:shadow-lg"
+          >
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">{item.skill}</p>
+            <div className="mt-2 flex items-center gap-2">
+              <span className={`inline-block h-4 w-4 rounded ${scoreClass(item.score)}`} />
+              <span className="text-sm font-semibold text-foreground">{item.score.toFixed(1)}</span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default WeaknessMap;

--- a/pages/dashboard/components/widgets/WeaknessMap.tsx
+++ b/pages/dashboard/components/widgets/WeaknessMap.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import Link from 'next/link';
 
 import type { SubscriptionTier } from '@/lib/navigation/types';
@@ -52,4 +53,4 @@ const WeaknessMap = ({ tier, skillScores }: WeaknessMapProps) => {
   );
 };
 
-export default WeaknessMap;
+export default memo(WeaknessMap);

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -560,7 +560,6 @@ const Dashboard: NextPage = () => {
 
   return (
     <FreeView>
-      <>
       <Head>
         <title>Dashboard — Gramor_X</title>
       </Head>
@@ -1266,7 +1265,6 @@ const Dashboard: NextPage = () => {
           </div>
         </div>
       )}
-      </>
     </FreeView>
   );
 };

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -519,15 +519,15 @@ const Dashboard: NextPage = () => {
   if (loading) return loadingSkeleton;
 
   if (subscriptionTier === 'seedling') {
-    return <SeedlingView />;
+    return <SeedlingView userId={sessionUserId} targetBand={goalBand ?? 7} />;
   }
 
   if (subscriptionTier === 'rocket') {
-    return <RocketView />;
+    return <RocketView userId={sessionUserId} targetBand={goalBand ?? 7} />;
   }
 
   if (subscriptionTier === 'owl') {
-    return <OwlView />;
+    return <OwlView userId={sessionUserId} targetBand={goalBand ?? 7} />;
   }
 
   const accentClass: Record<NonNullable<InnovationTile['accent']>, string> = {

--- a/utils/predictiveEngine.ts
+++ b/utils/predictiveEngine.ts
@@ -1,0 +1,45 @@
+import type { BandHistoryPoint, StudyLog } from '@/hooks/useDashboardData';
+
+export type PredictiveProjection = {
+  predictedBand: number;
+  confidencePercentage: number;
+  estimatedDate: string;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export function predictiveEngine(
+  bandHistory: BandHistoryPoint[],
+  studyFrequency: Pick<StudyLog, 'minutes'>[],
+): PredictiveProjection {
+  const sorted = [...bandHistory].sort((a, b) => a.weekLabel.localeCompare(b.weekLabel));
+  const latestBand = sorted.at(-1)?.band ?? 0;
+  const priorBand = sorted.at(-2)?.band ?? latestBand;
+  const trend = latestBand - priorBand;
+
+  const avgMinutes =
+    studyFrequency.length > 0
+      ? studyFrequency.reduce((sum, item) => sum + Number(item.minutes || 0), 0) /
+        studyFrequency.length
+      : 0;
+
+  const effortBoost = clamp(avgMinutes / 600, 0, 0.6);
+  const projectedGain = clamp(trend * 0.8 + effortBoost, -0.2, 0.8);
+  const predictedBand = clamp(latestBand + projectedGain, 0, 9);
+
+  const confidenceFromSamples = clamp(sorted.length / 12, 0.2, 1);
+  const confidenceFromConsistency = clamp(avgMinutes / 420, 0.25, 1);
+  const confidencePercentage = Math.round((confidenceFromSamples * 0.6 + confidenceFromConsistency * 0.4) * 100);
+
+  const etaDays = Math.round(clamp((Math.max(0.1, 8 - predictedBand) / Math.max(0.08, projectedGain + 0.1)) * 7, 14, 180));
+  const estimated = new Date();
+  estimated.setDate(estimated.getDate() + etaDays);
+
+  return {
+    predictedBand: Number(predictedBand.toFixed(1)),
+    confidencePercentage,
+    estimatedDate: estimated.toISOString(),
+  };
+}
+
+export default predictiveEngine;


### PR DESCRIPTION
### Motivation

- Provide separate dashboard experiences per subscription tier and route them dynamically at the page level.
- Centralize feature gating so child components depend on a single source of truth for tier capabilities.

### Description

- Added `hooks/useTierFeatures.ts` which exposes tier-configured feature flags and limits for `free`, `seedling`, `rocket`, and `owl` tiers (includes `aiWritingLimit`, `speakingAnalysisLimit`, `predictiveAnalytics`, `realtimeAnalytics`, `liveCoaching`, `exportReports`, `studyBuddyAccess`).
- Added placeholder tier view components under `pages/dashboard/components/tiers/`: `FreeView`, `SeedlingView`, `RocketView`, and `OwlView`.
- Updated `pages/dashboard/index.tsx` to detect tier from Supabase auth context (`user_metadata.tier` and `app_metadata.tier`), fall back to `profile.tier` then `'free'`, and render the matching tier component at the top level so child components remain tier-agnostic.
- Introduced helper functions `isSubscriptionTier` and `getTierFromAuthContext` and wrapped the existing default dashboard content with `FreeView` when appropriate.

### Testing

- Ran lint for the changed files with `npm run lint -- --file pages/dashboard/index.tsx --file hooks/useTierFeatures.ts --file pages/dashboard/components/tiers/*`, which failed in this environment because `next` was not available (`next: not found`).
- Attempted a Playwright navigation/screenshot of `http://127.0.0.1:3000/dashboard`, which failed with `ERR_EMPTY_RESPONSE` because no app server was running in the environment.
- No unit tests were added; manual smoke validation should be performed in a running dev environment to confirm tier detection and view routing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a114fea6f08328998a1ffa05cc2129)