### PR TITLE
Reduce header null-user flicker by stabilizing auth hydration

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -40,7 +40,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
 
   const user = React.useMemo(
     () => ({
-      id: headerUser?.id ?? contextUser?.id ?? null,
+      id: contextUser?.id ?? headerUser?.id ?? null,
       email: headerUser?.email ?? contextUser?.email ?? null,
       name:
         headerUser?.name ??
@@ -57,7 +57,8 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
     [contextUser, headerUser]
   );
 
-  const isHeaderReady = ready || !!contextUser?.id;
+  const isAuthHydrating = loading && !contextUser?.id && !headerUser?.id;
+  const isHeaderReady = (ready || !!contextUser?.id || !!headerUser?.id) && !isAuthHydrating;
 
   const [hasPremiumAccess, setHasPremiumAccess] = useState(false);
   const [premiumRooms, setPremiumRooms] = useState<string[]>([]);
@@ -214,7 +215,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
   const solidHeader = scrolled || openDesktopModules || mobileOpen;
 
   // Loading skeleton
-  if (loading && !user?.id) {
+  if (isAuthHydrating) {
     return (
       <header className="sticky top-0 z-50 w-full border-b border-border bg-surface/90 backdrop-blur-lg">
         <Container>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -38,9 +38,24 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
     subscriptionTier,
   } = useHeaderState(streak);
 
+  const [stableUserId, setStableUserId] = useState<string | null>(null);
+  const latestUserId = contextUser?.id ?? headerUser?.id ?? null;
+
+  useEffect(() => {
+    if (latestUserId) {
+      setStableUserId(latestUserId);
+      return;
+    }
+
+    // Allow clearing only after both auth sources settle to avoid post-login flicker.
+    if (!loading && ready) {
+      setStableUserId(null);
+    }
+  }, [latestUserId, loading, ready]);
+
   const user = React.useMemo(
     () => ({
-      id: contextUser?.id ?? headerUser?.id ?? null,
+      id: stableUserId,
       email: headerUser?.email ?? contextUser?.email ?? null,
       name:
         headerUser?.name ??
@@ -54,11 +69,11 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
           : null),
       avatarPath: headerUser?.avatarPath ?? null,
     }),
-    [contextUser, headerUser]
+    [contextUser, headerUser, stableUserId]
   );
 
-  const isAuthHydrating = loading && !contextUser?.id && !headerUser?.id;
-  const isHeaderReady = (ready || !!contextUser?.id || !!headerUser?.id) && !isAuthHydrating;
+  const isAuthHydrating = loading && !stableUserId;
+  const isHeaderReady = (ready || !!stableUserId) && !isAuthHydrating;
 
   const [hasPremiumAccess, setHasPremiumAccess] = useState(false);
   const [premiumRooms, setPremiumRooms] = useState<string[]>([]);

--- a/components/hooks/useHeaderState.ts
+++ b/components/hooks/useHeaderState.ts
@@ -19,6 +19,7 @@ interface UserInfo {
 
 export function useHeaderState(initialStreak?: number) {
   const router = useRouter();
+  const INITIAL_AUTH_RECHECK_DELAY_MS = 140;
 
   const [ready, setReady] = useState(false);
   const [role, setRole] = useState<string | null>(null);
@@ -120,6 +121,28 @@ export function useHeaderState(initialStreak?: number) {
       return { url: raw, path: null } as const;
     };
 
+    const applyAuthUser = async (authUser: Session['user'] | null) => {
+      const userMeta = (authUser?.user_metadata ?? {}) as Record<string, unknown>;
+      const avatar = await resolveAvatar(userMeta);
+
+      if (cancelled) return;
+
+      setUser({
+        id: authUser?.id ?? null,
+        email: authUser?.email ?? null,
+        name: typeof userMeta['full_name'] === 'string' ? (userMeta['full_name'] as string) : null,
+        avatarUrl: avatar.url,
+        avatarPath: avatar.path,
+      });
+
+      const identity = await computeIdentity(authUser?.id ?? null, authUser?.app_metadata, userMeta);
+      if (cancelled) return;
+
+      setRole(identity.role);
+      setSubscriptionTier(identity.tier ?? defaultTier);
+      if (!authUser) setStreak(0);
+    };
+
     const sync = async () => {
       try {
         const { data: { session }, error } = await supabase.auth.getSession();
@@ -143,22 +166,26 @@ export function useHeaderState(initialStreak?: number) {
           currentUser = fetchedUser ?? null;
         }
 
-        const userMeta = (currentUser?.user_metadata ?? {}) as Record<string, unknown>;
-        if (!cancelled) {
-          const avatar = await resolveAvatar(userMeta);
-          setUser({
-            id: currentUser?.id ?? null,
-            email: currentUser?.email ?? null,
-            name: typeof userMeta['full_name'] === 'string' ? (userMeta['full_name'] as string) : null,
-            avatarUrl: avatar.url,
-            avatarPath: avatar.path,
-          });
-          const identity = await computeIdentity(currentUser?.id ?? null, currentUser?.app_metadata, userMeta);
+        // One delayed retry for initialization races where both calls can briefly return null.
+        if (!currentUser) {
+          await new Promise((resolve) => setTimeout(resolve, INITIAL_AUTH_RECHECK_DELAY_MS));
           if (!cancelled) {
-            setRole(identity.role);
-            setSubscriptionTier(identity.tier ?? defaultTier);
+            const {
+              data: { session: retrySession },
+            } = await supabase.auth.getSession();
+
+            currentUser = retrySession?.user ?? null;
+
+            if (!currentUser) {
+              const {
+                data: { user: retryUser },
+              } = await supabase.auth.getUser();
+              currentUser = retryUser ?? null;
+            }
           }
         }
+
+        await applyAuthUser(currentUser);
       } catch (err) {
         console.error('Unexpected auth error:', err);
       } finally {
@@ -172,20 +199,10 @@ export function useHeaderState(initialStreak?: number) {
     const { data: sub } = supabase.auth.onAuthStateChange(
       async (_e: AuthChangeEvent, session: Session | null) => {
         try {
-          const s = session?.user ?? null;
-          const userMeta = (s?.user_metadata ?? {}) as Record<string, unknown>;
-          const avatar = await resolveAvatar(userMeta);
-          setUser({
-            id: s?.id ?? null,
-            email: s?.email ?? null,
-            name: typeof userMeta['full_name'] === 'string' ? (userMeta['full_name'] as string) : null,
-            avatarUrl: avatar.url,
-            avatarPath: avatar.path,
-          });
-          const identity = await computeIdentity(s?.id ?? null, s?.app_metadata, userMeta);
-          setRole(identity.role);
-          setSubscriptionTier(identity.tier ?? defaultTier);
-          if (!s) setStreak(0);
+          await applyAuthUser(session?.user ?? null);
+          if (!cancelled) {
+            setReady(true);
+          }
         } catch (err) {
           console.error('Auth state change error:', err);
         }


### PR DESCRIPTION
### Motivation
- Prevent transient "guest" UI flashes when auth is still initializing so `ready=true` does not coincide with a null `user.id` for authenticated users.
- Ensure auth-derived values (`user`, `role`, `subscriptionTier`) are applied in a consistent order to avoid racey UI state during login transitions.
- Provide a clearer loading/hydration signal so navigation components receive a stable `user.id` post-login (so `<StreakChip />` and `<UserMenu />` conditions pass reliably).

### Description
- Consolidated auth application into a shared `applyAuthUser` path inside `useHeaderState` so `user`, `role`, and `subscriptionTier` updates happen together before readiness is finalized (file: `components/hooks/useHeaderState.ts`).
- Added a short delayed re-check (`INITIAL_AUTH_RECHECK_DELAY_MS = 140`) in the initial auth sync to retry `getSession()`/`getUser()` once when both initially return `null`, reducing transient initialization races (file: `components/hooks/useHeaderState.ts`).
- Updated `onAuthStateChange` to use the same `applyAuthUser` path and to set `ready` only after user state is applied, avoiding `ready=true` with stale/null user state (file: `components/hooks/useHeaderState.ts`).
- Adjusted header merge/guard logic in `components/Header.tsx` to prefer `contextUser.id` first for a more stable post-login identity, added `isAuthHydrating` to detect active auth loading, and tightened `isHeaderReady` so nav components only receive `ready` when auth is not hydrating.
- Replaced the previous loading check with `isAuthHydrating` to avoid rendering guest-like auth UI while the auth context is still initializing (file: `components/Header.tsx`).

### Testing
- Ran linter on the modified files with `npx eslint components/hooks/useHeaderState.ts components/Header.tsx` and fixes from pre-commit tasks were applied, with no lint errors reported.
- No additional automated runtime tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fddb08a4832faa57a0f98dfe6cb3)