### PR TITLE
Unify auth gating for account & settings pages

### DIFF
--- a/lib/requirePageAuth.ts
+++ b/lib/requirePageAuth.ts
@@ -1,0 +1,55 @@
+import type { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+
+import { getServerClient } from '@/lib/supabaseServer';
+
+export function createAuthRedirect(resolvedUrl?: string) {
+  const next = resolvedUrl && resolvedUrl !== '/' ? `?next=${encodeURIComponent(resolvedUrl)}` : '';
+  return {
+    redirect: {
+      destination: `/login${next}`,
+      permanent: false,
+    },
+  };
+}
+
+export async function requirePageAuth(
+  ctx: GetServerSidePropsContext,
+): Promise<GetServerSidePropsResult<{ userId: string }>> {
+  const supabase = getServerClient(ctx.req, ctx.res);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return createAuthRedirect(ctx.resolvedUrl);
+  }
+
+  return {
+    props: {
+      userId: user.id,
+    },
+  };
+}
+
+export function withPageAuth<T extends Record<string, unknown> = Record<string, never>>(
+  handler?: (
+    ctx: GetServerSidePropsContext,
+    userId: string,
+  ) => Promise<GetServerSidePropsResult<T>>,
+): GetServerSideProps<T> {
+  return async (ctx) => {
+    const authResult = await requirePageAuth(ctx);
+
+    if ('redirect' in authResult || 'notFound' in authResult) {
+      return authResult as GetServerSidePropsResult<T>;
+    }
+
+    if (!handler) {
+      return {
+        props: {} as T,
+      };
+    }
+
+    return handler(ctx, authResult.props.userId);
+  };
+}

--- a/pages/profile/account/activity.tsx
+++ b/pages/profile/account/activity.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import type { GetServerSideProps, NextPage } from 'next';
 
 import { getServerClient } from '@/lib/supabaseServer';
+import { createAuthRedirect } from '@/lib/requirePageAuth';
 import type { Database } from '@/lib/database.types';
 
 import { Container } from '@/components/design-system/Container';
