### PR TITLE
Recognize Supabase SSR auth cookies in middleware to fix login redirect loop

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -37,7 +37,18 @@ function isSafePostAuthRedirect(path: string | null) {
 }
 
 function hasAuthCookie(req: NextRequest) {
-  return Boolean(req.cookies.get('sb-access-token')?.value && req.cookies.get('sb-refresh-token')?.value);
+  const accessToken = req.cookies.get('sb-access-token')?.value;
+  const refreshToken = req.cookies.get('sb-refresh-token')?.value;
+  if (accessToken && refreshToken) return true;
+
+  const legacyToken = req.cookies.get('sb:token')?.value || req.cookies.get('supabase-auth-token')?.value;
+  if (legacyToken) return true;
+
+  const projectScopedToken = req.cookies
+    .getAll()
+    .some((cookie) => /^sb-[a-z0-9-]+-auth-token(?:\.0)?$/i.test(cookie.name) && Boolean(cookie.value));
+
+  return projectScopedToken;
 }
 
 export async function middleware(req: NextRequest) {


### PR DESCRIPTION
### Motivation
- Users were stuck in an auth redirect loop because the middleware only treated the presence of `sb-access-token` + `sb-refresh-token` as authenticated and therefore missed other Supabase session cookie formats used in production.

### Description
- Updated `hasAuthCookie` in `middleware.ts` to return true when any valid session cookie is present: explicit `sb-access-token` + `sb-refresh-token`, legacy `sb:token` or `supabase-auth-token`, or project-scoped SSR cookies matching `/^sb-[a-z0-9-]+-auth-token(?:\.0)?$/i` discovered via `req.cookies.getAll()`.
- Left the existing protected-route redirect behavior unchanged so only the authentication detection was broadened.

### Testing
- Inspected the updated `middleware.ts` to confirm the new cookie checks are implemented and syntactically coherent.
- Attempted `npx eslint middleware.ts` which failed in this environment due to a missing `@eslint/eslintrc` package, and attempted `npx tsc --noEmit --pretty false middleware.ts` which failed due to missing `next/server` types and the isolated TypeScript invocation, so full lint/type validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40c3b7d108320be9c11be7a4878d5)