### PR TITLE
Add premium route progress bar and reusable skeleton loading system

### DIFF
--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,13 @@
+import { SkeletonCard } from '@/components/loading/Skeletons';
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-4 p-4 sm:p-6" aria-live="polite" aria-busy="true">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <SkeletonCard key={index} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/common/Loader.tsx
+++ b/components/common/Loader.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
 import clsx from 'clsx';
+import { SkeletonTextBlock } from '@/components/loading/Skeletons';
+import { useDelayedVisibility } from '@/components/loading/useDelayedVisibility';
 
 interface LoaderProps {
   label?: string;
   className?: string;
+  active?: boolean;
 }
 
-export const Loader: React.FC<LoaderProps> = ({ label = 'Loading…', className }) => {
+export const Loader: React.FC<LoaderProps> = ({ label = 'Loading…', className, active = true }) => {
+  const showSkeleton = useDelayedVisibility(active, 600);
+
+  if (!showSkeleton) return null;
+
   return (
-    <div className={clsx('flex items-center gap-2 text-muted-foreground', className)} role="status" aria-live="polite">
-      <span className="inline-flex h-4 w-4 animate-spin rounded-full border-2 border-border border-t-transparent" aria-hidden="true" />
-      <span className="text-small font-medium">{label}</span>
+    <div className={clsx('space-y-2 text-muted-foreground', className)} role="status" aria-live="polite">
+      <span className="sr-only">{label}</span>
+      <SkeletonTextBlock className="max-w-sm" />
     </div>
   );
 };

--- a/components/design-system/Input.tsx
+++ b/components/design-system/Input.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Loader2 } from 'lucide-react'; // or your icon library
+import { Skeleton } from '@/components/design-system/Skeleton';
 
 const cx = (...xs: Array<string | false | null | undefined>) => xs.filter(Boolean).join(' ');
 
@@ -123,7 +123,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
           {isLoading && (
             <span className="absolute inset-y-0 right-0 flex items-center pr-3">
-              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              <Skeleton shape="circle" className="h-4 w-4" />
             </span>
           )}
 

--- a/components/design-system/Skeleton.tsx
+++ b/components/design-system/Skeleton.tsx
@@ -9,9 +9,9 @@ export const Skeleton: React.FC<{ className?: string; shape?: 'rect' | 'circle';
   return (
     <div
       className={[
-        animated ? 'animate-pulse' : '',
+        animated ? 'relative overflow-hidden before:absolute before:inset-0 before:animate-[shimmer_1.7s_linear_infinite] before:bg-gradient-to-r before:from-transparent before:via-white/10 before:to-transparent' : '',
         shape === 'circle' ? 'rounded-full' : 'rounded-ds',
-        'bg-muted',
+        'bg-muted/80',
         className,
       ].join(' ')}
     />

--- a/components/loading/LoadingProvider.tsx
+++ b/components/loading/LoadingProvider.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from 'react';
+import RouteProgressBar from '@/components/loading/RouteProgressBar';
+
+export default function LoadingProvider({ children }: PropsWithChildren) {
+  return (
+    <>
+      <RouteProgressBar />
+      {children}
+    </>
+  );
+}

--- a/components/loading/RouteProgressBar.tsx
+++ b/components/loading/RouteProgressBar.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+
+const ROUTE_LOADER_DELAY_MS = 300;
+const COMPLETE_HIDE_DELAY_MS = 220;
+
+export default function RouteProgressBar() {
+  const router = useRouter();
+  const [visible, setVisible] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const activeRef = useRef(false);
+  const startAtRef = useRef<number | null>(null);
+  const delayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const completeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const clearTimers = () => {
+      if (delayTimerRef.current) {
+        clearTimeout(delayTimerRef.current);
+        delayTimerRef.current = null;
+      }
+      if (completeTimerRef.current) {
+        clearTimeout(completeTimerRef.current);
+        completeTimerRef.current = null;
+      }
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+
+    const tick = () => {
+      setProgress((current) => {
+        if (!activeRef.current) return current;
+        if (current >= 90) return current;
+        const next = current + (90 - current) * 0.08;
+        return Math.min(90, next);
+      });
+      rafRef.current = window.requestAnimationFrame(tick);
+    };
+
+    const start = () => {
+      clearTimers();
+      activeRef.current = true;
+      startAtRef.current = Date.now();
+
+      delayTimerRef.current = setTimeout(() => {
+        if (!activeRef.current) return;
+        setProgress(6);
+        setVisible(true);
+        rafRef.current = window.requestAnimationFrame(tick);
+      }, ROUTE_LOADER_DELAY_MS);
+    };
+
+    const done = () => {
+      activeRef.current = false;
+      const elapsed = startAtRef.current ? Date.now() - startAtRef.current : 0;
+
+      if (elapsed < ROUTE_LOADER_DELAY_MS) {
+        clearTimers();
+        setVisible(false);
+        setProgress(0);
+        return;
+      }
+
+      clearTimers();
+      setVisible(true);
+      setProgress(100);
+
+      completeTimerRef.current = setTimeout(() => {
+        setVisible(false);
+        setProgress(0);
+      }, COMPLETE_HIDE_DELAY_MS);
+    };
+
+    router.events.on('routeChangeStart', start);
+    router.events.on('routeChangeComplete', done);
+    router.events.on('routeChangeError', done);
+
+    return () => {
+      clearTimers();
+      router.events.off('routeChangeStart', start);
+      router.events.off('routeChangeComplete', done);
+      router.events.off('routeChangeError', done);
+    };
+  }, [router.events]);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-x-0 top-0 z-[200] h-[2px] overflow-hidden"
+    >
+      <div
+        className="h-full origin-left bg-gradient-to-r from-violet-400/95 via-cyan-300/95 to-emerald-300/95 shadow-[0_0_12px_rgba(120,185,255,0.45)] transition-[transform,opacity] duration-300 ease-out will-change-transform"
+        style={{
+          opacity: visible ? 1 : 0,
+          transform: `scaleX(${Math.max(0, Math.min(progress / 100, 1))})`,
+        }}
+      />
+    </div>
+  );
+}

