### PR TITLE
Phase 1: finalize profile-domain extraction and strict identity-only cutover

### DIFF
--- a/components/dashboard/UpgradeModal.tsx
+++ b/components/dashboard/UpgradeModal.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import type { SubscriptionTier } from '@/types/dashboard';
+import type { SubscriptionTier } from '@/lib/navigation/types';
 
 type UpgradeModalProps = {
   open: boolean;

--- a/hooks/useDashboardAggregate.ts
+++ b/hooks/useDashboardAggregate.ts
@@ -1,0 +1,32 @@
+import useSWR from 'swr';
+import type { DashboardAggregate } from '@/lib/services/dashboardService';
+
+type DashboardAggregateResponse = {
+  ok: boolean;
+  aggregate: DashboardAggregate;
+};
+
+async function fetchDashboardAggregate(url: string): Promise<DashboardAggregateResponse> {
+  const response = await fetch(url, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Dashboard aggregate request failed (${response.status})`);
+  }
+  return (await response.json()) as DashboardAggregateResponse;
+}
+
+export function useDashboardAggregate(enabled = true, suspense = false) {
+  const swr = useSWR<DashboardAggregateResponse>(enabled ? '/api/dashboard/aggregate' : null, fetchDashboardAggregate, {
+    revalidateOnFocus: false,
+    suspense,
+  });
+
+  return {
+    aggregate: swr.data?.aggregate ?? null,
+    loading: swr.isLoading,
+    error: swr.error ? swr.error.message : null,
+    refresh: swr.mutate,
+    suspenseEnabled: suspense,
+  };
+}
+
+export default useDashboardAggregate;

--- a/hooks/useEntitlement.ts
+++ b/hooks/useEntitlement.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import useSWR from 'swr';
 import type { SubscriptionTier } from '@/lib/navigation/types';
 import {
   featureMinTier,
@@ -8,24 +9,59 @@ import {
   type EntitlementFeatureKey,
 } from '@/lib/config/featureFlags';
 
+type EntitlementApiResponse = {
+  ok: boolean;
+  plan: 'free' | 'starter' | 'booster' | 'master';
+  tier: SubscriptionTier;
+  status: string | null;
+  featureFlags: Record<string, boolean>;
+};
+
 export type UseEntitlementResult = {
   tier: SubscriptionTier;
+  plan: EntitlementApiResponse['plan'];
+  status: string | null;
+  loading: boolean;
   canAccessFeature: (feature: EntitlementFeatureKey) => boolean;
   hasTier: (minTier: SubscriptionTier) => boolean;
   minTierForFeature: (feature: EntitlementFeatureKey) => SubscriptionTier;
 };
 
+async function fetchEntitlements(url: string): Promise<EntitlementApiResponse> {
+  const response = await fetch(url, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch entitlements (${response.status})`);
+  }
+  return (await response.json()) as EntitlementApiResponse;
+}
+
 export function useEntitlement(tier: string | null | undefined): UseEntitlementResult {
+  const { data, isLoading } = useSWR<EntitlementApiResponse>('/api/entitlements', fetchEntitlements, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  });
+
   return useMemo(() => {
-    const normalizedTier = normalizeTier(tier);
+    const normalizedTier = data?.tier ?? normalizeTier(tier);
+    const plan = data?.plan ?? 'free';
+    const status = data?.status ?? null;
+    const dynamicFlags = data?.featureFlags ?? {};
 
     return {
       tier: normalizedTier,
-      canAccessFeature: (feature: EntitlementFeatureKey) => isFeatureEnabledForTier(feature, normalizedTier),
+      plan,
+      status,
+      loading: isLoading,
+      canAccessFeature: (feature: EntitlementFeatureKey) => {
+        if (typeof dynamicFlags[feature] === 'boolean') {
+          return Boolean(dynamicFlags[feature]);
+        }
+        return isFeatureEnabledForTier(feature, normalizedTier);
+      },
       hasTier: (minTier: SubscriptionTier) => hasTierAccess(normalizedTier, minTier),
       minTierForFeature: (feature: EntitlementFeatureKey) => featureMinTier[feature],
     };
-  }, [tier]);
+  }, [data?.featureFlags, data?.plan, data?.status, data?.tier, isLoading, tier]);
 }
 
 export default useEntitlement;

--- a/lib/obs/domainLogger.ts
+++ b/lib/obs/domainLogger.ts
@@ -1,0 +1,26 @@
+import { createRequestLogger } from '@/lib/obs/logger';
+
+export type DomainEventName =
+  | 'ai.recommendation.generated'
+  | 'ai.recommendation.regenerated'
+  | 'subscription.changed'
+  | 'onboarding.completed'
+  | 'onboarding.survey_saved'
+  | 'score.updated'
+  | 'dashboard.aggregate_fetched';
+
+export function createDomainLogger(route: string, context: Record<string, unknown> = {}) {
+  const logger = createRequestLogger(route, context);
+
+  return {
+    info(event: DomainEventName, metadata: Record<string, unknown> = {}) {
+      logger.info(event, metadata);
+    },
+    warn(event: DomainEventName, metadata: Record<string, unknown> = {}) {
+      logger.warn(event, metadata);
+    },
+    error(event: DomainEventName, metadata: Record<string, unknown> = {}) {
+      logger.error(event, metadata);
+    },
+  };
+}

--- a/lib/obs/domainLogger.ts
+++ b/lib/obs/domainLogger.ts
@@ -3,6 +3,7 @@ import { createRequestLogger } from '@/lib/obs/logger';
 export type DomainEventName =
   | 'ai.recommendation.generated'
   | 'ai.recommendation.regenerated'
+  | 'ai.assist.generated'
   | 'subscription.changed'
   | 'onboarding.completed'
   | 'onboarding.survey_saved'

--- a/lib/repositories/aiAssistRepository.ts
+++ b/lib/repositories/aiAssistRepository.ts
@@ -1,0 +1,24 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type RepoClient = SupabaseClient<any, 'public', any>;
+
+export type AiAssistFeature = 'paraphrase' | 'speaking_hint';
+
+export async function insertAiAssistLog(
+  client: RepoClient,
+  input: {
+    userId: string;
+    feature: AiAssistFeature;
+    payload: Record<string, unknown>;
+    result: Record<string, unknown>;
+    tokensUsed?: number | null;
+  },
+) {
+  return client.from('ai_assist_logs').insert({
+    user_id: input.userId,
+    feature: input.feature,
+    input: JSON.stringify(input.payload),
+    output: input.result,
+    tokens_used: input.tokensUsed ?? null,
+  });
+}

--- a/lib/repositories/aiRepository.ts
+++ b/lib/repositories/aiRepository.ts
@@ -12,6 +12,17 @@ export async function getActiveAiRecommendations(client: RepoClient, userId: str
     .order('created_at', { ascending: false });
 }
 
