### PR TITLE
Merge header and context user state, add supabase getUser fallback, and refine loading/nav behavior

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -28,15 +28,36 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
 
-  const { loading } = useUserContext();
+  const { loading, user: contextUser } = useUserContext();
   const {
-    user,
+    user: headerUser,
     role,
     streak: streakState,
     ready,
     signOut,
     subscriptionTier,
   } = useHeaderState(streak);
+
+  const user = React.useMemo(
+    () => ({
+      id: headerUser?.id ?? contextUser?.id ?? null,
+      email: headerUser?.email ?? contextUser?.email ?? null,
+      name:
+        headerUser?.name ??
+        (typeof contextUser?.user_metadata?.full_name === 'string'
+          ? contextUser.user_metadata.full_name
+          : null),
+      avatarUrl:
+        headerUser?.avatarUrl ??
+        (typeof contextUser?.user_metadata?.avatar_url === 'string'
+          ? contextUser.user_metadata.avatar_url
+          : null),
+      avatarPath: headerUser?.avatarPath ?? null,
+    }),
+    [contextUser, headerUser]
+  );
+
+  const isHeaderReady = ready || !!contextUser?.id;
 
   const [hasPremiumAccess, setHasPremiumAccess] = useState(false);
   const [premiumRooms, setPremiumRooms] = useState<string[]>([]);
@@ -193,7 +214,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
   const solidHeader = scrolled || openDesktopModules || mobileOpen;
 
   // Loading skeleton
-  if (loading && !user) {
+  if (loading && !user?.id) {
     return (
       <header className="sticky top-0 z-50 w-full border-b border-border bg-surface/90 backdrop-blur-lg">
         <Container>
@@ -392,7 +413,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
               <DesktopNav
                 user={user}
                 role={role ?? 'guest'}
-                ready={ready}
+                ready={isHeaderReady}
                 streak={streakState}
                 openModules={openDesktopModules}
                 setOpenModules={setOpenDesktopModules}
@@ -410,7 +431,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
               <MobileNav
                 user={user}
                 role={role ?? 'guest'}
-                ready={ready}
+                ready={isHeaderReady}
                 streak={streakState ?? 0}
                 mobileOpen={mobileOpen}
                 setMobileOpen={setMobileOpen}

--- a/components/navigation/DesktopNav.tsx
+++ b/components/navigation/DesktopNav.tsx
@@ -331,8 +331,8 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
 
       {/* RIGHT CLUSTER: streak, notifications, theme, user */}
       <div className="flex items-center gap-3">
-        {/* Streak chip: always show when ready + logged in */}
-        {ready && uid && (
+        {/* Streak chip: show for authenticated users */}
+        {uid && (
           <StreakChip
             value={streak ?? 0}
             href="/profile/streak"
@@ -348,34 +348,32 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
 
         {/* User menu / Sign-in */}
         <div className="ml-1">
-          {ready ? (
-            uid ? (
-              <UserMenu
-                userId={uid}
-                email={user?.email ?? undefined}
-                name={user?.name ?? undefined}
-                role={role ?? undefined}
-                avatarUrl={user?.avatarUrl ?? undefined}
-                onSignOut={async () => {
-                  await signOut?.();
-                }}
-                isAdmin={role === 'admin'}
-                items={profileMenu.map((link) => ({
-                  id: link.id,
-                  label: link.label,
-                  href: link.href,
-                }))}
-              />
-            ) : (
-              <Button
-                href="/login"
-                variant="outline"
-                size="sm"
-                className="w-full sm:w-auto rounded-full"
-              >
-                Sign in
-              </Button>
-            )
+          {uid ? (
+            <UserMenu
+              userId={uid}
+              email={user?.email ?? undefined}
+              name={user?.name ?? undefined}
+              role={role ?? undefined}
+              avatarUrl={user?.avatarUrl ?? undefined}
+              onSignOut={async () => {
+                await signOut?.();
+              }}
+              isAdmin={role === 'admin'}
+              items={profileMenu.map((link) => ({
+                id: link.id,
+                label: link.label,
+                href: link.href,
+              }))}
+            />
+          ) : ready ? (
+            <Button
+              href="/login"
+              variant="outline"
+              size="sm"
+              className="w-full sm:w-auto rounded-full"
+            >
+              Sign in
+            </Button>
           ) : (
             <div className="h-9 w-24 animate-pulse rounded-full bg-surface-muted dark:bg-surface-muted-dark" />
           )}

--- a/components/navigation/MobileNav.tsx
+++ b/components/navigation/MobileNav.tsx
@@ -478,7 +478,7 @@ export function MobileNav({
             </div>
           )}
 
-          {!ready && (
+          {!ready && !user?.id && (
             <div className="mt-6 space-y-2">
               <div className="h-12 w-full animate-pulse rounded-xl bg-muted dark:bg-muted-dark" />
               <div className="h-12 w-full animate-pulse rounded-xl bg-muted dark:bg-muted-dark" />


### PR DESCRIPTION
### Motivation

- Ensure the header reflects authenticated state as soon as possible and avoid a stuck loading skeleton when Supabase session info lags.  
- Provide a robust fallback to fetch the authenticated user and compute identity reliably.  

### Description

- In `Header.tsx` combine `useHeaderState`'s `user` (`headerUser`) with `useUserContext`'s `user` (`contextUser`) via `React.useMemo` and expose a derived `isHeaderReady = ready || !!contextUser?.id`, and update the loading skeleton check to `if (loading && !user?.id)`.  
- Pass `isHeaderReady` into `DesktopNav` and `MobileNav` instead of `ready` and update usages to rely on the merged `user` object.  
- In `components/hooks/useHeaderState.ts` add a fallback to `supabase.auth.getUser()` when `supabase.auth.getSession()` returns no user, use the resolved `currentUser` for `setUser` and `computeIdentity`, and ensure `setReady(true)` runs in a `finally` block.  
- Adjust navigation components: `DesktopNav.tsx` shows the streak and `UserMenu` as soon as a `uid` is present and otherwise shows sign-in or a skeleton appropriately, and `MobileNav.tsx` avoids rendering the loading skeleton when a user id already exists.  

### Testing

- Type checking with `tsc --noEmit` was run and succeeded.  
- Frontend unit tests were run via `yarn test` and passed.  
- A production build was validated with `yarn build` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a445966cfc8320a95875f7acd8f7db)