--- a/components/loading/Skeletons.tsx
+++ b/components/loading/Skeletons.tsx
@@ -1,0 +1,38 @@
+import type { HTMLAttributes } from 'react';
+import clsx from 'clsx';
+import { Skeleton } from '@/components/design-system/Skeleton';
+
+type Props = HTMLAttributes<HTMLDivElement>;
+
+export function SkeletonCard({ className, ...rest }: Props) {
+  return (
+    <div className={clsx('rounded-ds-2xl border border-border/70 bg-card/70 p-5', className)} {...rest}>
+      <div className="space-y-3">
+        <Skeleton className="h-5 w-2/5" />
+        <Skeleton className="h-4 w-4/5" />
+        <Skeleton className="h-4 w-3/5" />
+      </div>
+    </div>
+  );
+}
+
+export function SkeletonTableRow({ className, ...rest }: Props) {
+  return (
+    <div className={clsx('grid grid-cols-12 gap-3 border-b border-border/60 py-3', className)} {...rest}>
+      <Skeleton className="col-span-4 h-4" />
+      <Skeleton className="col-span-3 h-4" />
+      <Skeleton className="col-span-2 h-4" />
+      <Skeleton className="col-span-3 h-4" />
+    </div>
+  );
+}
+
+export function SkeletonTextBlock({ className, ...rest }: Props) {
+  return (
+    <div className={clsx('space-y-2', className)} {...rest}>
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-2/3" />
+    </div>
+  );
+}

--- a/components/loading/useDelayedVisibility.ts
+++ b/components/loading/useDelayedVisibility.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export function useDelayedVisibility(active: boolean, delayMs: number): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!active) {
+      setVisible(false);
+      return;
+    }
+
+    const timer = setTimeout(() => setVisible(true), delayMs);
+    return () => clearTimeout(timer);
+  }, [active, delayMs]);
+
+  return visible;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -39,8 +39,7 @@ import type { SupportedLocale } from '@/lib/i18n/config';
 import type { SubscriptionTier } from '@/lib/navigation/types';
 import { getRouteConfig, isAttemptPath } from '@/lib/routes/routeLayoutMap';
 
