### PR TITLE
Fix onboarding finish redirect loop by reliably marking profile complete

### DIFF
--- a/pages/api/onboarding/complete.ts
+++ b/pages/api/onboarding/complete.ts
@@ -83,6 +83,7 @@ export default async function handler(
   const patch: Record<string, any> = {
     onboarding_step: step,
     onboarding_complete: true,
+    onboarding_completed_at: new Date().toISOString(),
     draft: false,
   };
 
@@ -93,7 +94,7 @@ export default async function handler(
   const { error: updateError } = await supabase
     .from('profiles')
     .update(patch)
-    .eq('user_id', user.id);
+    .or(`user_id.eq.${user.id},id.eq.${user.id}`);
 
   if (updateError) {
     console.error('onboarding/complete update error:', updateError);


### PR DESCRIPTION
### Motivation
- Users were getting redirected back into onboarding after pressing Finish because the profile state used by server/middleware checks wasn’t reliably updated (missing `onboarding_completed_at` and edge cases where the profile row key differed). 

### Description
- Set `onboarding_completed_at` and updated the Supabase `profiles` update to match by either `user_id` or `id` in `pages/api/onboarding/complete.ts` so completion persists regardless of profile key shape and prevents redirect loops.

### Testing
- Ran `npm run lint -- --file pages/api/onboarding/complete.ts`, which failed in this environment due to the missing `next` binary / node_modules and so no runtime lint validation could be completed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1c3135148832890d73f04a8416c41)