@@ -63,9 +64,7 @@ function describeActivity(row: ActivityRow): string {
 
   switch (activity_type) {
     case 'mock_attempt_started':
-      return testTitle
-        ? `Started mock test: ${testTitle}`
-        : 'Started a mock test';
+      return testTitle ? `Started mock test: ${testTitle}` : 'Started a mock test';
 
     case 'mock_attempt_submitted':
       if (testTitle && band != null) {
@@ -81,9 +80,7 @@ function describeActivity(row: ActivityRow): string {
       return `Completed a ${moduleLabel[module] ?? module} practice session`;
 
     case 'lesson_completed':
-      return testTitle
-        ? `Completed lesson: ${testTitle}`
-        : 'Completed a lesson';
+      return testTitle ? `Completed lesson: ${testTitle}` : 'Completed a lesson';
 
     case 'streak_day_recorded':
       return 'Daily streak updated';
@@ -133,21 +130,15 @@ const ActivityPage: NextPage<Props> = ({ activities }) => {
           {/* Header */}
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div>
-              <h1 className="text-h2 font-semibold tracking-tight">
-                Activity log
-              </h1>
+              <h1 className="text-h2 font-semibold tracking-tight">Activity log</h1>
               <p className="mt-1 max-w-xl text-small text-muted-foreground">
-                A unified timeline of your mocks, practice, lessons, and streak
-                updates – only visible to you (and admins for support).
+                A unified timeline of your mocks, practice, lessons, and streak updates – only
+                visible to you (and admins for support).
               </p>
             </div>
 
             <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="border border-border/60"
-              >
+              <Button variant="ghost" size="sm" className="border border-border/60">
                 <Icon name="filter" className="mr-2 h-4 w-4" />
                 Filters (coming soon)
               </Button>
@@ -162,10 +153,7 @@ const ActivityPage: NextPage<Props> = ({ activities }) => {
           <Card className="border border-border/60 bg-muted/40">
             <div className="flex flex-wrap items-center gap-4 px-4 py-3 text-small">
               <div className="flex items-center gap-2">
-                <Icon
-                  name="history"
-                  className="h-4 w-4 text-muted-foreground"
-                />
+                <Icon name="history" className="h-4 w-4 text-muted-foreground" />
                 <span className="font-medium">
                   {activities.length > 0
                     ? `${activities.length} activities tracked`
@@ -174,8 +162,7 @@ const ActivityPage: NextPage<Props> = ({ activities }) => {
               </div>
               <div className="hidden h-4 w-px bg-border/60 sm:block" />
               <p className="text-muted-foreground">
-                This log is personal to you. Only you and admins (for support)
-                can see it.
+                This log is personal to you. Only you and admins (for support) can see it.
               </p>
             </div>
           </Card>
@@ -183,14 +170,10 @@ const ActivityPage: NextPage<Props> = ({ activities }) => {
           {/* Timeline */}
           {activities.length === 0 ? (
             <Card className="py-10 text-center">
-              <Icon
-                name="inbox"
-                className="mx-auto mb-3 h-8 w-8 text-muted-foreground"
-              />
+              <Icon name="inbox" className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
               <p className="font-medium">No activity yet</p>
               <p className="mt-1 text-small text-muted-foreground">
-                Start a mock test or practice session and your timeline will
-                show up here.
+                Start a mock test or practice session and your timeline will show up here.
               </p>
             </Card>
           ) : (
@@ -209,21 +192,14 @@ const ActivityPage: NextPage<Props> = ({ activities }) => {
                     <ul className="divide-y divide-border/60">
                       {rows.map((row) => {
                         const label = moduleLabel[row.module] ?? row.module;
-                        const iconName =
-                          moduleIcon[row.module] ?? 'activity';
+                        const iconName = moduleIcon[row.module] ?? 'activity';
 
                         return (
-                          <li
-                            key={row.id}
-                            className="flex items-start gap-4 px-4 py-3"
-                          >
+                          <li key={row.id} className="flex items-start gap-4 px-4 py-3">
                             {/* Left: icon + vertical line */}
                             <div className="flex flex-col items-center">
                               <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary">
-                                <Icon
-                                  name={iconName}
-                                  className="h-4 w-4"
-                                />
+                                <Icon name={iconName} className="h-4 w-4" />
                               </div>
                               <div className="mt-1 h-full w-px flex-1 bg-border/40" />
                             </div>
@@ -231,9 +207,7 @@ const ActivityPage: NextPage<Props> = ({ activities }) => {
                             {/* Content */}
                             <div className="flex-1 space-y-1">
                               <div className="flex flex-wrap items-center gap-2">
-                                <p className="text-small font-medium">
-                                  {describeActivity(row)}
-                                </p>
+                                <p className="text-small font-medium">{describeActivity(row)}</p>
                                 <Badge size="sm" variant="soft">
                                   {label}
                                 </Badge>
@@ -246,17 +220,14 @@ const ActivityPage: NextPage<Props> = ({ activities }) => {
                                 </span>
                               </p>
 
-                              {row.meta &&
-                                Object.keys(row.meta).length > 0 && (
-                                  <div className="mt-1 rounded-md bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground">
-                                    <span className="font-medium">
-                                      Extra details:
-                                    </span>{' '}
-                                    <code className="font-mono text-[11px]">
-                                      {JSON.stringify(row.meta)}
-                                    </code>
-                                  </div>
-                                )}
+                              {row.meta && Object.keys(row.meta).length > 0 && (
+                                <div className="mt-1 rounded-md bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground">
+                                  <span className="font-medium">Extra details:</span>{' '}
+                                  <code className="font-mono text-[11px]">
+                                    {JSON.stringify(row.meta)}
+                                  </code>
+                                </div>
+                              )}
                             </div>
                           </li>
                         );
@@ -281,12 +252,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    return {
-      redirect: {
-        destination: '/auth/login?next=/account/activity',
-        permanent: false,
-      },
-    };
+    return createAuthRedirect(ctx.resolvedUrl);
   }
 
   const { data, error } = await supabase

--- a/pages/profile/account/billing.tsx
+++ b/pages/profile/account/billing.tsx
@@ -5,15 +5,12 @@ import { useRouter } from 'next/router';
 import type { GetServerSideProps } from 'next';
 
 import { getServerClient } from '@/lib/supabaseServer';
+import { createAuthRedirect } from '@/lib/requirePageAuth';
 
 import { Alert } from '@/components/design-system/Alert';
 import { Badge } from '@/components/design-system/Badge';
 import { Button } from '@/components/design-system/Button';
-import {
-  Card,
-  CardContent,
-  CardHeader,
-} from '@/components/design-system/Card';
+import { Card, CardContent, CardHeader } from '@/components/design-system/Card';
 import { Heading } from '@/components/design-system/Heading';
 import { Section } from '@/components/design-system/Section';
 import { SectionLabel } from '@/components/design-system/SectionLabel';
@@ -30,14 +27,7 @@ type Invoice = {
 
 type Summary = {
   plan: 'free' | 'starter' | 'booster' | 'master';
-  status:
-    | 'active'
-    | 'trialing'
-    | 'canceled'
-    | 'incomplete'
-    | 'past_due'
-    | 'unpaid'
-    | 'paused';
+  status: 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due' | 'unpaid' | 'paused';
   renewsAt?: string;
   trialEndsAt?: string;
 };
@@ -58,21 +48,14 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   const { data, error } = await supabase.auth.getUser();
 
   if (error || !data?.user) {
-    return {
-      redirect: {
-        destination: `/login?next=${encodeURIComponent(resolvedUrl)}`,
-        permanent: false,
-      },
-    };
+    return createAuthRedirect(resolvedUrl);
   }
 
   return { props: {} };
 };
 
 const toTitleCase = (value: string) =>
-  value
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
+  value.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 
 const getStatusVariant = (status: Summary['status']) => {
   switch (status) {
@@ -135,40 +118,38 @@ export default function BillingPage() {
 
   const providerValue = router.query['provider'];
   const providerParam = Array.isArray(providerValue)
-    ? providerValue[0] ?? null
+    ? (providerValue[0] ?? null)
     : typeof providerValue === 'string'
-    ? providerValue
-    : null;
+      ? providerValue
+      : null;
 
   const statusValue = router.query['status'];
   const statusParam = Array.isArray(statusValue)
-    ? statusValue[0] ?? null
+    ? (statusValue[0] ?? null)
     : typeof statusValue === 'string'
-    ? statusValue
-    : null;
+      ? statusValue
+      : null;
 
   const reasonValue = router.query['reason'];
   const reasonParam = Array.isArray(reasonValue)
-    ? reasonValue[0] ?? null
+    ? (reasonValue[0] ?? null)
     : typeof reasonValue === 'string'
-    ? reasonValue
-    : null;
+      ? reasonValue
+      : null;
 
   const setupValue = router.query['setup'];
   const setupParam = Array.isArray(setupValue)
-    ? setupValue[0] ?? null
+    ? (setupValue[0] ?? null)
     : typeof setupValue === 'string'
-    ? setupValue
-    : null;
+      ? setupValue
+      : null;
 
   const safepayStatus = providerParam === 'safepay' ? statusParam : null;
   const safepayReason = providerParam === 'safepay' ? reasonParam : null;
   const showSafepaySetup =
-    providerParam === 'safepay' &&
-    (setupParam === '1' || setupParam === 'true');
+    providerParam === 'safepay' && (setupParam === '1' || setupParam === 'true');
   const showSafepayPending = safepayStatus === 'pending';
-  const showSafepayCancelled =
-    safepayStatus === 'cancelled' || safepayStatus === 'canceled';
+  const showSafepayCancelled = safepayStatus === 'cancelled' || safepayStatus === 'canceled';
   const showSafepayFailed = safepayStatus === 'failed';
   const showSafepayError = safepayStatus === 'error';
 
@@ -194,8 +175,7 @@ export default function BillingPage() {
   );
 
   const formatDate = React.useCallback(
-    (value?: string | null) =>
-      value ? dateFormatter.format(new Date(value)) : null,
+    (value?: string | null) => (value ? dateFormatter.format(new Date(value)) : null),
     [dateFormatter],
   );
   const formatDateTime = React.useCallback(
@@ -265,11 +245,7 @@ export default function BillingPage() {
       </Head>
 
       <main className="min-h-screen bg-background text-foreground">
-        <Section
-          className="bg-background"
-          Container
-          containerClassName="max-w-5xl space-y-8 py-10"
-        >
+        <Section className="bg-background" Container containerClassName="max-w-5xl space-y-8 py-10">
           <header className="space-y-2">
             <Heading as="h1" size="lg" className="text-foreground">
               Billing
@@ -287,27 +263,21 @@ export default function BillingPage() {
               role="alert"
             >
               <p className="mt-2 text-small text-muted-foreground">
-                Safepay is running in developer mode. Add your Safepay public
-                and secret keys to enable the live checkout experience.
+                Safepay is running in developer mode. Add your Safepay public and secret keys to
+                enable the live checkout experience.
               </p>
               <p className="mt-2 text-caption text-muted-foreground">
-                Update <code>SAFEPAY_PUBLIC_KEY</code> and{' '}
-                <code>SAFEPAY_SECRET_KEY</code> in your environment, then
-                restart the app.
+                Update <code>SAFEPAY_PUBLIC_KEY</code> and <code>SAFEPAY_SECRET_KEY</code> in your
+                environment, then restart the app.
               </p>
             </Alert>
           )}
 
           {showSafepayPending && (
-            <Alert
-              variant="info"
-              appearance="soft"
-              title="Safepay payment pending"
-              role="status"
-            >
+            <Alert variant="info" appearance="soft" title="Safepay payment pending" role="status">
               <p className="mt-2 text-small text-muted-foreground">
-                We have not received confirmation from Safepay yet. You will
-                get an email once the payment completes.
+                We have not received confirmation from Safepay yet. You will get an email once the
+                payment completes.
               </p>
             </Alert>
           )}
@@ -320,19 +290,14 @@ export default function BillingPage() {
               role="alert"
             >
               <p className="mt-2 text-small text-muted-foreground">
-                Your Safepay session was cancelled before payment was
-                completed. Start a new checkout to try again.
+                Your Safepay session was cancelled before payment was completed. Start a new
+                checkout to try again.
               </p>
             </Alert>
           )}
 
           {showSafepayFailed && (
-            <Alert
-              variant="error"
-              appearance="soft"
-              title="Safepay payment failed"
-              role="alert"
-            >
+            <Alert variant="error" appearance="soft" title="Safepay payment failed" role="alert">
               <p className="mt-2 text-small text-muted-foreground">
                 {safepayReason
                   ? safepayReason
@@ -349,8 +314,8 @@ export default function BillingPage() {
               role="alert"
             >
               <p className="mt-2 text-small text-muted-foreground">
-                We could not verify the Safepay callback. If you completed the
-                payment, contact support with your receipt.
+                We could not verify the Safepay callback. If you completed the payment, contact
+                support with your receipt.
               </p>
             </Alert>
           )}
@@ -366,12 +331,7 @@ export default function BillingPage() {
           )}
 
           {!loading && error && (
-            <Alert
-              variant="error"
-              appearance="soft"
-              title="Couldn’t load billing"
-              role="alert"
-            >
+            <Alert variant="error" appearance="soft" title="Couldn’t load billing" role="alert">
               <p className="mt-2 text-small text-muted-foreground">{error}</p>
               <div className="mt-3">
                 <Button asChild variant="link" size="sm">
@@ -383,12 +343,7 @@ export default function BillingPage() {
 
           {!loading && !error && summary && (
             <div className="space-y-6">
-              <Card
-                as="section"
-                padding="none"
-                insetBorder
-                aria-labelledby="current-plan-heading"
-              >
+              <Card as="section" padding="none" insetBorder aria-labelledby="current-plan-heading">
                 <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-2">
                     <SectionLabel>Current plan</SectionLabel>
@@ -409,11 +364,7 @@ export default function BillingPage() {
                   </div>
 
                   {portalAvailable ? (
-                    <Button
-                      onClick={openPortal}
-                      loading={portalLoading}
-                      size="lg"
-                    >
+                    <Button onClick={openPortal} loading={portalLoading} size="lg">
                       {portalLoading ? 'Opening…' : 'Manage billing'}
                     </Button>
                   ) : (
@@ -426,17 +377,10 @@ export default function BillingPage() {
                 {(justVaulted || !portalAvailable) && (
                   <CardContent className="space-y-3 pt-0">
                     {!portalAvailable && (
-                      <Alert
-                        variant="info"
-                        appearance="soft"
-                        title="Billing portal unavailable"
-                      >
+                      <Alert variant="info" appearance="soft" title="Billing portal unavailable">
                         <p className="mt-1 text-small text-muted-foreground">
                           The hosted Stripe portal is temporarily offline. Email{' '}
-                          <a
-                            className="underline"
-                            href="mailto:support@gramorx.com"
-                          >
+                          <a className="underline" href="mailto:support@gramorx.com">
                             support@gramorx.com
                           </a>{' '}
                           to update or cancel your subscription.
@@ -451,12 +395,10 @@ export default function BillingPage() {
                         title="Card saved — payment due later"
                       >
                         <p className="mt-1 text-small text-muted-foreground">
-                          Payments are temporarily unavailable. If you recently
-                          subscribed, your card was{' '}
-                          <span className="font-medium">not charged</span> and
-                          the amount is marked as{' '}
-                          <span className="font-medium">due</span>. We’ll
-                          notify you before retrying payment.
+                          Payments are temporarily unavailable. If you recently subscribed, your
+                          card was <span className="font-medium">not charged</span> and the amount
+                          is marked as <span className="font-medium">due</span>. We’ll notify you
+                          before retrying payment.
                         </p>
                       </Alert>
                     )}
@@ -465,21 +407,11 @@ export default function BillingPage() {
               </Card>
 
               {dues.length > 0 && (
-                <Card
-                  as="section"
-                  padding="none"
-                  insetBorder
-                  aria-labelledby="pending-dues"
-                >
+                <Card as="section" padding="none" insetBorder aria-labelledby="pending-dues">
                   <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div>
                       <SectionLabel>Local payments</SectionLabel>
-                      <Heading
-                        as="h2"
-                        size="xs"
-                        id="pending-dues"
-                        className="text-foreground"
-                      >
+                      <Heading as="h2" size="xs" id="pending-dues" className="text-foreground">
                         Pending dues
                       </Heading>
                     </div>
@@ -511,8 +443,7 @@ export default function BillingPage() {
                                 {toTitleCase(d.status)}
                               </Badge>
                               <div className="text-small text-muted-foreground">
-                                {toTitleCase(d.plan_key)} ·{' '}
-                                {toTitleCase(d.cycle)}
+                                {toTitleCase(d.plan_key)} · {toTitleCase(d.cycle)}
                               </div>
                               <div className="text-caption text-muted-foreground">
                                 {formatDateTime(d.created_at)}
@@ -520,14 +451,9 @@ export default function BillingPage() {
                             </div>
                             <div className="space-y-1 text-right">
                               <p className="text-h4 font-semibold text-foreground">
-                                {currencyFormatter(
-                                  d.amount_cents / 100,
-                                  d.currency,
-                                )}
+                                {currencyFormatter(d.amount_cents / 100, d.currency)}
                               </p>
-                              <p className="text-caption text-muted-foreground">
-                                Not charged yet
-                              </p>
+                              <p className="text-caption text-muted-foreground">Not charged yet</p>
                             </div>
                           </div>
                         </li>
@@ -537,30 +463,18 @@ export default function BillingPage() {
                 </Card>
               )}
 
-              <Card
-                as="section"
-                padding="none"
-                insetBorder
-                aria-labelledby="invoices-heading"
-              >
+              <Card as="section" padding="none" insetBorder aria-labelledby="invoices-heading">
                 <CardHeader>
                   <div>
                     <SectionLabel>History</SectionLabel>
-                    <Heading
-                      as="h2"
-                      size="xs"
-                      id="invoices-heading"
-                      className="text-foreground"
-                    >
+                    <Heading as="h2" size="xs" id="invoices-heading" className="text-foreground">
                       Invoices
                     </Heading>
                   </div>
                 </CardHeader>
                 <CardContent>
                   {invoices.length === 0 ? (
-                    <p className="text-small text-muted-foreground">
-                      No invoices yet.
-                    </p>
+                    <p className="text-small text-muted-foreground">No invoices yet.</p>
                   ) : (
                     <ul className="space-y-3">
                       {invoices.map((inv) => (
@@ -570,9 +484,7 @@ export default function BillingPage() {
                         >
                           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                             <div className="space-y-2">
-                              <Badge
-                                variant={getInvoiceVariant(inv.status)}
-                              >
+                              <Badge variant={getInvoiceVariant(inv.status)}>
                                 {toTitleCase(inv.status)}
                               </Badge>
                               <p className="text-caption text-muted-foreground">
@@ -581,29 +493,16 @@ export default function BillingPage() {
                             </div>
                             <div className="space-y-2 text-right">
                               <p className="text-h4 font-semibold text-foreground">
-                                {currencyFormatter(
-                                  inv.amount / 100,
-                                  inv.currency,
-                                )}
+                                {currencyFormatter(inv.amount / 100, inv.currency)}
                               </p>
                               {inv.hostedInvoiceUrl ? (
-                                <Button
-                                  asChild
-                                  variant="link"
-                                  size="sm"
-                                >
-                                  <a
-                                    href={inv.hostedInvoiceUrl}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                  >
+                                <Button asChild variant="link" size="sm">
+                                  <a href={inv.hostedInvoiceUrl} target="_blank" rel="noreferrer">
                                     View invoice
                                   </a>
                                 </Button>
                               ) : (
-                                <span className="text-caption text-muted-foreground">
-                                  No PDF
-                                </span>
+                                <span className="text-caption text-muted-foreground">No PDF</span>
                               )}
                             </div>
                           </div>
@@ -617,13 +516,9 @@ export default function BillingPage() {
           )}
 
           {!loading && !error && !summary && (
-            <Alert
-              variant="info"
-              appearance="soft"
-              title="No subscription data"
-            >
-              We couldn’t find an active subscription yet. Start a plan from
-              the pricing page when you’re ready.
+            <Alert variant="info" appearance="soft" title="No subscription data">
+              We couldn’t find an active subscription yet. Start a plan from the pricing page when
+              you’re ready.
             </Alert>
           )}
         </Section>

--- a/pages/profile/account/index.tsx
+++ b/pages/profile/account/index.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -10,6 +11,7 @@ import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Card } from '@/components/design-system/Card';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { withPageAuth } from '@/lib/requirePageAuth';
 import { getPlan, isPaidPlan, type PlanId } from '@/types/pricing';
 
 import {
@@ -28,14 +30,7 @@ import {
 
 type BillingSummary = {
   plan: PlanId;
-  status:
-    | 'active'
-    | 'trialing'
-    | 'canceled'
-    | 'incomplete'
-    | 'past_due'
-    | 'unpaid'
-    | 'paused';
+  status: 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due' | 'unpaid' | 'paused';
   renewsAt?: string;
   trialEndsAt?: string;
 };
@@ -69,9 +64,7 @@ export default function AccountHubPage() {
   });
 
   const statusVariant = React.useCallback(
-    (status: BillingSummary['status']): React.ComponentProps<
-      typeof Badge
-    >['variant'] => {
+    (status: BillingSummary['status']): React.ComponentProps<typeof Badge>['variant'] => {
       switch (status) {
         case 'active':
           return 'success';
@@ -94,9 +87,7 @@ export default function AccountHubPage() {
 
   const formatStatus = React.useCallback(
     (status: BillingSummary['status']) =>
-      status
-        .replace(/_/g, ' ')
-        .replace(/\b\w/g, (char) => char.toUpperCase()),
+      status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
     [],
   );
 
@@ -124,14 +115,11 @@ export default function AccountHubPage() {
         if (cancelled) return;
 
         setSummary(data.summary);
-        const canOpenPortal =
-          Boolean(data.customerId) && !data.needsStripeSetup;
+        const canOpenPortal = Boolean(data.customerId) && !data.needsStripeSetup;
         setPortalAvailable(canOpenPortal);
       } catch (error) {
         if (cancelled) return;
-        setBillingError(
-          (error as Error).message || 'Failed to load billing',
-        );
+        setBillingError((error as Error).message || 'Failed to load billing');
         setSummary(null);
         setPortalAvailable(false);
       } finally {
@@ -163,10 +151,7 @@ export default function AccountHubPage() {
 
       if (profile) {
         setIsAdmin(profile.role === 'admin');
-        setIsTeacher(
-          profile.teacher_approved === true ||
-            profile.role === 'teacher',
-        );
+        setIsTeacher(profile.teacher_approved === true || profile.role === 'teacher');
       }
 
       if (sessionData.session?.user?.id) {
@@ -227,31 +212,23 @@ export default function AccountHubPage() {
 
       if (!response.ok) {
         throw new Error(
-          (payload && payload.error) ||
-            response.statusText ||
-            'Failed to open billing portal',
+          (payload && payload.error) || response.statusText || 'Failed to open billing portal',
         );
       }
 
-      const url =
-        typeof payload?.url === 'string' ? payload.url : null;
+      const url = typeof payload?.url === 'string' ? payload.url : null;
       if (!url) {
         throw new Error('Failed to open billing portal');
       }
 
       window.location.href = url;
     } catch (error) {
-      setBillingError(
-        (error as Error).message || 'Failed to open billing portal',
-      );
+      setBillingError((error as Error).message || 'Failed to open billing portal');
       setPortalLoading(false);
     }
   }, []);
 
-  const planDefinition = React.useMemo(
-    () => (summary ? getPlan(summary.plan) : null),
-    [summary],
-  );
+  const planDefinition = React.useMemo(() => (summary ? getPlan(summary.plan) : null), [summary]);
   const isPremiumPlan = React.useMemo(
     () => (summary ? isPaidPlan(summary.plan) : false),
     [summary],
@@ -264,16 +241,10 @@ export default function AccountHubPage() {
     if (!summary) return null;
     const parts: string[] = [];
     if (summary.renewsAt) {
-      parts.push(
-        `Renews ${dateFormatter.format(new Date(summary.renewsAt))}`,
-      );
+      parts.push(`Renews ${dateFormatter.format(new Date(summary.renewsAt))}`);
     }
     if (summary.trialEndsAt) {
-      parts.push(
-        `Trial ends ${dateFormatter.format(
-          new Date(summary.trialEndsAt),
-        )}`,
-      );
+      parts.push(`Trial ends ${dateFormatter.format(new Date(summary.trialEndsAt))}`);
     }
     return parts;
   }, [summary, dateFormatter]);
@@ -290,12 +261,9 @@ export default function AccountHubPage() {
         typeof window !== 'undefined'
           ? window.location.origin
           : process.env.NEXT_PUBLIC_SITE_URL || '';
-      const { error } = await supabase.auth.resetPasswordForEmail(
-        email,
-        {
-          redirectTo: `${origin}/login/reset`,
-        },
-      );
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${origin}/login/reset`,
+      });
       if (error) {
         alert(error.message);
       } else {
@@ -324,8 +292,8 @@ export default function AccountHubPage() {
               Account &amp; Settings
             </h1>
             <p className="mt-2 text-small text-muted-foreground">
-              This is your home for anything related to your account — plan,
-              activity, security, and shortcuts into all settings pages.
+              This is your home for anything related to your account — plan, activity, security, and
+              shortcuts into all settings pages.
             </p>
           </header>
 
@@ -337,12 +305,8 @@ export default function AccountHubPage() {
                   <Activity className="h-5 w-5" />
                 </div>
                 <div>
-                  <p className="text-small text-muted-foreground">
-                    Total Activities
-                  </p>
-                  <p className="text-h3 font-bold">
-                    {activityStats.totalActivities}
-                  </p>
+                  <p className="text-small text-muted-foreground">Total Activities</p>
+                  <p className="text-h3 font-bold">{activityStats.totalActivities}</p>
                 </div>
               </div>
             </div>
@@ -353,12 +317,8 @@ export default function AccountHubPage() {
                   <History className="h-5 w-5" />
                 </div>
                 <div>
-                  <p className="text-small text-muted-foreground">
-                    Recent (7d)
-                  </p>
-                  <p className="text-h3 font-bold">
-                    {activityStats.recentActivities}
-                  </p>
+                  <p className="text-small text-muted-foreground">Recent (7d)</p>
+                  <p className="text-h3 font-bold">{activityStats.recentActivities}</p>
                 </div>
               </div>
             </div>
@@ -370,12 +330,8 @@ export default function AccountHubPage() {
                   <CheckCircle className="h-5 w-5" />
                 </div>
                 <div>
-                  <p className="text-small text-muted-foreground">
-                    Pending Tasks
-                  </p>
-                  <p className="text-h3 font-bold">
-                    {activityStats.pendingTasks}
-                  </p>
+                  <p className="text-small text-muted-foreground">Pending Tasks</p>
+                  <p className="text-h3 font-bold">{activityStats.pendingTasks}</p>
                 </div>
               </div>
             </div>
@@ -386,12 +342,8 @@ export default function AccountHubPage() {
                   <CheckCircle className="h-5 w-5" />
                 </div>
                 <div>
-                  <p className="text-small text-muted-foreground">
-                    Completed
-                  </p>
-                  <p className="text-h3 font-bold">
-                    {activityStats.completedTasks}
-                  </p>
+                  <p className="text-small text-muted-foreground">Completed</p>
+                  <p className="text-h3 font-bold">{activityStats.completedTasks}</p>
                 </div>
               </div>
             </div>
@@ -407,42 +359,25 @@ export default function AccountHubPage() {
                     <History className="h-5 w-5" />
                   </div>
                   <div>
-                    <h2 className="text-small font-medium text-foreground">
-                      Activity log
-                    </h2>
+                    <h2 className="text-small font-medium text-foreground">Activity log</h2>
                     <p className="mt-1 text-small text-muted-foreground">
-                      Unified timeline of your mocks, practice, and streak
-                      events.
+                      Unified timeline of your mocks, practice, and streak events.
                     </p>
                   </div>
                 </div>
-                <Badge
-                  variant={
-                    activityStats.recentActivities > 0
-                      ? 'info'
-                      : 'neutral'
-                  }
-                >
+                <Badge variant={activityStats.recentActivities > 0 ? 'info' : 'neutral'}>
                   {activityStats.recentActivities} new
                 </Badge>
               </div>
 
               <div className="space-y-3">
                 <div className="flex items-center justify-between text-small">
-                  <span className="text-muted-foreground">
-                    Recent activities:
-                  </span>
-                  <span className="font-medium">
-                    {activityStats.recentActivities}
-                  </span>
+                  <span className="text-muted-foreground">Recent activities:</span>
+                  <span className="font-medium">{activityStats.recentActivities}</span>
                 </div>
                 <div className="flex items-center justify-between text-small">
-                  <span className="text-muted-foreground">
-                    Total logged:
-                  </span>
-                  <span className="font-medium">
-                    {activityStats.totalActivities}
-                  </span>
+                  <span className="text-muted-foreground">Total logged:</span>
+                  <span className="font-medium">{activityStats.totalActivities}</span>
                 </div>
 
                 <div className="mt-4 border-t border-border pt-4">
@@ -450,23 +385,13 @@ export default function AccountHubPage() {
                     Quick actions
                   </h3>
                   <div className="flex flex-wrap gap-2">
-                    <Button
-                      asChild
-                      variant="soft"
-                      size="sm"
-                      className="min-w-[120px] flex-1"
-                    >
+                    <Button asChild variant="soft" size="sm" className="min-w-[120px] flex-1">
                       <Link href="/account/activity">
                         <History className="mr-2 h-3 w-3" />
                         View timeline
                       </Link>
                     </Button>
-                    <Button
-                      asChild
-                      variant="soft"
-                      size="sm"
-                      className="min-w-[120px] flex-1"
-                    >
+                    <Button asChild variant="soft" size="sm" className="min-w-[120px] flex-1">
                       <Link href="/mock">
                         <History className="mr-2 h-3 w-3" />
                         Open mocks
@@ -485,12 +410,9 @@ export default function AccountHubPage() {
                     <Crown className="h-5 w-5" />
                   </div>
                   <div>
-                    <h2 className="text-small font-medium text-foreground">
-                      Plan &amp; billing
-                    </h2>
+                    <h2 className="text-small font-medium text-foreground">Plan &amp; billing</h2>
                     <p className="mt-1 text-small text-muted-foreground">
-                      Check subscription status and manage payments from one
-                      place.
+                      Check subscription status and manage payments from one place.
                     </p>
                   </div>
                 </div>
@@ -522,9 +444,7 @@ export default function AccountHubPage() {
                       <p className="text-caption text-muted-foreground">
                         {planMeta.map((part, index) => (
                           <React.Fragment key={`${part}-${index}`}>
-                            {index > 0 && (
-                              <span aria-hidden="true"> · </span>
-                            )}
+                            {index > 0 && <span aria-hidden="true"> · </span>}
                             <span>{part}</span>
                           </React.Fragment>
                         ))}
@@ -541,46 +461,28 @@ export default function AccountHubPage() {
                             tone="accent"
                             className="flex-1"
                           >
-                            {portalLoading
-                              ? 'Opening…'
-                              : 'Manage billing'}
+                            {portalLoading ? 'Opening…' : 'Manage billing'}
                           </Button>
                         ) : (
-                          <Button
-                            asChild
-                            variant="soft"
-                            className="flex-1"
-                          >
-                            <Link href="/profile/account/billing">
-                              Open billing hub
-                            </Link>
+                          <Button asChild variant="soft" className="flex-1">
+                            <Link href="/profile/account/billing">Open billing hub</Link>
                           </Button>
                         )
                       ) : (
-                        <Button
-                          asChild
-                          variant="soft"
-                          tone="accent"
-                          className="flex-1"
-                        >
-                          <Link href="/pricing">
-                            Upgrade to Premium
-                          </Link>
+                        <Button asChild variant="soft" tone="accent" className="flex-1">
+                          <Link href="/pricing">Upgrade to Premium</Link>
                         </Button>
                       )}
                     </div>
 
                     {!isPremiumPlan && (
                       <p className="mt-2 text-xs text-muted-foreground">
-                        Unlock unlimited mocks, full AI feedback, and advanced
-                        analytics.
+                        Unlock unlimited mocks, full AI feedback, and advanced analytics.
                       </p>
                     )}
                   </>
                 ) : (
-                  <p className="text-small text-muted-foreground">
-                    No active subscription found.
-                  </p>
+                  <p className="text-small text-muted-foreground">No active subscription found.</p>
                 )}
               </div>
             </div>
@@ -592,9 +494,7 @@ export default function AccountHubPage() {
                   <Globe className="h-5 w-5" />
                 </div>
                 <div>
-                  <h2 className="text-small font-medium text-foreground">
-                    Language
-                  </h2>
+                  <h2 className="text-small font-medium text-foreground">Language</h2>
                   <p className="mt-1 text-small text-muted-foreground">
                     Switch between English and Urdu interface.
                   </p>
@@ -619,9 +519,7 @@ export default function AccountHubPage() {
                   <Bell className="h-5 w-5" />
                 </div>
                 <div>
-                  <h2 className="text-small font-medium text-foreground">
-                    Notifications
-                  </h2>
+                  <h2 className="text-small font-medium text-foreground">Notifications</h2>
                   <p className="mt-1 text-small text-muted-foreground">
                     Daily reminders and nudges for your study rhythm.
                   </p>
@@ -654,9 +552,7 @@ export default function AccountHubPage() {
                   <SettingsIcon className="h-5 w-5" />
                 </div>
                 <div>
-                  <h2 className="text-small font-medium text-foreground">
-                    Accessibility
-                  </h2>
+                  <h2 className="text-small font-medium text-foreground">Accessibility</h2>
                   <p className="mt-1 text-small text-muted-foreground">
                     High contrast, focus ring tuning, and reduced motion.
                   </p>
@@ -679,9 +575,7 @@ export default function AccountHubPage() {
                   <Shield className="h-5 w-5" />
                 </div>
                 <div>
-                  <h2 className="text-small font-medium text-foreground">
-                    Security
-                  </h2>
+                  <h2 className="text-small font-medium text-foreground">Security</h2>
                   <p className="mt-1 text-small text-muted-foreground">
                     MFA, active sessions, and login history.
                   </p>
@@ -689,9 +583,7 @@ export default function AccountHubPage() {
               </div>
               <div className="space-y-3">
                 <div className="flex items-center justify-between text-small">
-                  <span className="text-muted-foreground">
-                    Email on file:
-                  </span>
+                  <span className="text-muted-foreground">Email on file:</span>
                   <span
                     className="max-w-[140px] truncate font-medium sm:max-w-[220px]"
                     title={email || ''}
@@ -728,9 +620,7 @@ export default function AccountHubPage() {
                   <Key className="h-5 w-5" />
                 </div>
                 <div>
-                  <h2 className="text-small font-medium text-foreground">
-                    Premium PIN
-                  </h2>
+                  <h2 className="text-small font-medium text-foreground">Premium PIN</h2>
                   <p className="mt-1 text-small text-muted-foreground">
                     Redeem a PIN to unlock premium without adding a card.
                   </p>
@@ -752,9 +642,7 @@ export default function AccountHubPage() {
                     <Users className="h-5 w-5" />
                   </div>
                   <div>
-                    <h2 className="text-small font-medium text-foreground">
-                      Teacher panel
-                    </h2>
+                    <h2 className="text-small font-medium text-foreground">Teacher panel</h2>
                     <p className="mt-1 text-small text-muted-foreground">
                       Manage students, assignments, and feedback.
                     </p>
@@ -776,32 +664,20 @@ export default function AccountHubPage() {
                   <MessageSquare className="h-5 w-5" />
                 </div>
                 <div>
-                  <h2 className="text-small font-medium text-foreground">
-                    Help &amp; support
-                  </h2>
+                  <h2 className="text-small font-medium text-foreground">Help &amp; support</h2>
                   <p className="mt-1 text-small text-muted-foreground">
                     Get help, send feedback, or report an issue.
                   </p>
                 </div>
               </div>
               <div className="space-y-2">
-                <Button
-                  asChild
-                  variant="soft"
-                  className="w-full"
-                  size="sm"
-                >
+                <Button asChild variant="soft" className="w-full" size="sm">
                   <Link href="/support">
                     <MessageSquare className="mr-2 h-4 w-4" />
                     Contact support
                   </Link>
                 </Button>
-                <Button
-                  asChild
-                  variant="outline"
-                  className="w-full"
-                  size="sm"
-                >
+                <Button asChild variant="outline" className="w-full" size="sm">
                   <Link href="/feedback">Send feedback</Link>
                 </Button>
               </div>
@@ -830,22 +706,14 @@ export default function AccountHubPage() {
                     </div>
                   </div>
                   <div className="mt-3 flex flex-wrap gap-2">
-                    <Badge variant="outline">
-                      Activities: {activityStats.totalActivities}
-                    </Badge>
-                    <Badge variant="outline">
-                      Pending tasks: {activityStats.pendingTasks}
-                    </Badge>
+                    <Badge variant="outline">Activities: {activityStats.totalActivities}</Badge>
+                    <Badge variant="outline">Pending tasks: {activityStats.pendingTasks}</Badge>
                     <Badge variant="outline">Reports: 12</Badge>
                   </div>
                 </div>
                 <div className="flex flex-col gap-2 sm:flex-row">
                   <Link href="/admin" className="flex-1">
-                    <Button
-                      variant="solid"
-                      tone="primary"
-                      className="w-full"
-                    >
+                    <Button variant="solid" tone="primary" className="w-full">
                       <Shield className="mr-2 h-4 w-4" />
                       Admin dashboard
                     </Button>
@@ -884,3 +752,5 @@ export default function AccountHubPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/profile/account/redeem.tsx
+++ b/pages/profile/account/redeem.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import Link from 'next/link';
 
 import { Alert } from '@/components/design-system/Alert';
 import { Badge } from '@/components/design-system/Badge';
+import { withPageAuth } from '@/lib/requirePageAuth';
 import { Button } from '@/components/design-system/Button';
 import { Card } from '@/components/design-system/Card';
 import { Container } from '@/components/design-system/Container';
@@ -65,19 +67,13 @@ export default function RedeemPinPage() {
         setMessage({
           kind: 'success',
           text: `Welcome to ${
-            data.plan === 'master'
-              ? 'Master'
-              : data.plan === 'booster'
-              ? 'Booster'
-              : 'Starter'
+            data.plan === 'master' ? 'Master' : data.plan === 'booster' ? 'Booster' : 'Starter'
           }!${formatted}`,
         });
         setPin('');
         setRemaining(null);
       } else {
-        const err = data.ok
-          ? 'Unable to redeem PIN.'
-          : data.error || 'Unable to redeem PIN.';
+        const err = data.ok ? 'Unable to redeem PIN.' : data.error || 'Unable to redeem PIN.';
         setMessage({ kind: 'error', text: err });
         if (!data.ok && typeof data.remainingAttempts === 'number') {
           setRemaining(Math.max(data.remainingAttempts, 0));
@@ -108,12 +104,9 @@ export default function RedeemPinPage() {
       <main className="min-h-screen bg-background py-8 text-foreground sm:py-10">
         <Container className="max-w-2xl space-y-5 sm:space-y-6">
           <header className="space-y-1">
-            <h1 className="text-h2 font-semibold text-foreground">
-              Redeem Premium PIN
-            </h1>
+            <h1 className="text-h2 font-semibold text-foreground">Redeem Premium PIN</h1>
             <p className="text-small text-muted-foreground">
-              Enter the one-time PIN shared by our team to instantly unlock
-              premium access.
+              Enter the one-time PIN shared by our team to instantly unlock premium access.
             </p>
           </header>
 
@@ -126,50 +119,32 @@ export default function RedeemPinPage() {
                   inputMode="numeric"
                   pattern="[0-9]*"
                   value={pin}
-                  onChange={(event) =>
-                    setPin(event.target.value.replace(/\D/g, '').slice(0, 6))
-                  }
+                  onChange={(event) => setPin(event.target.value.replace(/\D/g, '').slice(0, 6))}
                   autoComplete="one-time-code"
                   required
                 />
                 <p className="text-caption text-muted-foreground">
-                  PINs expire after use. Each code can be redeemed once per
-                  account.
+                  PINs expire after use. Each code can be redeemed once per account.
                 </p>
               </div>
 
               {message && (
                 <Alert
-                  variant={
-                    message.kind === 'success' ? 'success' : 'error'
-                  }
+                  variant={message.kind === 'success' ? 'success' : 'error'}
                   appearance="soft"
-                  title={
-                    message.kind === 'success'
-                      ? 'Success'
-                      : 'We couldn’t verify that PIN'
-                  }
+                  title={message.kind === 'success' ? 'Success' : 'We couldn’t verify that PIN'}
                 >
-                  <p className="mt-1 text-small text-muted-foreground">
-                    {message.text}
-                  </p>
-                  {remaining !== null &&
-                    remaining >= 0 &&
-                    message.kind === 'error' && (
-                      <p className="mt-2 text-caption text-muted-foreground">
-                        Attempts left before lockout:{' '}
-                        <span className="font-medium">{remaining}</span>
-                      </p>
-                    )}
+                  <p className="mt-1 text-small text-muted-foreground">{message.text}</p>
+                  {remaining !== null && remaining >= 0 && message.kind === 'error' && (
+                    <p className="mt-2 text-caption text-muted-foreground">
+                      Attempts left before lockout: <span className="font-medium">{remaining}</span>
+                    </p>
+                  )}
                 </Alert>
               )}
 
               <div className="flex flex-wrap items-center gap-3">
-                <Button
-                  type="submit"
-                  loading={loading}
-                  disabled={loading || pin.length < 4}
-                >
+                <Button type="submit" loading={loading} disabled={loading || pin.length < 4}>
                   {loading ? 'Checking…' : 'Redeem PIN'}
                 </Button>
                 <Badge variant="secondary">One-time use</Badge>
@@ -178,12 +153,10 @@ export default function RedeemPinPage() {
           </Card>
 
           <Card padding="lg" className="space-y-3 bg-muted/30">
-            <h2 className="text-h5 font-semibold text-foreground">
-              Need a PIN?
-            </h2>
+            <h2 className="text-h5 font-semibold text-foreground">Need a PIN?</h2>
             <p className="text-small text-muted-foreground">
-              Premium PINs are issued during onboarding and private offers. If
-              you believe you should have one, contact our success team.
+              Premium PINs are issued during onboarding and private offers. If you believe you
+              should have one, contact our success team.
             </p>
             <div>
               <Button asChild variant="link" size="sm">
@@ -196,3 +169,5 @@ export default function RedeemPinPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/profile/account/referrals.tsx
+++ b/pages/profile/account/referrals.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import type { NextPage } from 'next';
 
 import { Container } from '@/components/design-system/Container';
+import { withPageAuth } from '@/lib/requirePageAuth';
 import ReferralCard from '@/components/account/ReferralCard';
 
 const ReferralsPage: NextPage = () => (
@@ -18,8 +20,8 @@ const ReferralsPage: NextPage = () => (
       <Container className="max-w-3xl space-y-4 sm:space-y-6">
         <h1 className="text-h2 font-semibold">Referrals</h1>
         <p className="mt-1 text-small text-muted-foreground">
-          Share your code with friends and both of you receive premium credits
-          when they join GramorX.
+          Share your code with friends and both of you receive premium credits when they join
+          GramorX.
         </p>
 
         <ReferralCard className="mt-6" />
@@ -29,3 +31,5 @@ const ReferralsPage: NextPage = () => (
 );
 
 export default ReferralsPage;
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/profile/billing.tsx
+++ b/pages/profile/billing.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 
 import { Container } from '@/components/design-system/Container';
@@ -9,6 +10,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { Badge } from '@/components/design-system/Badge';
+import { withPageAuth } from '@/lib/requirePageAuth';
 import { useToast } from '@/components/design-system/Toaster';
 import { fetchProfile } from '@/lib/profile';
 import type { Profile } from '@/types/profile';
@@ -65,10 +67,7 @@ export default function BillingHistoryPage() {
           return;
         }
         console.error('Failed to load billing history', err);
-        const message = t(
-          'billing.load.error',
-          'Unable to load billing history.',
-        );
+        const message = t('billing.load.error', 'Unable to load billing history.');
         setError(message);
         toastError(message);
       } finally {
@@ -81,9 +80,7 @@ export default function BillingHistoryPage() {
   }, [router, t, toastError]);
 
   const currentPlan: PlanId = profile?.tier ?? 'free';
-  const hasSubscription =
-    !!profile?.stripe_customer_id &&
-    profile.subscription_status === 'active';
+  const hasSubscription = !!profile?.stripe_customer_id && profile.subscription_status === 'active';
 
   if (loading) {
     return (
@@ -127,10 +124,7 @@ export default function BillingHistoryPage() {
 
               {!hasSubscription && (
                 <Alert variant="info" className="rounded-ds-2xl">
-                  {t(
-                    'billing.noHistory',
-                    'No billing history yet. Upgrade to see invoices.',
-                  )}
+                  {t('billing.noHistory', 'No billing history yet. Upgrade to see invoices.')}
                 </Alert>
               )}
 
@@ -145,10 +139,7 @@ export default function BillingHistoryPage() {
                       className="rounded-ds-xl"
                       onClick={() => router.push('/profile/account/billing')}
                     >
-                      {t(
-                        'billing.portal',
-                        'Open billing & subscription hub',
-                      )}
+                      {t('billing.portal', 'Open billing & subscription hub')}
                     </Button>
                   )}
                 </div>
@@ -162,18 +153,12 @@ export default function BillingHistoryPage() {
                     <table className="min-w-[640px] w-full text-small">
                       <thead>
                         <tr className="border-b border-border">
-                          <th className="py-3 text-left">
-                            {t('billing.table.date', 'Date')}
-                          </th>
+                          <th className="py-3 text-left">{t('billing.table.date', 'Date')}</th>
                           <th className="py-3 text-left">
                             {t('billing.table.desc', 'Description')}
                           </th>
-                          <th className="py-3 text-right">
-                            {t('billing.table.amount', 'Amount')}
-                          </th>
-                          <th className="py-3 text-left">
-                            {t('billing.table.status', 'Status')}
-                          </th>
+                          <th className="py-3 text-right">{t('billing.table.amount', 'Amount')}</th>
+                          <th className="py-3 text-left">{t('billing.table.status', 'Status')}</th>
                           <th className="py-3 text-left">
                             {t('billing.table.actions', 'Actions')}
                           </th>
@@ -181,25 +166,12 @@ export default function BillingHistoryPage() {
                       </thead>
                       <tbody>
                         {invoices.map((invoice) => (
-                          <tr
-                            key={invoice.id}
-                            className="border-b border-border last:border-b-0"
-                          >
-                            <td className="py-3">
-                              {formatDate(invoice.date)}
-                            </td>
+                          <tr key={invoice.id} className="border-b border-border last:border-b-0">
+                            <td className="py-3">{formatDate(invoice.date)}</td>
                             <td className="py-3">{invoice.description}</td>
-                            <td className="py-3 text-right">
-                              {formatAmount(invoice.amount)}
-                            </td>
+                            <td className="py-3 text-right">{formatAmount(invoice.amount)}</td>
                             <td className="py-3">
-                              <Badge
-                                variant={
-                                  invoice.status === 'paid'
-                                    ? 'success'
-                                    : 'secondary'
-                                }
-                              >
+                              <Badge variant={invoice.status === 'paid' ? 'success' : 'secondary'}>
                                 {invoice.status}
                               </Badge>
                             </td>
@@ -217,9 +189,7 @@ export default function BillingHistoryPage() {
                                   {t('billing.download', 'PDF')}
                                 </Button>
                               ) : (
-                                <span className="text-muted-foreground">
-                                  —
-                                </span>
+                                <span className="text-muted-foreground">—</span>
                               )}
                             </td>
                           </tr>
@@ -236,3 +206,5 @@ export default function BillingHistoryPage() {
     </GlobalPlanGuard>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/profile/streak.tsx
+++ b/pages/profile/streak.tsx
@@ -7,6 +7,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { StreakChip } from '@/components/user/StreakChip';
 import { getServerClient } from '@/lib/supabaseServer';
+import { createAuthRedirect } from '@/lib/requirePageAuth';
 import { buildCompletionHistory } from '@/utils/streak';
 
 const Heatmap = dynamic(
@@ -51,7 +52,8 @@ const StreakPage: NextPage<Props> = ({ streak, history }) => {
           <div>
             <h1 className="font-slab text-h2 sm:text-display">Your streak</h1>
             <p className="max-w-2xl text-body text-muted-foreground">
-              Keep learning every day—complete a study task before midnight Pakistan time to maintain the streak.
+              Keep learning every day—complete a study task before midnight Pakistan time to
+              maintain the streak.
             </p>
           </div>
           <StreakChip value={streak.current} href="/profile/streak" />
@@ -92,9 +94,17 @@ const StreakPage: NextPage<Props> = ({ streak, history }) => {
             <div className="rounded-xl bg-muted/60 px-4 py-3 text-small text-muted-foreground">
               <h3 className="font-semibold text-foreground">How your streak works</h3>
               <ul className="mt-2 list-disc space-y-2 pl-4">
-                <li>Complete at least one scheduled study task before midnight Pakistan time (PKT) each day.</li>
-                <li>Every productive day extends your streak and fills the heatmap for that date.</li>
-                <li>Missing a day resets your current streak, but your longest streak stays recorded for motivation.</li>
+                <li>
+                  Complete at least one scheduled study task before midnight Pakistan time (PKT)
+                  each day.
+                </li>
+                <li>
+                  Every productive day extends your streak and fills the heatmap for that date.
+                </li>
+                <li>
+                  Missing a day resets your current streak, but your longest streak stays recorded
+                  for motivation.
+                </li>
               </ul>
             </div>
             <div className="pt-4">
@@ -116,12 +126,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   } = await supabase.auth.getUser();
 
   if (!user?.id) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false,
-      },
-    };
+    return createAuthRedirect(ctx.resolvedUrl);
   }
 
   const DAYS_BACK = 84;

--- a/pages/settings/accessibility.tsx
+++ b/pages/settings/accessibility.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import React from 'react';
 
 import { Container } from '@/components/design-system/Container';
+import { withPageAuth } from '@/lib/requirePageAuth';
 import AccessibilitySettingsCard from '@/components/settings/Accessibility';
 
 export default function AccessibilitySettingsPage() {
@@ -32,3 +34,5 @@ export default function AccessibilitySettingsPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/settings/billing.tsx
+++ b/pages/settings/billing.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import type { GetServerSideProps } from 'next';
 
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
@@ -8,6 +9,7 @@ import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { Skeleton } from '@/components/design-system/Skeleton';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { withPageAuth } from '@/lib/requirePageAuth';
 
 type BillingState = {
   plan?: 'free' | 'starter' | 'booster' | 'master';
@@ -60,11 +62,21 @@ export default function BillingPage() {
           return;
         }
 
-        let current: BillingState = { plan: 'free', status: 'none', paymentMethod: 'none', renewal: null };
+        let current: BillingState = {
+          plan: 'free',
+          status: 'none',
+          paymentMethod: 'none',
+          renewal: null,
+        };
 
         try {
-          const { data: profile } = await supabase.from('profiles').select('membership_plan').eq('id', user.id).single();
-          if (profile?.membership_plan) current.plan = profile.membership_plan as BillingState['plan'];
+          const { data: profile } = await supabase
+            .from('profiles')
+            .select('membership_plan')
+            .eq('id', user.id)
+            .single();
+          if (profile?.membership_plan)
+            current.plan = profile.membership_plan as BillingState['plan'];
         } catch {
           /* ignore */
         }
@@ -110,7 +122,9 @@ export default function BillingPage() {
       <Container className="max-w-3xl space-y-6">
         <header className="space-y-2">
           <h1 className="text-h2 font-semibold">Billing</h1>
-          <p className="text-small text-muted-foreground">Review your plan, payment method, and next steps.</p>
+          <p className="text-small text-muted-foreground">
+            Review your plan, payment method, and next steps.
+          </p>
         </header>
 
         {activated ? (
@@ -132,15 +146,21 @@ export default function BillingPage() {
             <Card padding="lg" insetBorder as="section" aria-labelledby="current-plan-heading">
               <div className="space-y-3">
                 <div>
-                  <p className="text-caption uppercase tracking-[0.12em] text-muted-foreground">Current plan</p>
+                  <p className="text-caption uppercase tracking-[0.12em] text-muted-foreground">
+                    Current plan
+                  </p>
                   <div className="mt-2 flex flex-wrap items-center gap-3">
                     <h2 id="current-plan-heading" className="text-h3 font-semibold capitalize">
                       {formatPlan(billing.plan)}
                     </h2>
-                    <Badge variant={statusVariant(billing.status)}>{formatStatus(billing.status)}</Badge>
+                    <Badge variant={statusVariant(billing.status)}>
+                      {formatStatus(billing.status)}
+                    </Badge>
                   </div>
                   {renewalLabel ? (
-                    <p className="mt-2 text-small text-muted-foreground">Renews on {renewalLabel}</p>
+                    <p className="mt-2 text-small text-muted-foreground">
+                      Renews on {renewalLabel}
+                    </p>
                   ) : (
                     <p className="mt-2 text-small text-muted-foreground">No renewal scheduled</p>
                   )}
@@ -189,3 +209,5 @@ export default function BillingPage() {
     </main>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/settings/index.tsx
+++ b/pages/settings/index.tsx
@@ -2,12 +2,14 @@
 
 import * as React from 'react';
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import Link from 'next/link';
 
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
+import { withPageAuth } from '@/lib/requirePageAuth';
 
 type SettingsSection = {
   href: string;
@@ -22,24 +24,21 @@ const sections: SettingsSection[] = [
   {
     href: '/account',
     label: 'Account overview',
-    description:
-      'See your plan, activity, and access all account tools from one place.',
+    description: 'See your plan, activity, and access all account tools from one place.',
     badge: 'Hub',
     group: 'account',
   },
   {
     href: '/account/billing',
     label: 'Billing & plan',
-    description:
-      'View your current plan, renewal date, invoices, and local dues.',
+    description: 'View your current plan, renewal date, invoices, and local dues.',
     badge: 'Plan',
     group: 'account',
   },
   {
     href: '/account/activity',
     label: 'Activity log',
-    description:
-      'Timeline of mocks, practices, streak updates, and other account events.',
+    description: 'Timeline of mocks, practices, streak updates, and other account events.',
     group: 'account',
   },
 
@@ -95,8 +94,8 @@ export default function SettingsHomePage() {
           <header className="space-y-2">
             <h1 className="text-h2 font-bold">Settings</h1>
             <p className="max-w-2xl text-small text-muted-foreground">
-              Use the account hub for the full picture, or jump straight into a
-              specific settings area from here.
+              Use the account hub for the full picture, or jump straight into a specific settings
+              area from here.
             </p>
             <div className="flex flex-wrap gap-3">
               <Button asChild size="sm" variant="soft">
@@ -118,19 +117,13 @@ export default function SettingsHomePage() {
                   </h2>
                   <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                     {items.map((section) => (
-                      <Link
-                        key={section.href}
-                        href={section.href}
-                        className="group block"
-                      >
+                      <Link key={section.href} href={section.href} className="group block">
                         <Card
                           as="article"
                           className="h-full cursor-pointer rounded-ds-2xl border border-border bg-card p-5 text-card-foreground transition-colors group-hover:border-primary/60"
                         >
                           <div className="flex items-start justify-between gap-3">
-                            <h3 className="text-body font-semibold">
-                              {section.label}
-                            </h3>
+                            <h3 className="text-body font-semibold">{section.label}</h3>
                             {section.badge ? (
                               <Badge size="sm" variant="info">
                                 {section.badge}
@@ -160,3 +153,5 @@ export default function SettingsHomePage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/settings/language.tsx
+++ b/pages/settings/language.tsx
@@ -1,26 +1,26 @@
-// pages/settings/language.tsx 
-import * as React from "react";
-import Head from "next/head";
-import { Container } from "@/components/design-system/Container";
-import LocaleSwitcher from "@/components/common/LocaleSwitcher";
-import { _detectLocale as detectLocale, persistLocale } from "@/lib/locale";
-import { loadTranslations, t, getLocale } from "@/lib/i18n";
-import type { SupportedLocale } from "@/lib/i18n/config";
-import { supabaseBrowser } from "@/lib/supabaseBrowser";
+// pages/settings/language.tsx
+import * as React from 'react';
+import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
+import { Container } from '@/components/design-system/Container';
+import LocaleSwitcher from '@/components/common/LocaleSwitcher';
+import { _detectLocale as detectLocale, persistLocale } from '@/lib/locale';
+import { loadTranslations, t, getLocale } from '@/lib/i18n';
+import type { SupportedLocale } from '@/lib/i18n/config';
+import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { withPageAuth } from '@/lib/requirePageAuth';
 
 export default function LanguageSettingsPage() {
-  const [locale, setLocale] = React.useState<SupportedLocale>("en");
+  const [locale, setLocale] = React.useState<SupportedLocale>('en');
   const [busy, setBusy] = React.useState(false);
-  const [saved, setSaved] = React.useState<null | "ok" | "err">(null);
+  const [saved, setSaved] = React.useState<null | 'ok' | 'err'>(null);
   const [userId, setUserId] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     (async () => {
       // Guard: some builds export detectLocale as object/default.
       const safeDetect =
-        typeof detectLocale === "function"
-          ? (detectLocale as () => SupportedLocale)
-          : null;
+        typeof detectLocale === 'function' ? (detectLocale as () => SupportedLocale) : null;
 
       const initial = safeDetect ? safeDetect() : getLocale();
       await loadTranslations(initial);
@@ -41,11 +41,11 @@ export default function LanguageSettingsPage() {
 
       // Persist to profile if logged in
       if (userId) {
-        await supabaseBrowser.from("profiles").update({ locale: next }).eq("id", userId);
+        await supabaseBrowser.from('profiles').update({ locale: next }).eq('id', userId);
       }
-      setSaved("ok");
+      setSaved('ok');
     } catch {
-      setSaved("err");
+      setSaved('err');
     } finally {
       setBusy(false);
       setTimeout(() => setSaved(null), 2000);
@@ -63,9 +63,9 @@ export default function LanguageSettingsPage() {
         <Container>
           <header className="mb-4 flex items-center justify-between">
             <div>
-              <h1 className="text-h2 font-bold text-foreground">{t("Language Settings")}</h1>
+              <h1 className="text-h2 font-bold text-foreground">{t('Language Settings')}</h1>
               <p className="text-small text-mutedText">
-                {t("Choose your preferred interface language.")}
+                {t('Choose your preferred interface language.')}
               </p>
             </div>
           </header>
@@ -73,33 +73,45 @@ export default function LanguageSettingsPage() {
           <section className="rounded-ds-2xl border border-border bg-card p-4 text-card-foreground">
             <div className="flex items-center justify-between">
               <LocaleSwitcher
-                label={t("Language")}
+                label={t('Language')}
                 // If your switcher supports a controlled value, pass it:
                 // value={locale}
                 onChanged={handleChange}
               />
               <span className="text-caption text-mutedText" role="status" aria-live="polite">
-                {busy ? t("Saving…") : saved === "ok" ? t("Saved ✓") : saved === "err" ? t("Error") : null}
+                {busy
+                  ? t('Saving…')
+                  : saved === 'ok'
+                    ? t('Saved ✓')
+                    : saved === 'err'
+                      ? t('Error')
+                      : null}
               </span>
             </div>
 
             <div className="mt-4 grid gap-3 md:grid-cols-2">
               <div className="rounded-lg border border-border bg-background p-3">
-                <h3 className="mb-1 text-small font-medium text-foreground">{t("Preview (English)")}</h3>
+                <h3 className="mb-1 text-small font-medium text-foreground">
+                  {t('Preview (English)')}
+                </h3>
                 <p className="text-small text-mutedText">
-                  Welcome to GramorX. Let’s raise your IELTS band with daily practice and AI feedback.
+                  Welcome to GramorX. Let’s raise your IELTS band with daily practice and AI
+                  feedback.
                 </p>
               </div>
               <div className="rounded-lg border border-border bg-background p-3">
-                <h3 className="mb-1 text-small font-medium text-foreground">{t("Preview (Urdu)")}</h3>
+                <h3 className="mb-1 text-small font-medium text-foreground">
+                  {t('Preview (Urdu)')}
+                </h3>
                 <p className="text-small text-mutedText">
-                  GramorX میں خوش آمدید۔ روزانہ مشق اور AI فیڈبیک کے ساتھ اپنا IELTS بینڈ بہتر بنائیں۔
+                  GramorX میں خوش آمدید۔ روزانہ مشق اور AI فیڈبیک کے ساتھ اپنا IELTS بینڈ بہتر
+                  بنائیں۔
                 </p>
               </div>
             </div>
 
             <div className="mt-4 text-caption text-mutedText">
-              {t("Current locale")}: <span className="font-mono">{locale}</span>
+              {t('Current locale')}: <span className="font-mono">{locale}</span>
             </div>
           </section>
         </Container>
@@ -107,3 +119,5 @@ export default function LanguageSettingsPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/settings/notifications.tsx
+++ b/pages/settings/notifications.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 import { Container } from '@/components/design-system/Container';
+import { withPageAuth } from '@/lib/requirePageAuth';
 import { Toggle } from '@/components/design-system/Toggle';
 import { Input } from '@/components/design-system/Input';
 import { Select } from '@/components/design-system/Select';
@@ -58,7 +60,10 @@ function toTimeInput(value: string | null): string | null {
   return null;
 }
 
-function normalizePayload(preferences: ServerPreferences): { form: FormState; contact: ContactState } {
+function normalizePayload(preferences: ServerPreferences): {
+  form: FormState;
+  contact: ContactState;
+} {
   return {
     form: {
       channels: {
@@ -347,7 +352,9 @@ export default function NotificationsSettingsPage() {
                   <ul className="mt-2 space-y-2 text-small text-mutedText">
                     <li>
                       <span className="font-medium text-foreground">Email:</span>{' '}
-                      {contact.email ? contact.email : 'Add an email in your profile to receive emails.'}
+                      {contact.email
+                        ? contact.email
+                        : 'Add an email in your profile to receive emails.'}
                     </li>
                     <li>
                       <span className="font-medium text-foreground">WhatsApp:</span>{' '}
@@ -409,3 +416,5 @@ export default function NotificationsSettingsPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();

--- a/pages/settings/security.tsx
+++ b/pages/settings/security.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
+import type { GetServerSideProps } from 'next';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Input } from '@/components/design-system/Input';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { withPageAuth } from '@/lib/requirePageAuth';
 
 interface SessionInfo {
   id: string;
@@ -96,7 +98,10 @@ export default function SecuritySettings() {
                 <ul className="space-y-2">
                   {sessions.map((s) => (
                     <li key={s.id} className="flex items-center justify-between text-body">
-                      <span>{s.user_agent || 'Unknown'}{s.ip ? ` • ${s.ip}` : ''}</span>
+                      <span>
+                        {s.user_agent || 'Unknown'}
+                        {s.ip ? ` • ${s.ip}` : ''}
+                      </span>
                       <Button size="sm" variant="secondary" onClick={() => revoke(s.id)}>
                         Revoke
                       </Button>
@@ -126,3 +131,5 @@ export default function SecuritySettings() {
     </section>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = withPageAuth();


### PR DESCRIPTION
### Motivation
- Several account and settings pages used mixed auth approaches (client-side guards, SSR with different redirect targets) which exposed UI to unauthenticated users and produced inconsistent redirects (`/login` vs `/auth/login`).
- The goal is to centralize server-side auth for Pages Router pages so protected UI always redirects to a single login flow with a `next` parameter. 
- This also reduces duplicated redirect logic and makes it straightforward to extend server-side protections later.

### Description
- Added a shared Pages Router helper `lib/requirePageAuth.ts` that exports `createAuthRedirect`, `requirePageAuth`, and `withPageAuth` to centralize the `POST-auth` behavior and standardize redirects to `/login?next=...`.
- Replaced inline SSR redirect logic with `createAuthRedirect(...)` in SSR pages that already used `getServerSideProps`, and added `getServerSideProps = withPageAuth()` to settings and account pages that previously relied on client-only checks (examples: `/account`, `/account/redeem`, `/account/referrals`, `/settings/*`, `/profile/billing`, `/profile/streak`, `/account/activity`, `/account/billing`).
- Normalized redirect destinations so unauthenticated users are routed to `/login` with a `next` query when applicable, replacing ad-hoc `/auth/login` or mixed behaviors.
- Performed automatic style cleanups (Prettier) and minor formatting/consistency fixes across the modified pages while applying the auth changes.

### Testing
- Ran code formatting with `npx prettier --write` on the modified files and the command completed successfully.
- Ran static checks with `npx eslint` across the changed files and the linter completed without errors after automatic fixes were applied.
- No runtime test suite was executed in this change; the updates focus on SSR gating and were validated via the formatting and linting runs described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4765649a0832f8b2cd719b7e1e4bd)