### PR TITLE
feat(onboarding): generate study plan with AI fallback

### DIFF
--- a/pages/api/ai/generate-plan.ts
+++ b/pages/api/ai/generate-plan.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
 import {
-  buildRuleBasedPlan,
+  generateOnboardingStudyPlan,
   onboardingPayloadSchema,
   studyPlanSchema,
   type StudyPlan,
@@ -33,8 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   try {
     const input = parsedInput.data;
 
-    // Deterministic rule-based output (no OpenAI usage).
-    const generated = buildRuleBasedPlan(input);
+    const generated = await generateOnboardingStudyPlan(input);
     const validated = studyPlanSchema.safeParse(generated);
     if (!validated.success) {
       return res.status(500).json({ error: 'Failed to build a valid study plan' });

--- a/tests/lib/ai.client-selection.test.ts
+++ b/tests/lib/ai.client-selection.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+describe('resolveProviderType', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.AI_PROVIDER;
+    delete process.env.GX_AI_PROVIDER;
+    delete process.env.PUBLICAI_API_KEY;
+    delete process.env.GROQ_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it('uses explicitly selected provider when its key exists', async () => {
+    process.env.AI_PROVIDER = 'publicai';
+    process.env.PUBLICAI_API_KEY = 'pk_test';
+
+    const mod = await import('@/lib/ai/client');
+    expect(mod.resolveProviderType()).toBe('publicai');
+  });
+
+  it('falls back to best available provider when explicit key is missing', async () => {
+    process.env.AI_PROVIDER = 'publicai';
+    process.env.GROQ_API_KEY = 'gsk_test';
+
+    const mod = await import('@/lib/ai/client');
+    expect(mod.resolveProviderType()).toBe('groq');
+  });
+
+  it('uses GX_AI_PROVIDER as a compatibility fallback', async () => {
+    process.env.GX_AI_PROVIDER = 'deepseek';
+    process.env.DEEPSEEK_API_KEY = 'sk_test';
+
+    const mod = await import('@/lib/ai/client');
+    expect(mod.resolveProviderType()).toBe('deepseek');
+  });
+});

--- a/tests/lib/onboarding.ai-study-plan.test.ts
+++ b/tests/lib/onboarding.ai-study-plan.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/ai/client', () => ({
+  aiClient: {
+    generateChatCompletion: vi.fn(),
+  },
+  isAIAvailable: true,
+}));
+
+import { aiClient } from '@/lib/ai/client';
+import { buildRuleBasedPlan, generateOnboardingStudyPlan, type OnboardingPayload } from '@/lib/onboarding/aiStudyPlan';
+
+const baseInput: OnboardingPayload = {
+  targetBand: 7,
+  examDate: '2026-08-01',
+  readingLevel: 3,
+  writingLevel: 2,
+  listeningLevel: 4,
+  speakingLevel: 3,
+  learningStyle: 'Mixed',
+};
+
+describe('generateOnboardingStudyPlan', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses AI JSON output when valid', async () => {
+    vi.mocked(aiClient.generateChatCompletion).mockResolvedValueOnce(`\
+\`\`\`json
+{"duration_weeks":8,"daily_hours":2,"priority_skill":"Writing","weekly_plan":[{"week":1,"focus":"Writing bootcamp","tasks":["Task A","Task B","Task C"]}]}
+\`\`\``);
+
+    const plan = await generateOnboardingStudyPlan(baseInput);
+
+    expect(plan.priority_skill).toBe('Writing');
+    expect(plan.duration_weeks).toBe(8);
+    expect(plan.weekly_plan[0]?.tasks).toHaveLength(3);
+  });
+
+  it('falls back to rule-based plan when AI output is invalid', async () => {
+    vi.mocked(aiClient.generateChatCompletion).mockResolvedValueOnce('not-json');
+
+    const plan = await generateOnboardingStudyPlan(baseInput);
+    const fallback = buildRuleBasedPlan(baseInput);
+
+    expect(plan).toEqual(fallback);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide an AI-backed study plan generator that uses user onboarding responses to create personalized plans while preserving the existing deterministic rule-based generator as a safe fallback.

### Description
- Added `generateOnboardingStudyPlan` in `lib/onboarding/aiStudyPlan.ts` to call the configured AI provider, parse fenced or raw JSON responses, and normalize them into the existing `StudyPlan` shape.
- Implemented `extractJson` and `buildAIPrompt` helpers and wired `aiClient`/`isAIAvailable` so AI is used only when available and valid.
- Updated `/api/ai/generate-plan` to call `generateOnboardingStudyPlan` and validate/persist the resulting plan instead of always using the rule-based generator.
- Added unit tests (`tests/lib/onboarding.ai-study-plan.test.ts`) to verify valid AI JSON handling and fallback behavior.

### Testing
- Added a Vitest unit test file `tests/lib/onboarding.ai-study-plan.test.ts` which covers both successful AI JSON parsing and fallback to the rule-based plan, and the tests are present in the repository.
- Attempted to run `npx vitest run tests/lib/onboarding.ai-study-plan.test.ts` but the run failed in this environment due to npm registry access restrictions (403) preventing installation of `vitest`.
- Attempted to run a local `./node_modules/.bin/vitest` binary but it was not available because dependencies are not installed in this container, so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1aef17ac88328be3819049b79badc)