### PR TITLE
Add `dev:next` wrapper and update `dev` script to improve Next.js dev reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"next dev\" \"npm:dev:premium\"",
+    "dev": "concurrently \"npm:dev:next\" \"npm:dev:premium\"",
     "dev:premium": "tailwindcss -i ./styles/premium.css -c tailwind.config.premium.js -o ./public/premium.css --watch",
     "dev:3001": "next dev -p 3001 -H 0.0.0.0",
     "build": "npm run routes:gen && npm run build:premium && node ./scripts/next-build.mjs",
@@ -49,7 +49,8 @@
     "lh:summary": "node scripts/lh-extract.mjs",
     "prepare": "husky",
     "replace-createClient": "node replace-createClient.js",
-    "lhci": "lhci autorun --config=.lighthouserc.json"
+    "lhci": "lhci autorun --config=.lighthouserc.json",
+    "dev:next": "node scripts/dev-next.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.916.0",

--- a/scripts/dev-next.mjs
+++ b/scripts/dev-next.mjs
@@ -1,0 +1,49 @@
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const isWindows = process.platform === 'win32';
+
+const env = {
+  ...process.env,
+  WATCHPACK_POLLING: process.env.WATCHPACK_POLLING || 'true',
+  CHOKIDAR_USEPOLLING: process.env.CHOKIDAR_USEPOLLING || '1',
+};
+
+const args = ['dev'];
+
+// Windows file watching can emit unstable events in webpack dev mode on some setups.
+// Turbopack avoids the crashing Watchpack code path seen in setup-dev-bundler.js.
+if (isWindows && !process.env.NEXT_DISABLE_TURBO_DEV) {
+  args.push('--turbo');
+}
+
+let command = 'next';
+let commandArgs = args;
+
+try {
+  const nextBin = require.resolve('next/dist/bin/next');
+  command = process.execPath;
+  commandArgs = [nextBin, ...args];
+} catch {
+  // Fallback to resolving `next` from PATH when local package metadata is unavailable.
+}
+
+const child = spawn(command, commandArgs, {
+  stdio: 'inherit',
+  env,
+});
+
+
+child.on('error', (error) => {
+  console.error(`[dev:next] Failed to start Next.js dev server: ${error.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
### Motivation

- Make the `npm run dev` workflow more robust across platforms by isolating Next.js startup into a small wrapper that sets file-watching env vars and applies Windows-specific options to avoid unstable Watchpack behavior. 

### Description

- Change the top-level `dev` script in `package.json` to run `npm:dev:next` under `concurrently` instead of invoking `next dev` directly. 
- Add a new `dev:next` script in `package.json` that runs `node scripts/dev-next.mjs`. 
- Add `scripts/dev-next.mjs`, a small Node wrapper that sets `WATCHPACK_POLLING` and `CHOKIDAR_USEPOLLING` defaults, resolves the local `next` binary when available, enables `--turbo` on Windows unless `NEXT_DISABLE_TURBO_DEV` is set, and forwards stdio and exit codes; it also prints an error and exits non-zero on spawn failure. 

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a325e21b008320b5de8dcec55beb49)