### PR TITLE
Canonicalize host in middleware to prevent www redirect loop

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -127,6 +127,16 @@ async function loadAuthState(req: NextRequest, res: NextResponse): Promise<AuthS
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
+  const hostHeader = req.headers.get('x-forwarded-host') ?? req.headers.get('host');
+  const host = hostHeader?.split(',')[0]?.trim().toLowerCase();
+
+  if (host && host.startsWith('www.')) {
+    const canonicalUrl = req.nextUrl.clone();
+    canonicalUrl.host = host.slice(4);
+    canonicalUrl.protocol = 'https:';
+    return NextResponse.redirect(canonicalUrl, 308);
+  }
+
   // Skip static and API routes (we only guard real pages)
   if (
     pathname.startsWith('/_next') || // includes /_next/data prefetches

--- a/middleware.ts
+++ b/middleware.ts
@@ -67,8 +67,8 @@ function assignRedirectTarget(url: URL, targetPath: string, fallbackPath: string
 }
 
 // ensure refreshed cookies from Supabase are preserved when redirecting
-function redirectWithCookies(from: NextResponse, url: URL) {
-  const r = NextResponse.redirect(url);
+function redirectWithCookies(from: NextResponse, url: URL, status?: 307 | 308) {
+  const r = NextResponse.redirect(url, status);
   // copy any cookies written to `from` (e.g., refreshed tokens) into the redirect
   for (const c of from.cookies.getAll()) r.cookies.set(c);
   return r;
@@ -127,16 +127,6 @@ async function loadAuthState(req: NextRequest, res: NextResponse): Promise<AuthS
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
-  const hostHeader = req.headers.get('x-forwarded-host') ?? req.headers.get('host');
-  const host = hostHeader?.split(',')[0]?.trim().toLowerCase();
-
-  if (host && host.startsWith('www.')) {
-    const canonicalUrl = req.nextUrl.clone();
-    canonicalUrl.host = host.slice(4);
-    canonicalUrl.protocol = 'https:';
-    return NextResponse.redirect(canonicalUrl, 308);
-  }
-
   // Skip static and API routes (we only guard real pages)
   if (
     pathname.startsWith('/_next') || // includes /_next/data prefetches
@@ -154,6 +144,16 @@ export async function middleware(req: NextRequest) {
 
   const res = NextResponse.next();
   const authState = await loadAuthState(req, res);
+
+  const hostHeader = req.headers.get('x-forwarded-host') ?? req.headers.get('host');
+  const host = hostHeader?.split(',')[0]?.trim().toLowerCase();
+
+  if (host && host.startsWith('www.')) {
+    const canonicalUrl = req.nextUrl.clone();
+    canonicalUrl.host = host.slice(4);
+    canonicalUrl.protocol = 'https:';
+    return redirectWithCookies(res, canonicalUrl, 308);
+  }
 
   const isAuthPage = pathStartsWithAny(pathname, AUTH_PAGES);
   const isProtected = pathStartsWithAny(pathname, PROTECTED_PREFIXES);


### PR DESCRIPTION
### Motivation
- Prevent browsers from getting stuck in host-level redirect loops when requests arrive at `www.` hosts by canonicalizing to the apex domain before any auth/onboarding or premium redirect logic runs.

### Description
- Add an early host canonicalization in `middleware.ts` that reads `x-forwarded-host`/`host`, normalizes and strips a leading `www.`, clones `req.nextUrl` to preserve path and query, forces `https`, and issues a `308` redirect to the apex host.

### Testing
- Attempted `npm run lint -- --file middleware.ts`, which failed in this environment because the `next` binary is not available (`sh: 1: next: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fcf9573883289957b794efe02b2f)