### PR TITLE
Add folder ownership READMEs and architecture baseline

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,18 @@
+# Components (`components/`)
+
+## Scope
+This folder is for **presentational UI only**.
+
+### Allowed
+- Reusable UI components (buttons, cards, tables, banners, section shells).
+- Styling and visual composition.
+- Props-driven rendering logic.
+
+### Disallowed
+- Domain/business rules and decisions (move to `lib/`).
+- Third-party integration clients (move to `services/`).
+- Heavy data-fetching/state orchestration (move to `hooks/`).
+- Route declarations and layout routing concerns (move to `pages/`).
+
+## Rule of thumb
+Components should remain easy to preview/test with mocked props.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation (`docs/`)
+
+## Scope
+This folder is for **architecture and engineering guidance**.
+
+### Allowed
+- Architecture baselines and decisions.
+- Conventions for folder ownership and boundaries.
+- Operational runbooks and contributor onboarding docs.
+
+### Disallowed
+- Executable application code.
+- Source-of-truth config that should live in code.
+
+## Rule of thumb
+Docs should explain *why* and *where* code belongs, with maintainable examples.

--- a/docs/architecture-baseline.md
+++ b/docs/architecture-baseline.md
@@ -1,0 +1,17 @@
+# Architecture Baseline
+
+## Routing baseline
+The repository currently uses the **Pages Router** as the primary routing system via the root-level `pages/` directory.
+
+- `pages/` is the active route boundary and should contain routing/layout composition only.
+- `app/` is not currently present at repo root.
+
+If `app/` is introduced in the future, this document must be updated with a single declared primary router and migration plan.
+
+## Layer constraints
+- **routes (`pages/` or `app/`)**: routing/layout only.
+- **components/**: presentational UI only.
+- **hooks/**: fetching/state orchestration.
+- **lib/**: domain/business logic.
+- **services/**: third-party integrations.
+- **types/**: shared TypeScript contracts.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,17 @@
+# Hooks (`hooks/`)
+
+## Scope
+This folder is for **fetching and state orchestration**.
+
+### Allowed
+- Custom hooks that fetch or mutate data.
+- Local and shared state orchestration for features.
+- Glue code that composes services + lib helpers for UI consumption.
+
+### Disallowed
+- UI markup/presentational rendering (move to `components/`).
+- Pure domain logic that has no React concerns (move to `lib/`).
+- Direct route declarations (move to `pages/`).
+
+## Rule of thumb
+Hooks should expose a clean interface for UI components and hide orchestration details.

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,17 @@
+# Domain Library (`lib/`)
+
+## Scope
+This folder is for **domain and business logic**.
+
+### Allowed
+- Business rules, calculations, policy checks, and domain transformations.
+- Framework-agnostic helpers used across features.
+- Validation and mapping logic tied to product behavior.
+
+### Disallowed
+- JSX/visual components (move to `components/`).
+- Route/layout definitions (move to `pages/`).
+- Third-party client wiring (move to `services/`).
+
+## Rule of thumb
+`lib/` code should be portable and testable without rendering UI.

--- a/pages/README.md
+++ b/pages/README.md
@@ -1,0 +1,18 @@
+# Routes (`pages/`)
+
+## Scope
+This folder is for **routing and layout wiring only**.
+
+### Allowed
+- Route files that map URLs to screens.
+- Next.js page-level wrappers and layout composition.
+- Route-level metadata and lightweight guards that delegate business decisions.
+
+### Disallowed
+- Core domain/business logic.
+- Direct third-party SDK integration code.
+- Reusable presentational components (place them in `components/`).
+- Shared data-fetching/state orchestration hooks (place them in `hooks/`).
+
+## Rule of thumb
+If code can be reused outside a single route, move it out of `pages/`.

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,17 @@
+# Services (`services/`)
+
+## Scope
+This folder is for **third-party integrations**.
+
+### Allowed
+- API clients and adapters for external providers.
+- Auth/configuration wrappers around third-party SDKs.
+- Integration-specific request/response shaping.
+
+### Disallowed
+- Product/business policy decisions (move to `lib/`).
+- UI rendering and component logic (move to `components/`).
+- Route handling/layout composition (move to `pages/`).
+
+## Rule of thumb
+Services isolate vendor details from the rest of the codebase.

--- a/types/README.md
+++ b/types/README.md
@@ -1,0 +1,16 @@
+# Types (`types/`)
+
+## Scope
+This folder is for **shared TypeScript contracts**.
+
+### Allowed
+- Reusable interfaces, type aliases, enums, and DTO contracts.
+- Cross-layer type definitions used by routes, hooks, lib, and services.
+
+### Disallowed
+- Runtime business logic (move to `lib/`).
+- Side-effecting integration code (move to `services/`).
+- UI rendering logic (move to `components/`).
+
+## Rule of thumb
+Keep `types/` dependency-light so contracts can be imported everywhere.


### PR DESCRIPTION
### Motivation
- Establish clear ownership and scope rules for the main repository layers to reduce cross-cutting responsibilities and accidental coupling. 
- Make an explicit decision about the routing system when both `pages/` and `app/` patterns could exist so future contributions follow a single baseline. 
- Provide quick, discoverable guidance for contributors describing allowed vs disallowed content per folder to speed reviews and onboarding.

### Description
- Added baseline README files for the primary folders: `pages/`, `components/`, `hooks/`, `lib/`, `services/`, `types/`, and `docs/`, each describing scope, `Allowed`/`Disallowed` examples, and a short `Rule of thumb` section. 
- Added `docs/architecture-baseline.md` that documents the routing baseline (declares the `pages/` router as primary since `app/` is not present) and enumerates the explicit layer constraints. 
- Each README encodes the requested explicit constraints: `routes` (routing/layout only), `components` (presentational UI only), `hooks` (fetching/state orchestration), `lib` (domain/business logic), `services` (third-party integrations), and `types` (shared TS contracts).

### Testing
- Verified each new file is present and non-empty using `test -s` checks for `pages/README.md`, `components/README.md`, `hooks/README.md`, `lib/README.md`, `services/README.md`, `types/README.md`, `docs/README.md`, and `docs/architecture-baseline.md`, and all checks passed. 
- Confirmed repository layout includes an existing `pages/` directory and no top-level `app/` directory using a directory discovery check, which validated the routing decision.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eab228dc832faea6595d0796877c)