### PR TITLE
Enable Watchpack polling for local dev to avoid Windows watcher crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev\" \"npm:dev:premium\"",
+    "dev": "concurrently \"npm:dev:next\" \"npm:dev:premium\"",
     "dev:premium": "tailwindcss -i ./styles/premium.css -c tailwind.config.premium.js -o ./public/premium.css --watch",
     "dev:3001": "next dev -p 3001 -H 0.0.0.0",
     "build": "npm run routes:gen && npm run build:premium && node ./scripts/next-build.mjs",
@@ -49,7 +49,8 @@
     "lh:summary": "node scripts/lh-extract.mjs",
     "prepare": "husky",
     "replace-createClient": "node replace-createClient.js",
-    "lhci": "lhci autorun --config=.lighthouserc.json"
+    "lhci": "lhci autorun --config=.lighthouserc.json",
+    "dev:next": "node scripts/dev-next.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.916.0",

--- a/scripts/dev-next.mjs
+++ b/scripts/dev-next.mjs
@@ -1,0 +1,20 @@
+import { spawn } from 'node:child_process';
+
+const env = {
+  ...process.env,
+  WATCHPACK_POLLING: process.env.WATCHPACK_POLLING || 'true',
+};
+
+const child = spawn('next', ['dev'], {
+  stdio: 'inherit',
+  shell: true,
+  env,
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
### Motivation
- Local `next dev` was crashing on some Windows setups with `TypeError [ERR_INVALID_ARG_TYPE]` from Next's watcher; forcing Watchpack polling is a practical workaround to avoid undefined file paths emitted by native watch events.

### Description
- Added `scripts/dev-next.mjs` which sets `WATCHPACK_POLLING=true` by default and spawns `next dev`, and updated `package.json` to route `dev` through a new `dev:next` script so `npm run dev` uses the polling-enabled launcher.

### Testing
- Ran `node --check scripts/dev-next.mjs` which passed; attempting `npm run dev:next` and `npm run -s dev:premium -- --help` exercised the wiring but could not fully start due to missing `next`/`tailwindcss` binaries in the container environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a325e21b008320b5de8dcec55beb49)