-// ⭐ NEW BreadcrumbBar V2
-import { BreadcrumbBar } from '@/components/navigation/BreadcrumbBar';
+import LoadingProvider from '@/components/loading/LoadingProvider';
 
 const PricingReasonBanner = dynamic(
   () => import('@/components/paywall/PricingReasonBanner'),
@@ -272,43 +271,45 @@ function InnerApp({ Component, pageProps }: AppProps) {
 
   return (
     <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <HighContrastProvider>
-        <div
-          className={`${poppins.className} ${slab.className}
+      <LoadingProvider>
+        <HighContrastProvider>
+          <div
+            className={`${poppins.className} ${slab.className}
           min-h-screen min-h-[100dvh] bg-background text-foreground antialiased`}
-        >
-          <AnimationProvider>
-            <AppLayoutManager
-              isAuthPage={routeConfiguration.isAuthPage}
-              isProctoringRoute={routeConfiguration.isProctoringRoute}
-              showLayout={routeConfiguration.showLayout}
-              forceLayoutOnAuthPage={forceLayoutOnAuthPage}
-              isAdminRoute={routeConfiguration.isAdminRoute}
-              isInstitutionsRoute={routeConfiguration.isInstitutionsRoute}
-              isDashboardRoute={routeConfiguration.isDashboardRoute}
-              isMarketplaceRoute={routeConfiguration.isMarketplaceRoute}
-              isLearningRoute={routeConfiguration.isLearningRoute}
-              isCommunityRoute={routeConfiguration.isCommunityRoute}
-              isReportsRoute={routeConfiguration.isReportsRoute}
-              isMarketingRoute={routeConfiguration.isMarketingRoute}
-              subscriptionTier={subscriptionTier}
-              role={role}
-              isTeacherApproved={isTeacherApproved}
-              guardFallback={() => <GuardSkeleton />}
+          >
+            <AnimationProvider>
+              <AppLayoutManager
+                isAuthPage={routeConfiguration.isAuthPage}
+                isProctoringRoute={routeConfiguration.isProctoringRoute}
+                showLayout={routeConfiguration.showLayout}
+                forceLayoutOnAuthPage={forceLayoutOnAuthPage}
+                isAdminRoute={routeConfiguration.isAdminRoute}
+                isInstitutionsRoute={routeConfiguration.isInstitutionsRoute}
+                isDashboardRoute={routeConfiguration.isDashboardRoute}
+                isMarketplaceRoute={routeConfiguration.isMarketplaceRoute}
+                isLearningRoute={routeConfiguration.isLearningRoute}
+                isCommunityRoute={routeConfiguration.isCommunityRoute}
+                isReportsRoute={routeConfiguration.isReportsRoute}
+                isMarketingRoute={routeConfiguration.isMarketingRoute}
+                subscriptionTier={subscriptionTier}
+                role={role}
+                isTeacherApproved={isTeacherApproved}
+                guardFallback={() => <GuardSkeleton />}
 
-              // ⭐ SEND TO LAYOUT MANAGER
-              showBreadcrumbs={showBreadcrumbs}
-            >
-              {(router.pathname === '/pricing' ||
-                router.pathname === '/pricing/overview') && (
-                <PricingReasonBanner />
-              )}
+                // ⭐ SEND TO LAYOUT MANAGER
+                showBreadcrumbs={showBreadcrumbs}
+              >
+                {(router.pathname === '/pricing' ||
+                  router.pathname === '/pricing/overview') && (
+                  <PricingReasonBanner />
+                )}
 
-              {basePage}
-            </AppLayoutManager>
-          </AnimationProvider>
-        </div>
-      </HighContrastProvider>
+                {basePage}
+              </AppLayoutManager>
+            </AnimationProvider>
+          </div>
+        </HighContrastProvider>
+      </LoadingProvider>
     </ThemeProvider>
   );
 }

--- a/pages/mock/writing/run.tsx
+++ b/pages/mock/writing/run.tsx
@@ -8,7 +8,6 @@ import React, {
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import clsx from 'clsx';
-import { Loader2 } from 'lucide-react';
 
 import { Button } from '@/components/design-system/Button';
 import { Card } from '@/components/design-system/Card';
@@ -21,6 +20,7 @@ import { useAutoSaveDraft } from '@/lib/mock/useAutoSaveDraft';
 import { api } from '@/lib/http';
 import { writingExamSummaries } from '@/data/writing/exam-index';
 import { useUserContext } from '@/context/UserContext';
+import { SkeletonTextBlock } from '@/components/loading/Skeletons';
 import type {
   WritingExamPrompts,
   WritingScorePayload,
@@ -642,7 +642,10 @@ const WritingMockCBERunPage: React.FC = () => {
         {stage === 'submitting' ? (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
             <Card className="w-full max-w-md rounded-3xl border border-slate-200 bg-white p-8 text-center shadow-xl">
-              <Loader2 className="mx-auto h-10 w-10 animate-spin text-primary" aria-hidden="true" />
+              <div className="mx-auto max-w-[220px]" role="status" aria-live="polite">
+                <span className="sr-only">Submitting your responses…</span>
+                <SkeletonTextBlock />
+              </div>
               <h3 className="mt-4 text-xl font-semibold text-slate-900">Time is up</h3>
               <p className="mt-2 text-sm text-slate-600">Your editor is locked while we save and submit your responses.</p>
               {submissionError ? (

--- a/pages/vocabulary/[word].tsx
+++ b/pages/vocabulary/[word].tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import * as React from 'react';
-import { ArrowLeft, Loader2 } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 
 import { Alert } from '@/components/design-system/Alert';
 import { Badge } from '@/components/design-system/Badge';
@@ -12,6 +12,7 @@ import { Container } from '@/components/design-system/Container';
 import { EmptyState } from '@/components/design-system/EmptyState';
 import { Heading } from '@/components/design-system/Heading';
 import { Separator } from '@/components/design-system/Separator';
+import { SkeletonTextBlock } from '@/components/loading/Skeletons';
 import { PronunciationBar } from '@/components/vocab/PronunciationBar';
 import { SenseList } from '@/components/vocab/SenseList';
 import { WordCard } from '@/components/vocab/WordCard';
@@ -86,9 +87,9 @@ export default function WordDetailPage() {
 
           <Card className="space-y-6 p-6">
             {loading && (
-              <div className="flex flex-col items-center gap-3 py-16 text-muted-foreground">
-                <Loader2 className="h-10 w-10 animate-spin" aria-hidden="true" />
-                Loading word details…
+              <div className="py-12" role="status" aria-live="polite">
+                <span className="sr-only">Loading word details…</span>
+                <SkeletonTextBlock className="mx-auto max-w-xl" />
               </div>
             )}
 


### PR DESCRIPTION
### Motivation
- Provide a lightweight, premium-grade loading experience for route transitions and data fetches that avoids flashes on fast navigations and matches the dark theme design system.
- Replace inconsistent spinner affordances with reusable Skeleton components and a small provider layer so loading UX is centralized and non-blocking.

### Description
- Added a top gradient progress bar that hooks into Next.js route events and delays showing until 300ms to avoid flashes, implemented in `components/loading/RouteProgressBar.tsx` and mounted via `components/loading/LoadingProvider.tsx` integrated into `pages/_app.tsx`.
- Introduced reusable skeleton primitives and a delayed-visibility hook in `components/loading/Skeletons.tsx` and `components/loading/useDelayedVisibility.ts` to enforce the data-loading threshold and provide `SkeletonCard`, `SkeletonTableRow`, and `SkeletonTextBlock` components.
- Upgraded the design-system `Skeleton` to a subtle shimmer dark-theme style, and swapped spinner usage for skeletons in the shared loader and key surfaces (`components/common/Loader.tsx`, `components/design-system/Input.tsx`, `pages/vocabulary/[word].tsx`, and `pages/mock/writing/run.tsx`).
- Added an App Router segment loading fallback for dashboard (`app/dashboard/loading.tsx`) and structured the changes to avoid layout shift and preserve existing auth/subscription/route-guard behavior.

### Testing
- `git commit` was performed successfully and changes were committed locally; commit included new `components/loading/*` files and updates to `pages/_app.tsx` and several UI files.
- `npm run build` failed in this environment due to missing/invalid local toolchain dependencies (error locating `fast-glob`) so a full Next.js build could not be completed here.
- `npm run lint` could not run successfully in-container because the `next` binary/tooling is not available in the execution environment.
- Playwright screenshot attempt failed because no local dev server was running (`ERR_EMPTY_RESPONSE` against `http://127.0.0.1:3000`), so visual verification should be performed during CI or locally after installing dependencies and running the dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44054bce483208a9824872470477d)