### PR TITLE
Align mobile streak chip visibility with desktop behavior

### DIFF
--- a/components/navigation/MobileNav.tsx
+++ b/components/navigation/MobileNav.tsx
@@ -216,8 +216,8 @@ export function MobileNav({
           >
             <Icon name="X" size={20} />
           </motion.button>
-          {typeof streak === 'number' && streak > 0 && (
-            <StreakChip value={streak} href="/profile/streak" className="shrink-0" />
+          {Boolean(user?.id) && (
+            <StreakChip value={streak ?? 0} href="/profile/streak" className="shrink-0" />
           )}
         </div>
 


### PR DESCRIPTION
### Motivation
- Ensure the mobile header matches desktop behavior by showing the streak chip for authenticated users even when the streak value is zero.

### Description
- Replace the previous `typeof streak === 'number' && streak > 0` check with an auth-based `Boolean(user?.id)` and pass `streak ?? 0` into `StreakChip`, while keeping the same `href="/profile/streak"` and styling.

### Testing
- Ran pre-commit lint via `lint-staged` which executed `eslint --fix` and completed successfully.
- Attempted a Playwright screenshot test against `http://127.0.0.1:3000`, but it failed with `ERR_EMPTY_RESPONSE` because the local app server was not responding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fdf35d30832faae3b44d19387734)