### PR TITLE
Fix login/signup redirect routing to dashboard vs onboarding

### DIFF
--- a/lib/routeAccess.ts
+++ b/lib/routeAccess.ts
@@ -109,11 +109,14 @@ export function destinationByRole(user: User | null | undefined): string {
   }
 
   const role = getUserRole(user);
-  const onboarded = !!(user as unknown as { user_metadata?: { onboarding_complete?: boolean } })?.user_metadata?.onboarding_complete;
+  const metadata = (user as unknown as {
+    user_metadata?: { onboarding_complete?: boolean; onboarding_required?: boolean };
+  })?.user_metadata;
+  const onboardingRequired = metadata?.onboarding_required === true && metadata?.onboarding_complete !== true;
 
   if (role === 'teacher') return '/teacher';
   if (role === 'admin') return '/admin';
-  return onboarded ? '/dashboard' : '/onboarding';
+  return onboardingRequired ? '/onboarding' : '/dashboard';
 }
 
 /** Backwards-compatible helper that *navigates* only on client */

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -64,7 +64,11 @@ export default async function handler(
       password,
       options: {
         emailRedirectTo: `${SITE_URL}/auth/callback`,
-        data: referral ? { referral_code: referral.trim() } : undefined,
+        data: {
+          ...(referral ? { referral_code: referral.trim() } : {}),
+          onboarding_required: true,
+          onboarding_complete: false,
+        },
       },
     });
 

--- a/pages/api/onboarding/complete.ts
+++ b/pages/api/onboarding/complete.ts
@@ -122,7 +122,7 @@ export default async function handler(
 
   // 🔁 Sync the onboarding_complete flag to the user's metadata
   const { error: metadataError } = await supabase.auth.updateUser({
-    data: { onboarding_complete: true }
+    data: { onboarding_complete: true, onboarding_required: false }
   });
 
   if (metadataError) {

--- a/pages/signup/email.tsx
+++ b/pages/signup/email.tsx
@@ -80,7 +80,7 @@ export default function SignUpWithEmail() {
           email: trimmedEmail,
           password,
           redirectTo: redirectTarget,
-          data: { role: role || 'student' },
+          data: { role: role || 'student', onboarding_required: true, onboarding_complete: false },
           codeChallenge: pkcePair.challenge,
           codeChallengeMethod: pkcePair.method,
         });

--- a/pages/signup/phone.tsx
+++ b/pages/signup/phone.tsx
@@ -52,7 +52,11 @@ export default function SignupWithPhone() {
     setPhoneErr(null);
     setLoading(true);
 
-    const data: Record<string, string> = { status: 'pending_verification' };
+    const data: Record<string, string> = {
+      status: 'pending_verification',
+      onboarding_required: 'true',
+      onboarding_complete: 'false',
+    };
     if (referral) data.referral_code = referral.trim();
 
     const { error } = await supabase.auth.signInWithOtp({
@@ -111,7 +115,11 @@ export default function SignupWithPhone() {
     setLoading(true);
     try {
       const trimmedPhone = phone.trim();
-      const data: Record<string, string> = { status: 'pending_verification' };
+      const data: Record<string, string> = {
+        status: 'pending_verification',
+        onboarding_required: 'true',
+        onboarding_complete: 'false',
+      };
       if (referral) data.referral_code = referral.trim();
       const { error } = await supabase.auth.signInWithOtp({
         phone: trimmedPhone,


### PR DESCRIPTION
### Motivation
- Prevent regular logins from being routed back into onboarding while ensuring first-time signups are taken into the onboarding wizard until they finish it.

### Description
- Use an explicit `user_metadata.onboarding_required` flag in `destinationByRole` to decide whether a student should go to `/onboarding` or `/dashboard` (`lib/routeAccess.ts`).
- Mark newly created accounts as onboarding-required when signing up via email PKCE by adding `onboarding_required: true, onboarding_complete: false` to the signup payload (`pages/signup/email.tsx`).
- Mark phone OTP signups (request/resend) with onboarding metadata so SMS-created accounts are routed into onboarding (`pages/signup/phone.tsx`).
- Stamp server-side signups with onboarding metadata in the signup API to keep behavior consistent (`pages/api/auth/signup.ts`).
- Clear `onboarding_required` and set `onboarding_complete: true` in the onboarding completion endpoint so completed users land on the dashboard (`pages/api/onboarding/complete.ts`).

### Testing
- Ran ESLint on the changed files via `npx eslint lib/routeAccess.ts pages/signup/email.tsx pages/signup/phone.tsx pages/api/auth/signup.ts pages/api/onboarding/complete.ts`, which could not complete due to a missing environment dependency (`@eslint/eslintrc`) in this environment.
- Verified changes were staged and committed successfully to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a422ed3b9483208385e26fb0815a14)