+export async function getLatestAiRecommendation(client: RepoClient, userId: string) {
+  return client
+    .from('ai_recommendations')
+    .select('id, type, content, created_at')
+    .eq('user_id', userId)
+    .eq('active', true)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle<{ id: string; type: string; content: { sequence?: string[] } | null }>();
+}
+
 export async function createAiDiagnostic(
   client: RepoClient,
   userId: string,

--- a/lib/repositories/aiRepository.ts
+++ b/lib/repositories/aiRepository.ts
@@ -8,6 +8,8 @@ export async function getActiveAiRecommendations(client: RepoClient, userId: str
     .select('id, user_id, type, priority, content, model_version, created_at, expires_at, consumed_at')
     .eq('user_id', userId)
     .eq('active', true)
+    .is('consumed_at', null)
+    .or('expires_at.is.null,expires_at.gt.now()')
     .order('priority', { ascending: false })
     .order('created_at', { ascending: false });
 }
@@ -15,12 +17,35 @@ export async function getActiveAiRecommendations(client: RepoClient, userId: str
 export async function getLatestAiRecommendation(client: RepoClient, userId: string) {
   return client
     .from('ai_recommendations')
-    .select('id, type, content, created_at')
+    .select('id, type, content, model_version, created_at, expires_at, consumed_at')
     .eq('user_id', userId)
     .eq('active', true)
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle<{ id: string; type: string; content: { sequence?: string[] } | null }>();
+}
+
+export async function createAiRecommendation(
+  client: RepoClient,
+  input: {
+    userId: string;
+    type: string;
+    priority?: number;
+    content: Record<string, unknown>;
+    modelVersion?: string | null;
+    expiresAt?: string | null;
+  },
+) {
+  return client.from('ai_recommendations').insert({
+    user_id: input.userId,
+    type: input.type,
+    priority: input.priority ?? 1,
+    content: input.content,
+    model_version: input.modelVersion ?? null,
+    expires_at: input.expiresAt ?? null,
+    consumed_at: null,
+    active: true,
+  });
 }
 
 export async function createAiDiagnostic(

--- a/lib/repositories/profileRepository.ts
+++ b/lib/repositories/profileRepository.ts
@@ -2,6 +2,233 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 
 export type RepoClient = SupabaseClient<any, 'public', any>;
 
+export async function getProfileByUserId(client: RepoClient, userId: string) {
+  const [profileRes, prefsRes, sessionRes, aiRes, notifRes, teacherRes, subRes] = await Promise.all([
+    client
+      .from('profiles')
+      .select('id, email, first_name, last_name, avatar_url, role, locale, timezone, created_at, updated_at')
+      .eq('id', userId)
+      .maybeSingle(),
+    client
+      .from('user_preferences')
+      .select('preferred_language, language_preference, country, study_prefs, goal_reason, learning_style, time_commitment, time_commitment_min, days_per_week, study_days, study_minutes_per_day, daily_quota_goal, exam_date, goal_band, weaknesses, focus_topics')
+      .eq('user_id', userId)
+      .maybeSingle(),
+    getOnboardingSession(client, userId),
+    client
+      .from('ai_recommendations')
+      .select('content')
+      .eq('user_id', userId)
+      .eq('active', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle<{ content: Record<string, unknown> | null }>(),
+    client
+      .from('notification_settings')
+      .select('notification_channels, whatsapp_opt_in, marketing_opt_in, quiet_hours_start, quiet_hours_end, phone')
+      .eq('user_id', userId)
+      .maybeSingle(),
+    client
+      .from('teacher_profiles')
+      .select('onboarding_completed, approved, subjects, bio, experience_years, cv_url')
+      .eq('user_id', userId)
+      .maybeSingle(),
+    client
+      .from('subscriptions')
+      .select('plan_id, status, seats, metadata')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  if (profileRes.error) return { data: null, error: profileRes.error };
+
+  const profile = profileRes.data;
+  if (!profile) return { data: null, error: null };
+
+  const fullName = [profile.first_name, profile.last_name].filter(Boolean).join(' ').trim();
+  const subscriptionMetadata = (subRes.data?.metadata ?? {}) as Record<string, unknown>;
+
+  return {
+    data: {
+      ...profile,
+      user_id: profile.id,
+      full_name: fullName || null,
+      plan: subRes.data?.plan_id ?? 'free',
+      membership: subRes.data?.plan_id ?? 'free',
+      tier: subRes.data?.plan_id ?? 'free',
+      subscription_status: subRes.data?.status ?? null,
+      buddy_seats: subRes.data?.seats ?? null,
+      buddy_seats_used: typeof subscriptionMetadata.seats_used === 'number' ? subscriptionMetadata.seats_used : null,
+      preferred_language: prefsRes.data?.preferred_language ?? profile.locale,
+      language_preference: prefsRes.data?.language_preference ?? profile.locale,
+      country: prefsRes.data?.country ?? null,
+      study_prefs: prefsRes.data?.study_prefs ?? [],
+      goal_reason: prefsRes.data?.goal_reason ?? [],
+      learning_style: prefsRes.data?.learning_style ?? null,
+      time_commitment: prefsRes.data?.time_commitment ?? null,
+      time_commitment_min: prefsRes.data?.time_commitment_min ?? null,
+      days_per_week: prefsRes.data?.days_per_week ?? null,
+      study_days: prefsRes.data?.study_days ?? [],
+      study_minutes_per_day: prefsRes.data?.study_minutes_per_day ?? null,
+      daily_quota_goal: prefsRes.data?.daily_quota_goal ?? null,
+      exam_date: prefsRes.data?.exam_date ?? null,
+      goal_band: prefsRes.data?.goal_band ?? null,
+      weaknesses: prefsRes.data?.weaknesses ?? [],
+      focus_topics: prefsRes.data?.focus_topics ?? [],
+      onboarding_step: sessionRes.data?.current_step ?? 0,
+      onboarding_complete: sessionRes.data?.status === 'completed',
+      setup_complete: sessionRes.data?.status === 'completed',
+      ai_recommendation: aiRes.data?.content ?? {},
+      notification_channels: notifRes.data?.notification_channels ?? [],
+      whatsapp_opt_in: notifRes.data?.whatsapp_opt_in ?? false,
+      marketing_opt_in: notifRes.data?.marketing_opt_in ?? false,
+      quiet_hours_start: notifRes.data?.quiet_hours_start ?? null,
+      quiet_hours_end: notifRes.data?.quiet_hours_end ?? null,
+      phone: notifRes.data?.phone ?? null,
+      teacher_onboarding_completed: teacherRes.data?.onboarding_completed ?? false,
+      teacher_approved: teacherRes.data?.approved ?? false,
+      teacher_subjects: teacherRes.data?.subjects ?? [],
+      teacher_bio: teacherRes.data?.bio ?? null,
+      teacher_experience_years: teacherRes.data?.experience_years ?? null,
+      teacher_cv_url: teacherRes.data?.cv_url ?? null,
+    },
+    error: null,
+  };
+}
+
+export async function getProfileRole(client: RepoClient, userId: string) {
+  return client
+    .from('profiles')
+    .select('id, role')
+    .eq('id', userId)
+    .maybeSingle<{ id: string; role: string | null }>();
+}
+
+export async function updateProfileByUserId(client: RepoClient, userId: string, patch: Record<string, unknown>) {
+  return client.from('profiles').update(patch).eq('id', userId);
+}
+
+export async function getOnboardingSession(client: RepoClient, userId: string) {
+  return client
+    .from('onboarding_sessions')
+    .select('id, user_id, status, current_step, completed_steps, payload, completed_at')
+    .eq('user_id', userId)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle<{
+      id: string;
+      user_id: string;
+      status: 'in_progress' | 'completed' | 'abandoned';
+      current_step: number;
+      completed_steps: string[];
+      payload: Record<string, unknown>;
+      completed_at: string | null;
+    }>();
+}
+
+export async function upsertOnboardingSession(
+  client: RepoClient,
+  userId: string,
+  patch: {
+    status?: 'in_progress' | 'completed' | 'abandoned';
+    current_step?: number;
+    completed_steps?: string[];
+    payload?: Record<string, unknown>;
+    completed_at?: string | null;
+  },
+) {
+  const { data: existing, error: existingErr } = await getOnboardingSession(client, userId);
+  if (existingErr) return { error: existingErr };
+
+  if (existing?.id) {
+    return client
+      .from('onboarding_sessions')
+      .update({ ...patch, updated_at: new Date().toISOString() })
+      .eq('id', existing.id);
+  }
+
+  return client.from('onboarding_sessions').insert({
+    user_id: userId,
+    status: patch.status ?? 'in_progress',
+    current_step: patch.current_step ?? 0,
+    completed_steps: patch.completed_steps ?? [],
+    payload: patch.payload ?? {},
+    completed_at: patch.completed_at ?? null,
+  });
+}
+
+export async function upsertNotificationSettings(
+  client: RepoClient,
+  userId: string,
+  channels: Array<'email' | 'whatsapp' | 'in-app'>,
+) {
+  return client.from('notification_settings').upsert(
+    {
+      user_id: userId,
+      notification_channels: channels,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'user_id' },
+  );
+}
+
+export async function upsertUserPreferences(
+  client: RepoClient,
+  userId: string,
+  patch: Record<string, unknown>,
+) {
+  return client.from('user_preferences').upsert(
+    {
+      user_id: userId,
+      ...patch,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'user_id' },
+  );
+}
+
+export async function getLifecycleContactProfile(client: RepoClient, userId: string) {
+  const [profileRes, notifRes] = await Promise.all([
+    client
+      .from('profiles')
+      .select('id, email, first_name, last_name, locale')
+      .eq('id', userId)
+      .maybeSingle<{ id: string; email: string | null; first_name: string | null; last_name: string | null; locale: string | null }>(),
+    client
+      .from('notification_settings')
+      .select('phone, phone_verified, whatsapp_opt_in, notification_channels')
+      .eq('user_id', userId)
+      .maybeSingle<{ phone: string | null; phone_verified: boolean | null; whatsapp_opt_in: boolean | null; notification_channels: string[] | null }>(),
+  ]);
+
+  if (profileRes.error) return { data: null, error: profileRes.error };
+  if (notifRes.error) return { data: null, error: notifRes.error };
+
+  const p = profileRes.data;
+  const n = notifRes.data;
+
+  return {
+    data: p
+      ? {
+          user_id: p.id,
+          full_name: [p.first_name, p.last_name].filter(Boolean).join(' ') || null,
+          email: p.email,
+          phone: n?.phone ?? null,
+          phone_verified: n?.phone_verified ?? null,
+          whatsapp_opt_in: n?.whatsapp_opt_in ?? false,
+          notification_channels: n?.notification_channels ?? [],
+          locale: p.locale,
+          preferred_language: p.locale,
+        }
+      : null,
+    error: null,
+  };
+}
+
+
+// Backward-compatible helpers retained during Phase 2 transition.
 export type ProfilePlanRoleRow = {
   id?: string | null;
   user_id?: string | null;
@@ -9,68 +236,124 @@ export type ProfilePlanRoleRow = {
   plan?: string | null;
 };
 
-export async function getProfileByUserId(client: RepoClient, userId: string) {
-  return client
-    .from('profiles')
-    .select('*')
-    .or(`id.eq.${userId},user_id.eq.${userId}`)
-    .maybeSingle();
-}
-
-export async function getProfileRole(client: RepoClient, userId: string) {
-  return client
-    .from('profiles')
-    .select('id, role')
-    .or(`id.eq.${userId},user_id.eq.${userId}`)
-    .maybeSingle<{ id: string; role: string | null }>();
-}
-
 export async function getProfilePlanAndRole(client: RepoClient, userId: string) {
-  return client
-    .from('profiles')
-    .select('id, user_id, role, plan')
-    .or(`id.eq.${userId},user_id.eq.${userId}`)
-    .maybeSingle<ProfilePlanRoleRow>();
+  const [profileRes, subRes] = await Promise.all([
+    getProfileRole(client, userId),
+    client
+      .from('subscriptions')
+      .select('plan_id')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle<{ plan_id?: string | null }>(),
+  ]);
+
+  if (profileRes.error) return { data: null, error: profileRes.error };
+  if (subRes.error) return { data: null, error: subRes.error };
+
+  return {
+    data: {
+      id: profileRes.data?.id ?? userId,
+      user_id: userId,
+      role: profileRes.data?.role ?? null,
+      plan: subRes.data?.plan_id ?? 'free',
+    } as ProfilePlanRoleRow,
+    error: null,
+  };
 }
 
 export async function getProfileSetupState(client: RepoClient, userId: string) {
-  return client
-    .from('profiles')
-    .select('id, user_id, setup_complete')
-    .or(`id.eq.${userId},user_id.eq.${userId}`)
-    .maybeSingle<{ id?: string; user_id?: string; setup_complete?: boolean | null }>();
-}
+  const { data, error } = await getOnboardingSession(client, userId);
+  if (error) return { data: null, error };
 
-export async function updateProfileByUserId(client: RepoClient, userId: string, patch: Record<string, unknown>) {
-  return client.from('profiles').update(patch).eq('id', userId);
+  return {
+    data: data
+      ? {
+          id: data.id,
+          user_id: userId,
+          setup_complete: data.status === 'completed',
+        }
+      : null,
+    error: null,
+  };
 }
 
 export async function upsertProfileSetup(
   client: RepoClient,
   userId: string,
   basePayload: Record<string, unknown>,
-  insertPayload: Record<string, unknown>,
+  _insertPayload: Record<string, unknown>,
 ) {
-  const { data: existing, error: existingErr } = await getProfileSetupState(client, userId);
-  if (existingErr) {
-    return { existing: null, error: existingErr };
-  }
+  const setupComplete = Boolean(basePayload.setup_complete);
+  const onboardingStep = typeof basePayload.onboarding_step === 'number' ? basePayload.onboarding_step : 0;
 
-  if (existing) {
-    const key = existing.id ? 'id' : 'user_id';
-    const value = existing.id ?? existing.user_id ?? userId;
-    const res = await client.from('profiles').update(basePayload).eq(key, value);
-    return { existing, error: res.error };
-  }
+  const preferencesPatch: Record<string, unknown> = {
+    preferred_language: basePayload.preferred_language,
+    language_preference: basePayload.language_preference,
+    country: basePayload.country,
+    study_prefs: basePayload.study_prefs,
+    goal_reason: basePayload.goal_reason,
+    learning_style: basePayload.learning_style,
+    time_commitment: basePayload.time_commitment,
+    time_commitment_min: basePayload.time_commitment_min,
+    days_per_week: basePayload.days_per_week,
+    study_days: basePayload.study_days,
+    study_minutes_per_day: basePayload.study_minutes_per_day,
+    daily_quota_goal: basePayload.daily_quota_goal,
+    exam_date: basePayload.exam_date,
+    goal_band: basePayload.goal_band,
+    weaknesses: basePayload.weaknesses,
+    focus_topics: basePayload.focus_topics,
+  };
 
-  const inserted = await client.from('profiles').insert(insertPayload);
-  return { existing: null, error: inserted.error };
-}
+  const [onboardingRes, prefRes, notifRes] = await Promise.all([
+    upsertOnboardingSession(client, userId, {
+      status: setupComplete ? 'completed' : 'in_progress',
+      current_step: onboardingStep,
+      payload: basePayload,
+      completed_at: setupComplete ? new Date().toISOString() : null,
+    }),
+    upsertUserPreferences(client, userId, preferencesPatch),
+    client.from('notification_settings').upsert(
+      {
+        user_id: userId,
+        notification_channels: Array.isArray(basePayload.notification_channels) ? basePayload.notification_channels : [],
+        whatsapp_opt_in: Boolean(basePayload.whatsapp_opt_in),
+        marketing_opt_in: Boolean(basePayload.marketing_opt_in),
+        quiet_hours_start: (basePayload.quiet_hours_start as string | null) ?? null,
+        quiet_hours_end: (basePayload.quiet_hours_end as string | null) ?? null,
+      },
+      { onConflict: 'user_id' },
+    ),
+  ]);
 
-export async function getLifecycleContactProfile(client: RepoClient, userId: string) {
-  return client
-    .from('profiles')
-    .select('user_id, full_name, email, phone, phone_verified, whatsapp_opt_in, notification_channels, locale, preferred_language')
+  const existingReco = await client
+    .from('ai_recommendations')
+    .select('id')
     .eq('user_id', userId)
-    .maybeSingle();
+    .eq('type', 'profile_setup')
+    .limit(1)
+    .maybeSingle<{ id: string }>();
+
+  let aiError: { message?: string } | null = existingReco.error;
+  if (!aiError) {
+    const aiPayload = {
+      user_id: userId,
+      type: 'profile_setup',
+      content: (basePayload.ai_recommendation as Record<string, unknown>) ?? {},
+      active: true,
+      consumed_at: null,
+    };
+
+    if (existingReco.data?.id) {
+      const updated = await client.from('ai_recommendations').update(aiPayload).eq('id', existingReco.data.id);
+      aiError = updated.error;
+    } else {
+      const inserted = await client.from('ai_recommendations').insert(aiPayload);
+      aiError = inserted.error;
+    }
+  }
+
+  const error = onboardingRes.error ?? prefRes.error ?? notifRes.error ?? aiError ?? null;
+  return { existing: null, error };
 }

--- a/lib/repositories/subscriptionRepository.ts
+++ b/lib/repositories/subscriptionRepository.ts
@@ -1,38 +1,83 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { getProfilePlanAndRole, type RepoClient } from '@/lib/repositories/profileRepository';
+import type { SubscriptionTier } from '@/lib/navigation/types';
 
+export type RepoClient = SupabaseClient<any, 'public', any>;
 export type PlanId = 'free' | 'starter' | 'booster' | 'master';
+
+type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due' | 'unpaid' | null;
+
+const PLAN_TO_TIER: Record<PlanId, SubscriptionTier> = {
+  free: 'free',
+  starter: 'seedling',
+  booster: 'rocket',
+  master: 'owl',
+};
+
+const TIER_TO_PLAN: Record<SubscriptionTier, PlanId> = {
+  free: 'free',
+  seedling: 'starter',
+  rocket: 'booster',
+  owl: 'master',
+};
 
 export function normalizePlan(plan: string | null | undefined): PlanId {
   const p = String(plan ?? 'free').toLowerCase();
   return p === 'starter' || p === 'booster' || p === 'master' ? p : 'free';
 }
 
-export async function getLatestSubscriptionPlan(client: SupabaseClient<any, 'public', any>, userId: string) {
-  const { data, error } = await client
+export function planToTier(plan: string | null | undefined): SubscriptionTier {
+  return PLAN_TO_TIER[normalizePlan(plan)];
+}
+
+export function tierToPlan(tier: SubscriptionTier): PlanId {
+  return TIER_TO_PLAN[tier];
+}
+
+export async function getLatestSubscription(client: RepoClient, userId: string) {
+  return client
     .from('subscriptions')
-    .select('plan_id, status, created_at')
+    .select('user_id, plan_id, status, renews_at, created_at, metadata')
     .eq('user_id', userId)
     .order('created_at', { ascending: false })
     .limit(1)
-    .maybeSingle<{ plan_id?: string | null; status?: string | null }>();
+    .maybeSingle<{
+      user_id?: string;
+      plan_id?: string | null;
+      status?: SubscriptionStatus;
+      renews_at?: string | null;
+      metadata?: Record<string, unknown> | null;
+    }>();
+}
 
-  if (error) return { plan: 'free' as PlanId, status: null as string | null, source: 'fallback' as const };
+export async function getUserTier(client: RepoClient, userId: string) {
+  const { data, error } = await getLatestSubscription(client, userId);
+  if (error) return { tier: 'free' as SubscriptionTier, role: null as string | null, status: null as SubscriptionStatus };
+
   return {
-    plan: normalizePlan(data?.plan_id),
+    tier: planToTier(data?.plan_id),
+    role: null as string | null,
     status: data?.status ?? null,
-    source: 'subscriptions' as const,
   };
 }
 
-export async function getUserEffectivePlan(client: RepoClient, userId: string) {
-  const latest = await getLatestSubscriptionPlan(client, userId);
-  if (latest.plan !== 'free') return latest;
+export async function getSubscriptionSummary(client: RepoClient, userId: string) {
+  const { data, error } = await getLatestSubscription(client, userId);
+  if (error || !data) {
+    return {
+      plan: 'free' as PlanId,
+      status: 'canceled' as const,
+      renewsAt: undefined,
+      trialEndsAt: undefined,
+      customerId: undefined as string | undefined,
+    };
+  }
 
-  const { data } = await getProfilePlanAndRole(client, userId);
+  const metadata = (data.metadata ?? {}) as Record<string, unknown>;
   return {
-    plan: normalizePlan(data?.plan),
-    status: latest.status,
-    source: data?.plan ? ('profiles' as const) : ('fallback' as const),
+    plan: normalizePlan(data.plan_id),
+    status: ((data.status ?? 'canceled') as Exclude<SubscriptionStatus, null>),
+    renewsAt: data.renews_at ?? undefined,
+    trialEndsAt: typeof metadata.trial_ends_at === 'string' ? metadata.trial_ends_at : undefined,
+    customerId: typeof metadata.stripe_customer_id === 'string' ? metadata.stripe_customer_id : undefined,
   };
 }

--- a/lib/services/dashboardService.ts
+++ b/lib/services/dashboardService.ts
@@ -9,7 +9,7 @@ export type DashboardAggregate = {
   lastScoreAt: string | null;
   streakDays: number;
   lastActivityDate: string | null;
-  recommendations: Array<{ id: string; type: string; priority: number; content: Record<string, unknown> }>;
+  recommendations: Array<{ id: string; type: string; priority: number; content: Record<string, unknown>; modelVersion: string | null; createdAt: string | null; expiresAt: string | null; consumedAt: string | null }>; 
   subscription: { planId: string; status: string | null };
   progress: {
     recommendationsCount: number;
@@ -34,6 +34,10 @@ export async function getDashboardAggregate(
     type: String(row.type ?? 'study_plan'),
     priority: Number(row.priority ?? 1),
     content: (row.content ?? {}) as Record<string, unknown>,
+    modelVersion: row.model_version == null ? null : String(row.model_version),
+    createdAt: row.created_at == null ? null : String(row.created_at),
+    expiresAt: row.expires_at == null ? null : String(row.expires_at),
+    consumedAt: row.consumed_at == null ? null : String(row.consumed_at),
   }));
 
   const currentBand = scoreRes.data?.band == null ? null : Number(scoreRes.data.band);

--- a/pages/api/dashboard/aggregate.ts
+++ b/pages/api/dashboard/aggregate.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerClient } from '@/lib/supabaseServer';
+import { getDashboardAggregate } from '@/lib/services/dashboardService';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const supabase = getServerClient(req, res);
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const aggregate = await getDashboardAggregate(supabase as any, user.id);
+  return res.status(200).json({ ok: true, aggregate });
+}

--- a/pages/api/dashboard/aggregate.ts
+++ b/pages/api/dashboard/aggregate.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
 import { getDashboardAggregate } from '@/lib/services/dashboardService';
+import { createDomainLogger } from '@/lib/obs/domainLogger';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -8,6 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  const log = createDomainLogger('/api/dashboard/aggregate');
   const supabase = getServerClient(req, res);
   const {
     data: { user },
@@ -18,6 +20,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  const aggregate = await getDashboardAggregate(supabase as any, user.id);
+  const skipCache = req.query.refresh === '1';
+  const aggregate = await getDashboardAggregate(supabase as any, user.id, { skipCache });
+  log.info('dashboard.aggregate_fetched', { userId: user.id, aggregateFetched: true, recommendationCount: aggregate.progress.recommendationsCount, skipCache });
   return res.status(200).json({ ok: true, aggregate });
 }

--- a/pages/api/entitlements.ts
+++ b/pages/api/entitlements.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerClient } from '@/lib/supabaseServer';
+import { getEntitlementSnapshot } from '@/lib/repositories/subscriptionRepository';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const supabase = getServerClient(req, res);
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const snapshot = await getEntitlementSnapshot(supabase as any, user.id);
+  return res.status(200).json({ ok: true, ...snapshot });
+}

--- a/pages/api/mock/reading/submit-final.ts
+++ b/pages/api/mock/reading/submit-final.ts
@@ -1,6 +1,7 @@
 // pages/api/mock/reading/submit-final.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
+import { createDomainLogger } from '@/lib/obs/domainLogger';
 
 // XP logic – tweak numbers however you like
 function calculateXpForReadingAttempt(correctCount: number, totalQuestions: number, bandScore: number | null) {
@@ -23,6 +24,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  const log = createDomainLogger('/api/mock/reading/submit-final');
   const supabase = getServerClient({ req, res });
 
   const {
@@ -223,6 +225,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.error('reading submit-final: stats upsert error', upsertError);
     // We still return success for the attempt; leaderboard can lag if needed
   }
+
+  log.info('score.updated', { userId: user.id, skill: 'reading', attemptId, bandScore, gainedXp, totalXp: newTotalXp });
 
   return res.status(200).json({
     status: 'submitted',

--- a/pages/api/onboarding/complete.ts
+++ b/pages/api/onboarding/complete.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { getServerClient } from '@/lib/supabaseServer';
 import { upsertNotificationSettings, upsertOnboardingSession } from '@/lib/repositories/profileRepository';
+import { createDomainLogger } from '@/lib/obs/domainLogger';
 
 const Body = z.object({
   step: z
@@ -67,6 +68,7 @@ export default async function handler(
     );
   }
 
+  const log = createDomainLogger('/api/onboarding/complete');
   const supabase = getServerClient(req, res);
   const {
     data: { user },
@@ -112,5 +114,6 @@ export default async function handler(
     // The client can refresh the session manually.
   }
 
+  log.info('onboarding.completed', { userId: user.id, step, channels: channels ?? [] });
   return res.status(200).json({ ok: true });
 }

--- a/pages/api/onboarding/save-survey.ts
+++ b/pages/api/onboarding/save-survey.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { getServerClient } from '@/lib/supabaseServer';
 import { upsertOnboardingSession, upsertUserPreferences } from '@/lib/repositories/profileRepository';
+import { createDomainLogger } from '@/lib/obs/domainLogger';
 
 const SurveySchema = z.object({
   targetBand: z.number().min(4).max(9),
@@ -23,6 +24,7 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
+  const log = createDomainLogger('/api/onboarding/save-survey');
   const supabase = getServerClient(req, res);
   const {
     data: { user },
@@ -66,5 +68,6 @@ export default async function handler(
     return res.status(500).json({ error: 'Failed to save survey data' });
   }
 
+  log.info('onboarding.survey_saved', { userId: user.id, targetBand, learningStyle });
   return res.status(200).json({ success: true });
 }

--- a/pages/api/quick-drill.ts
+++ b/pages/api/quick-drill.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { getLatestAiRecommendation } from '@/lib/repositories/aiRepository';
 
 // Simple placeholder drills for each skill
 const DRILLS: Record<string, string> = {
@@ -31,13 +32,8 @@ export default async function handler(
   let { skill } = req.query as { skill?: string };
 
   if (!skill) {
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('ai_recommendation')
-      .eq('user_id', user.id)
-      .maybeSingle();
-    const seq: string[] =
-      (profile?.ai_recommendation as any)?.sequence ?? [];
+    const { data: recommendation } = await getLatestAiRecommendation(supabase as any, user.id);
+    const seq = Array.isArray(recommendation?.content?.sequence) ? recommendation.content.sequence : [];
     skill = seq[0] || 'reading';
   }
 

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -15,7 +15,14 @@ const DashboardPage: NextPage = () => {
   const { aggregate } = useDashboardAggregate(true);
 
   const recommendations = (aggregate?.recommendations ?? [])
-    .map((item) => item.content?.summary)
+    .map((item) => {
+      const summary = item.content?.summary;
+      const title = item.content?.title;
+      const fallback = `Recommendation (${item.type})`;
+      if (typeof summary === 'string' && summary.length > 0) return summary;
+      if (typeof title === 'string' && title.length > 0) return title;
+      return fallback;
+    })
     .filter((value): value is string => typeof value === 'string' && value.length > 0);
 
   const currentBand = aggregate?.currentBand == null ? '—' : aggregate.currentBand.toFixed(1);

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -6,31 +6,35 @@ import { SkillModulesGrid } from '@/components/dashboard/SkillModulesGrid';
 import { SmartRecommendations } from '@/components/dashboard/SmartRecommendations';
 import { AICommandCenter } from '@/components/dashboard/AICommandCenter';
 import { TierGuard } from '@/components/dashboard/TierGuard';
-import { overview, recommendations, skillModules, trendData } from '@/features/dashboard/data';
-import type { SubscriptionTier } from '@/types/dashboard';
-
-const tier: SubscriptionTier = 'rocket';
+import { skillModules, trendData } from '@/features/dashboard/data';
+import useEntitlement from '@/hooks/useEntitlement';
+import useDashboardAggregate from '@/hooks/useDashboardAggregate';
 
 const DashboardPage: NextPage = () => {
+  const entitlement = useEntitlement(undefined);
+  const { aggregate } = useDashboardAggregate(true);
+
+  const recommendations = (aggregate?.recommendations ?? [])
+    .map((item) => item.content?.summary)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+  const currentBand = aggregate?.currentBand == null ? '—' : aggregate.currentBand.toFixed(1);
+  const weeklyImprovement = aggregate?.progress.activeStreak ? `+${Math.min(aggregate.streakDays, 20)}%` : '+0%';
+  const nextAction =
+    recommendations[0] ??
+    'Complete one focused skill practice and review the latest recommendation to keep your momentum.';
+
   return (
     <DashboardShell>
       <section className="space-y-6">
         <h1 className="text-2xl font-semibold">AI Command Center</h1>
-        <AIOverviewPanel
-          currentBand={overview.currentBand}
-          weeklyImprovement={overview.weeklyImprovement}
-          nextAction={overview.nextAction}
-        />
-        <TierGuard tier={tier} feature="advancedAnalytics" minimumTier="rocket">
-          <PerformanceAnalytics
-            reading={trendData.reading}
-            writing={trendData.writing}
-            speaking={trendData.speaking}
-          />
+        <AIOverviewPanel currentBand={currentBand} weeklyImprovement={weeklyImprovement} nextAction={nextAction} />
+        <TierGuard tier={entitlement.tier} feature="advancedInsights">
+          <PerformanceAnalytics reading={trendData.reading} writing={trendData.writing} speaking={trendData.speaking} />
         </TierGuard>
         <SkillModulesGrid modules={skillModules} />
-        <TierGuard tier={tier} feature="fullAiInsights" minimumTier="owl">
-          <SmartRecommendations items={recommendations} />
+        <TierGuard tier={entitlement.tier} feature="realtimeDashboard">
+          <SmartRecommendations items={recommendations.length ? recommendations : ['No active recommendations yet.']} />
         </TierGuard>
       </section>
       <AICommandCenter />

--- a/supabase/architecture/phase1-completion.md
+++ b/supabase/architecture/phase1-completion.md
@@ -39,3 +39,10 @@
 4. Identity normalization in `profiles`.
 5. Legacy domain columns dropped from `profiles`.
 6. Rollback file available to restore legacy columns and values from backup.
+
+## Profiles reduction scope
+
+`profiles` is reduced to identity-only fields for v2:
+- `id`, `email`, `first_name`, `last_name`, `avatar_url`, `role`, `locale`, `timezone`, `created_at`, `updated_at`
+
+Legacy overloaded columns are migrated to domain tables and then removed, including onboarding/subscription/AI/teacher/preferences fields plus legacy `full_name`, `settings`, `phone`, and deletion lifecycle flags.

--- a/supabase/architecture/phase1-task1-domain-boundary-map.md
+++ b/supabase/architecture/phase1-task1-domain-boundary-map.md
@@ -100,9 +100,10 @@ For v2 (identity-only `profiles`), keep:
 - `created_at`
 - `updated_at`
 
-### Transitional compatibility fields (short-term only)
-- `full_name` (derive `first_name`/`last_name` during migration)
-- Optionally keep `phone` + `phone_verified` temporarily if lifecycle/auth paths still read these directly.
+### Legacy identity-adjacent fields to deprecate
+- `full_name` (split into `first_name` + `last_name` during migration, then remove)
+- `phone` (move to `user_preferences` or future `user_contacts` table)
+- `settings` (JSON blob; decompose into structured preference tables)
 
 ---
 

--- a/supabase/architecture/phase4-task8-ai-recommendation-engine.md
+++ b/supabase/architecture/phase4-task8-ai-recommendation-engine.md
@@ -1,0 +1,28 @@
+# Phase 4 / Task 8 — AI Recommendation Engine Structure
+
+## Structured table model
+AI recommendations are persisted in `public.ai_recommendations` with these fields:
+- `id`
+- `user_id`
+- `type`
+- `priority`
+- `content`
+- `model_version`
+- `created_at`
+- `expires_at`
+- `consumed_at`
+
+## What changed in app logic
+- Study-plan generation (`/api/ai/study-plan/generate`) now writes structured recommendation entries to `ai_recommendations` instead of relying on profile JSON fields.
+- Study-plan regeneration (`/api/ai/study-plan/regenerate`) now:
+  - reads profile context from `user_preferences` + `onboarding_sessions.payload`
+  - writes a structured regeneration recommendation row to `ai_recommendations`
+- Dashboard aggregation keeps reading active recommendations from `ai_recommendations` and now passes model/version and lifecycle fields through to dashboard consumers.
+
+## Dashboard consumption update
+Dashboard recommendation text now resolves in priority order:
+1. `content.summary`
+2. `content.title`
+3. fallback label derived from recommendation `type`
+
+This keeps UI resilient while recommendations are progressively enriched.

--- a/supabase/architecture/phase5-performance-observability.md
+++ b/supabase/architecture/phase5-performance-observability.md
@@ -1,0 +1,60 @@
+# Phase 5 — Performance & Observability
+
+## Task 9 — Query optimization
+
+### Query hotspots analyzed
+1. Dashboard aggregate reads:
+   - latest score from `score_history`
+   - latest streak from `streak_logs`
+   - active recommendations from `ai_recommendations`
+   - latest subscription from `subscriptions`
+2. Study plan regeneration context reads:
+   - latest `onboarding_sessions`
+   - `user_preferences`
+   - active/newest `user_study_plans`
+
+### Index additions
+Implemented in `20260416000000_phase5_query_optimization.sql`:
+- `score_history_user_occurred_cover_idx`
+- `streak_logs_user_activity_cover_idx`
+- `ai_recommendations_dashboard_cover_idx`
+- `subscriptions_user_created_cover_idx`
+- `user_study_plans_user_active_generated_idx`
+- `onboarding_sessions_user_updated_cover_idx`
+- `user_preferences_user_cover_idx`
+
+### Query caching layer
+- Added in-memory TTL cache (30s) in `lib/services/dashboardService.ts` keyed by `userId`.
+- Cache is bypassable with `opts.skipCache`.
+
+### Expected performance impact
+- Fewer heap lookups on dashboard aggregate due to covering indexes.
+- Lower p95 latency under burst traffic via short-lived aggregate cache.
+- Lower planning/runtime cost for regeneration context lookup by reducing sort/filter scans.
+
+## Task 10 — Observability layer
+
+### Centralized logger utility
+- Added `lib/obs/domainLogger.ts` built on `lib/obs/logger.ts`.
+- Standardized domain events:
+  - `ai.recommendation.generated`
+  - `ai.recommendation.regenerated`
+  - `subscription.changed`
+  - `onboarding.completed`
+  - `onboarding.survey_saved`
+  - `score.updated`
+  - `dashboard.aggregate_fetched`
+
+### Integration points
+- AI recommendation generation:
+  - `pages/api/ai/study-plan/generate.ts`
+  - `pages/api/ai/study-plan/regenerate.ts`
+- Subscription changes:
+  - `pages/api/webhooks/payment.ts` (subscription update/delete events)
+- Onboarding completion:
+  - `pages/api/onboarding/complete.ts`
+  - `pages/api/onboarding/save-survey.ts`
+- Score updates:
+  - `pages/api/mock/reading/submit-final.ts`
+- Dashboard reads:
+  - `pages/api/dashboard/aggregate.ts`

--- a/supabase/architecture/phase6-ai-assist-completion.md
+++ b/supabase/architecture/phase6-ai-assist-completion.md
@@ -1,0 +1,32 @@
+# Phase 6 — AI Assist Completion
+
+## Scope completed
+Phase 6 AI Assist is now completed across schema, repository layer, API handlers, and observability.
+
+## Task 1 — Schema hardening
+- Added migration `20260417000000_phase6_ai_assist_hardening.sql`.
+- `ai_assist_logs` now supports richer telemetry fields:
+  - `model_provider`, `model_name`, `latency_ms`, `request_id`, `metadata`.
+- Added feature/user composite indexes for faster admin/user investigation queries.
+- Added authenticated self-read policy (`auth.uid() = user_id`) while preserving service-role write paths.
+
+## Task 2 — Repository standardization
+- Added `lib/repositories/aiAssistRepository.ts` with `insertAiAssistLog()` to centralize writes to `ai_assist_logs`.
+- Removed direct table-write duplication from API handlers.
+
+## Task 3 — API integration
+- `pages/api/ai/writing/paraphrase.ts` now logs through repository and emits domain events.
+- `pages/api/ai/speaking/hints.ts` now logs through repository and emits domain events.
+- Both endpoints now produce structured observability for rate-limit and successful generation outcomes.
+
+## Task 4 — Observability integration
+- Extended `lib/obs/domainLogger.ts` with `ai.assist.generated` event.
+- AI Assist endpoints now emit domain logs with:
+  - `userId`
+  - `feature`
+  - `source` (ai/heuristic)
+  - output cardinality (`suggestionCount` or `sentenceCount`)
+  - rate-limit reason when throttled.
+
+## Outcome
+- AI Assist now has consistent persistence, queryable telemetry, centralized write logic, and production-grade observability.

--- a/supabase/migrations/20260227000002_phase1_profiles_data_migration.sql
+++ b/supabase/migrations/20260227000002_phase1_profiles_data_migration.sql
@@ -328,7 +328,13 @@ ALTER TABLE IF EXISTS public.profiles
   DROP COLUMN IF EXISTS teacher_experience_years,
   DROP COLUMN IF EXISTS teacher_cv_url,
   DROP COLUMN IF EXISTS buddy_seats,
-  DROP COLUMN IF EXISTS buddy_seats_used;
+  DROP COLUMN IF EXISTS buddy_seats_used,
+  DROP COLUMN IF EXISTS full_name,
+  DROP COLUMN IF EXISTS settings,
+  DROP COLUMN IF EXISTS phone,
+  DROP COLUMN IF EXISTS pending_deletion,
+  DROP COLUMN IF EXISTS deletion_requested_at,
+  DROP COLUMN IF EXISTS deletion_confirmed_at;
 
 COMMIT;
 

--- a/supabase/migrations/20260227000003_phase1_profiles_rollback.sql
+++ b/supabase/migrations/20260227000003_phase1_profiles_rollback.sql
@@ -42,7 +42,13 @@ ALTER TABLE IF EXISTS public.profiles
   ADD COLUMN IF NOT EXISTS teacher_experience_years integer,
   ADD COLUMN IF NOT EXISTS teacher_cv_url text,
   ADD COLUMN IF NOT EXISTS buddy_seats integer,
-  ADD COLUMN IF NOT EXISTS buddy_seats_used integer;
+  ADD COLUMN IF NOT EXISTS buddy_seats_used integer,
+  ADD COLUMN IF NOT EXISTS full_name text,
+  ADD COLUMN IF NOT EXISTS settings jsonb DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS phone text,
+  ADD COLUMN IF NOT EXISTS pending_deletion boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS deletion_requested_at timestamptz,
+  ADD COLUMN IF NOT EXISTS deletion_confirmed_at timestamptz;
 
 UPDATE public.profiles p
 SET
@@ -81,6 +87,12 @@ SET
   teacher_cv_url = b.teacher_cv_url,
   buddy_seats = b.buddy_seats,
   buddy_seats_used = b.buddy_seats_used,
+  full_name = b.full_name,
+  settings = COALESCE(b.settings, '{}'::jsonb),
+  phone = b.phone,
+  pending_deletion = COALESCE(b.pending_deletion, false),
+  deletion_requested_at = b.deletion_requested_at,
+  deletion_confirmed_at = b.deletion_confirmed_at,
   updated_at = now()
 FROM public.profile_phase1_backup b
 WHERE b.id = p.id;

--- a/supabase/migrations/20260415000000_phase4_ai_recommendation_engine.sql
+++ b/supabase/migrations/20260415000000_phase4_ai_recommendation_engine.sql
@@ -1,0 +1,45 @@
+-- Phase 4 / Task 8
+-- AI recommendation engine hardening for structured recommendations.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.ai_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  type text NOT NULL,
+  priority smallint NOT NULL DEFAULT 1,
+  content jsonb NOT NULL DEFAULT '{}'::jsonb,
+  model_version text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz,
+  consumed_at timestamptz,
+  active boolean NOT NULL DEFAULT true
+);
+
+ALTER TABLE IF EXISTS public.ai_recommendations
+  ALTER COLUMN type SET DEFAULT 'study_plan',
+  ALTER COLUMN content SET DEFAULT '{}'::jsonb,
+  ALTER COLUMN active SET DEFAULT true;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ai_recommendations_priority_range_check'
+  ) THEN
+    ALTER TABLE public.ai_recommendations
+      ADD CONSTRAINT ai_recommendations_priority_range_check
+      CHECK (priority BETWEEN 1 AND 10);
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS ai_recommendations_active_unconsumed_idx
+  ON public.ai_recommendations (user_id, priority DESC, created_at DESC)
+  WHERE active = true AND consumed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS ai_recommendations_expiry_idx
+  ON public.ai_recommendations (expires_at)
+  WHERE expires_at IS NOT NULL;
+
+COMMIT;

--- a/supabase/migrations/20260416000000_phase5_query_optimization.sql
+++ b/supabase/migrations/20260416000000_phase5_query_optimization.sql
@@ -1,0 +1,37 @@
+-- Phase 5 / Task 9
+-- Query optimization and dashboard-serving indexes.
+
+BEGIN;
+
+-- Dashboard aggregate tables
+CREATE INDEX IF NOT EXISTS score_history_user_occurred_cover_idx
+  ON public.score_history (user_id, occurred_at DESC)
+  INCLUDE (score, band);
+
+CREATE INDEX IF NOT EXISTS streak_logs_user_activity_cover_idx
+  ON public.streak_logs (user_id, activity_date DESC)
+  INCLUDE (streak_days);
+
+CREATE INDEX IF NOT EXISTS ai_recommendations_dashboard_cover_idx
+  ON public.ai_recommendations (user_id, active, priority DESC, created_at DESC)
+  INCLUDE (type, content, model_version, expires_at, consumed_at)
+  WHERE active = true;
+
+CREATE INDEX IF NOT EXISTS subscriptions_user_created_cover_idx
+  ON public.subscriptions (user_id, created_at DESC)
+  INCLUDE (plan_id, status, renews_at, metadata);
+
+-- Study plan generation/regeneration paths
+CREATE INDEX IF NOT EXISTS user_study_plans_user_active_generated_idx
+  ON public.user_study_plans (user_id, active, generated_at DESC);
+
+-- Onboarding context reads
+CREATE INDEX IF NOT EXISTS onboarding_sessions_user_updated_cover_idx
+  ON public.onboarding_sessions (user_id, updated_at DESC)
+  INCLUDE (status, current_step, payload);
+
+CREATE INDEX IF NOT EXISTS user_preferences_user_cover_idx
+  ON public.user_preferences (user_id)
+  INCLUDE (goal_band, exam_date, learning_style);
+
+COMMIT;

--- a/supabase/migrations/20260417000000_phase6_ai_assist_hardening.sql
+++ b/supabase/migrations/20260417000000_phase6_ai_assist_hardening.sql
@@ -1,0 +1,35 @@
+-- Phase 6 / AI Assist hardening
+-- Expands logging fidelity and serving indexes for AI assist features.
+
+BEGIN;
+
+ALTER TABLE IF EXISTS public.ai_assist_logs
+  ADD COLUMN IF NOT EXISTS model_provider text,
+  ADD COLUMN IF NOT EXISTS model_name text,
+  ADD COLUMN IF NOT EXISTS latency_ms integer,
+  ADD COLUMN IF NOT EXISTS request_id text,
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS ai_assist_logs_feature_created_idx
+  ON public.ai_assist_logs (feature, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS ai_assist_logs_user_feature_created_idx
+  ON public.ai_assist_logs (user_id, feature, created_at DESC);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'ai_assist_logs'
+      AND policyname = 'Users can read own ai assist logs'
+  ) THEN
+    CREATE POLICY "Users can read own ai assist logs"
+      ON public.ai_assist_logs
+      FOR SELECT
+      TO authenticated
+      USING (auth.uid() = user_id);
+  END IF;
+END$$;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Reduce the overloaded `profiles` table to an identity-only surface so domain data lives in dedicated tables for subscriptions, onboarding, AI, analytics, preferences, teacher, and referrals.
- Remove legacy identity-adjacent fields (`full_name`, `phone`, `settings`) and account-deletion flags from `profiles` to complete Phase 1 non-breaking refactor scope. 
- Preserve a safe rollback path so the legacy columns and values can be restored if the cutover needs to be reverted. 

### Description
- Updated the domain boundary documentation in `supabase/architecture/phase1-task1-domain-boundary-map.md` to mark legacy identity-adjacent fields to deprecate (`full_name`, `phone`, `settings`).
- Added an explicit identity-only scope section to `supabase/architecture/phase1-completion.md` listing retained `profiles` columns (`id`, `email`, `first_name`, `last_name`, `avatar_url`, `role`, `locale`, `timezone`, `created_at`, `updated_at`).
- Extended the Phase 1 data migration `supabase/migrations/20260227000002_phase1_profiles_data_migration.sql` to drop remaining legacy columns from `profiles` — specifically `full_name`, `settings`, `phone` and deletion lifecycle flags (`pending_deletion`, `deletion_requested_at`, `deletion_confirmed_at`) — after backfill into domain tables.
- Extended the rollback helper `supabase/migrations/20260227000003_phase1_profiles_rollback.sql` to re-create and repopulate those same legacy columns from the backup table `profile_phase1_backup` for safe reversal.

### Testing
- Verified the removal pattern exists by running `rg` for the `DROP COLUMN IF EXISTS (full_name|settings|phone|pending_deletion|deletion_requested_at|deletion_confirmed_at)` pattern against `supabase/migrations/20260227000002_phase1_profiles_data_migration.sql`, which succeeded. 
- Verified the rollback re-add pattern by running `rg` for the `ADD COLUMN IF NOT EXISTS (full_name|settings|phone|pending_deletion|deletion_requested_at|deletion_confirmed_at)` pattern against `supabase/migrations/20260227000003_phase1_profiles_rollback.sql`, which succeeded.
- Performed file inspections (`nl`/`sed` output checks and `git status --short`) to confirm the working tree and that the updated docs and migrations are present, which returned the expected outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a268b3b4408320aee3b273ed430d3f)