### PR TITLE
Prevent post-auth redirects back to auth pages (fix redirect loop)

### DIFF
--- a/components/auth/AuthOptions.tsx
+++ b/components/auth/AuthOptions.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/design-system/icons';
 import { SectionLabel } from '@/components/design-system/SectionLabel';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
-import { destinationByRole } from '@/lib/routeAccess';
+import { destinationByRole, isSafePostAuthRedirect } from '@/lib/routeAccess';
 
 type AuthMode = 'login' | 'signup';
 type OAuthProvider = 'apple' | 'google' | 'facebook';
@@ -33,7 +33,7 @@ export default function AuthOptions({ mode }: AuthOptionsProps) {
 
   const ref = mode === 'signup' && typeof router.query.ref === 'string' ? router.query.ref : '';
   const rawNext = typeof router.query.next === 'string' ? router.query.next : '';
-  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '';
+  const next = isSafePostAuthRedirect(rawNext) ? rawNext : '';
   const actionVerb = mode === 'login' ? 'Sign in' : 'Sign up';
   const sharedQS = useMemo(() => {
     const qp = new URLSearchParams();

--- a/lib/routeAccess.test.ts
+++ b/lib/routeAccess.test.ts
@@ -7,6 +7,7 @@ import {
   isPublicRoute,
   isGuestOnlyRoute,
   redirectByRole,
+  isSafePostAuthRedirect,
 } from './routeAccess';
 
 test('canAccess respects role gates', () => {
@@ -39,4 +40,13 @@ test('redirectByRole sends unverified users to verification', () => {
 
 test('verification page is considered public', () => {
   assert.strictEqual(isPublicRoute('/auth/verify'), true);
+});
+
+
+test('isSafePostAuthRedirect blocks auth routes and allows app routes', () => {
+  assert.strictEqual(isSafePostAuthRedirect('/dashboard'), true);
+  assert.strictEqual(isSafePostAuthRedirect('/progress?tab=weekly'), true);
+  assert.strictEqual(isSafePostAuthRedirect('/login/email?role=student'), false);
+  assert.strictEqual(isSafePostAuthRedirect('/auth/verify'), false);
+  assert.strictEqual(isSafePostAuthRedirect('//evil.com'), false);
 });

--- a/lib/routeAccess.ts
+++ b/lib/routeAccess.ts
@@ -47,6 +47,16 @@ const matchesRoute = (path: string, allowlist: RouteMatcher[]) => {
 export const isPublicRoute = (path: string) => matchesRoute(path, PUBLIC_ROUTES);
 export const isGuestOnlyRoute = (path: string) => matchesRoute(path, GUEST_ONLY_ROUTES);
 
+/**
+ * Validates a `next` path used after auth so we don't redirect users back into auth screens.
+ */
+export const isSafePostAuthRedirect = (path: string): boolean => {
+  if (!path || !path.startsWith('/') || path.startsWith('//')) return false;
+  if (isGuestOnlyRoute(path)) return false;
+  if (/^\/auth\/(login|signup|register|mfa|verify)(\/|$)/.test(path)) return false;
+  return true;
+};
+
 /** Role extraction */
 export const getUserRole = (user: User | null | undefined): AppRole | null =>
   extractRole(user);

--- a/middleware.ts
+++ b/middleware.ts
@@ -47,6 +47,12 @@ function pathStartsWithAny(pathname: string, prefixes: string[]) {
   return prefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 }
 
+function isSafePostAuthRedirect(path: string | null) {
+  if (!path || !path.startsWith('/') || path.startsWith('//')) return false;
+  if (pathStartsWithAny(path, AUTH_PAGES)) return false;
+  return true;
+}
+
 // ensure refreshed cookies from Supabase are preserved when redirecting
 function redirectWithCookies(from: NextResponse, url: URL) {
   const r = NextResponse.redirect(url);
@@ -173,7 +179,7 @@ export async function middleware(req: NextRequest) {
   if (authState.authenticated && isAuthPage) {
     const url = req.nextUrl.clone();
     const nextParam = req.nextUrl.searchParams.get('next');
-    url.pathname = nextParam && nextParam.startsWith('/') ? nextParam : '/';
+    url.pathname = isSafePostAuthRedirect(nextParam) ? nextParam : '/';
     url.search = '';
     return redirectWithCookies(res, url);
   }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -22,7 +22,7 @@ import { env } from '@/lib/env';
 import { LocaleProvider, useLocale } from '@/lib/locale';
 import { initIdleTimeout } from '@/utils/idleTimeout';
 import useRouteGuard from '@/hooks/useRouteGuard';
-import { destinationByRole } from '@/lib/routeAccess';
+import { destinationByRole, isSafePostAuthRedirect } from '@/lib/routeAccess';
 import { refreshClientFlags, flagsHydratedRef } from '@/lib/flags/refresh';
 import { InstalledAppProvider } from '@/hooks/useInstalledApp';
 
@@ -151,7 +151,7 @@ function useAuthBridge() {
         const url = new URL(window.location.href);
         const next = url.searchParams.get('next');
         const target =
-          next && next.startsWith('/')
+          isSafePostAuthRedirect(next)
             ? next
             : destinationByRole(session.user) ?? '/';
         router.replace(target);
@@ -169,7 +169,7 @@ function useAuthBridge() {
         if (event === 'SIGNED_IN' && sessionNow?.user) {
           const url = new URL(window.location.href);
           const next = url.searchParams.get('next');
-          if (next && next.startsWith('/')) {
+          if (isSafePostAuthRedirect(next)) {
             router.replace(next);
           } else if (isAuthPage(router.pathname)) {
             router.replace(destinationByRole(sessionNow.user));

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -10,7 +10,7 @@ import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
-import { destinationByRole } from '@/lib/routeAccess';
+import { destinationByRole, isSafePostAuthRedirect } from '@/lib/routeAccess';
 import { isValidEmail } from '@/utils/validation';
 import { getAuthErrorMessage } from '@/lib/authErrors';
 import useEmailLoginMFA from '@/hooks/useEmailLoginMFA';
@@ -156,7 +156,7 @@ export default function LoginWithEmail() {
         await recordLoginEvent(body.session);
 
         const rawNext = typeof router.query.next === 'string' ? router.query.next : '';
-        const safeNext = rawNext && rawNext.startsWith('/') && rawNext !== '/login' ? rawNext : null;
+        const safeNext = isSafePostAuthRedirect(rawNext) ? rawNext : null;
 
         const fallback = user ? destinationByRole(user) : '/dashboard';
         const target = safeNext ?? fallback;


### PR DESCRIPTION
### Motivation
- Users signing in were sometimes bounced back to auth pages (e.g. `/login/email?...`) causing a redirect loop instead of landing in the app, so `next` targets need validation before post-auth navigation. 
- The change centralizes a safety check so client, server (middleware) and OAuth flows all agree on what a safe post-auth redirect is.

### Description
- Added `isSafePostAuthRedirect` in `lib/routeAccess.ts` to validate `next` URLs and block guest/auth pages and malformed targets (e.g. `//evil.com`).
- Updated client-side flows to use the helper: email login flow in `pages/login/email.tsx`, the app auth bridge in `pages/_app.tsx`, and auth UI in `components/auth/AuthOptions.tsx` now only honor safe `next` redirects.
- Hardened edge behavior in `middleware.ts` with an equivalent `isSafePostAuthRedirect` check so authenticated users on auth pages are not bounced back to auth screens via `next`.
- Added a unit test `lib/routeAccess.test.ts` to cover the new safe-redirect logic (allows app routes, blocks auth routes and malformed origins).

### Testing
- Added `lib/routeAccess.test.ts` with assertions for `isSafePostAuthRedirect`, but automated test execution was not possible in this environment due to missing dependencies and registry access issues.
- Attempted to run `npx tsx --test lib/routeAccess.test.ts`, which failed with an npm registry permission error, and attempted `./node_modules/.bin/tsx --test lib/routeAccess.test.ts`, which failed because `node_modules` is not present.
- Static verification performed by running repository searches and diffs to confirm the new helper is used consistently across `pages/login/email.tsx`, `pages/_app.tsx`, `components/auth/AuthOptions.tsx`, and `middleware.ts` and the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a1d2602c8328b19d4d5aa549b87a)