### PR TITLE
Refactor profile route to use useProfile hook and profile domain helpers

### DIFF
--- a/hooks/useProfile.ts
+++ b/hooks/useProfile.ts
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+
+import { languageOptions as onboardingLanguages } from '@/lib/onboarding/schema';
+import {
+  buildLanguageOptions,
+  fetchProfile,
+  formatTargetBand,
+  type ProfileFieldErrors,
+  type ProfileFormValues,
+  getProfileInitials,
+  toProfileFormValues,
+  upsertProfile,
+  validateProfileForm,
+} from '@/lib/profile';
+import type { Profile } from '@/types/profile';
+
+export function useProfile(t: (key: string, fallback: string) => string) {
+  const router = useRouter();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [form, setForm] = useState<ProfileFormValues>({
+    fullName: '',
+    preferredLanguage: 'en',
+    targetBand: '',
+    examDate: '',
+  });
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<ProfileFieldErrors>({});
+
+  const languageOptions = useMemo(() => buildLanguageOptions(onboardingLanguages as unknown), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+      try {
+        const nextProfile = await fetchProfile();
+        if (cancelled) return;
+
+        if (!nextProfile || nextProfile.draft) {
+          await router.replace('/profile/setup');
+          return;
+        }
+
+        setProfile(nextProfile);
+        setForm(toProfileFormValues(nextProfile));
+        setAvatarUrl(nextProfile.avatar_url ?? null);
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+
+        if (err instanceof Error && err.message === 'Not authenticated') {
+          await router.replace('/login');
+          return;
+        }
+
+        setError(t('profile.load.error', 'Unable to load your profile right now.'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router, t]);
+
+  const setField = (field: keyof ProfileFormValues, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+  };
+
+  const save = async () => {
+    if (!profile) return { ok: false } as const;
+
+    const { isValid, parsedTarget, trimmedName, errors } = validateProfileForm(
+      form,
+      languageOptions,
+      t,
+    );
+
+    setFieldErrors(errors);
+    if (!isValid) {
+      return { ok: false, validationFailed: true } as const;
+    }
+
+    setSaving(true);
+    try {
+      const updated = await upsertProfile({
+        full_name: trimmedName,
+        preferred_language: form.preferredLanguage,
+        target_band: parsedTarget ?? undefined,
+        exam_date: form.examDate || null,
+      });
+
+      setProfile(updated);
+      setForm({
+        fullName: updated.full_name ?? trimmedName,
+        preferredLanguage: updated.preferred_language ?? form.preferredLanguage,
+        targetBand: formatTargetBand(updated.target_band),
+        examDate: updated.exam_date?.slice?.(0, 10) ?? '',
+      });
+      setAvatarUrl(updated.avatar_url ?? avatarUrl ?? null);
+
+      return { ok: true } as const;
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : t('profile.save.fail', 'Unable to save your profile right now.');
+      return { ok: false, message } as const;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return {
+    form,
+    setField,
+    loading,
+    saving,
+    error,
+    fieldErrors,
+    avatarUrl,
+    languageOptions,
+    initials: getProfileInitials(form.fullName),
+    goToFullSetup: () => router.push('/profile/setup'),
+    save,
+  };
+}

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -7,6 +7,29 @@ type ProfilePatch = Partial<Profile> & Partial<ProfileProgress>;
 
 type SupabaseProfile = Profile & { id?: string; user_id?: string };
 
+export type ProfileFieldErrors = {
+  fullName?: string;
+  preferredLanguage?: string;
+  targetBand?: string;
+  examDate?: string;
+};
+
+export type ProfileLanguageOption = { value: string; label: string };
+
+export type ProfileFormValues = {
+  fullName: string;
+  preferredLanguage: string;
+  targetBand: string;
+  examDate: string;
+};
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  en: 'English',
+  ur: 'اردو',
+};
+
+type OnboardingLanguageOption = { value: string; label?: string };
+
 function sanitizePatch(patch: ProfilePatch): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(patch)) {
@@ -56,4 +79,103 @@ export async function upsertProfile(patch: ProfilePatch): Promise<SupabaseProfil
 export async function markOnboardingComplete(): Promise<void> {
   await getSessionUserId();
   await supabaseBrowser.auth.updateUser({ data: { onboarding_complete: true } });
+}
+
+export function buildLanguageOptions(onboardingLanguages: unknown): ProfileLanguageOption[] {
+  if (
+    Array.isArray(onboardingLanguages) &&
+    onboardingLanguages.length > 0 &&
+    typeof onboardingLanguages[0] === 'string'
+  ) {
+    return (onboardingLanguages as string[]).map((value) => ({
+      value,
+      label: LANGUAGE_LABELS[value] ?? value.toUpperCase(),
+    }));
+  }
+
+  if (
+    Array.isArray(onboardingLanguages) &&
+    onboardingLanguages.length > 0 &&
+    typeof onboardingLanguages[0] === 'object' &&
+    onboardingLanguages[0] !== null &&
+    'value' in (onboardingLanguages[0] as OnboardingLanguageOption)
+  ) {
+    return (onboardingLanguages as OnboardingLanguageOption[]).map((opt) => ({
+      value: opt.value,
+      label: LANGUAGE_LABELS[opt.value] ?? opt.label ?? opt.value.toUpperCase(),
+    }));
+  }
+
+  return ['en', 'ur'].map((value) => ({
+    value,
+    label: LANGUAGE_LABELS[value] ?? value.toUpperCase(),
+  }));
+}
+
+export function formatTargetBand(targetBand: number | null | undefined): string {
+  if (typeof targetBand !== 'number') return '';
+  return targetBand.toFixed(Number.isInteger(targetBand) ? 0 : 1);
+}
+
+export function toProfileFormValues(profile: SupabaseProfile | null): ProfileFormValues {
+  return {
+    fullName: profile?.full_name ?? '',
+    preferredLanguage: profile?.preferred_language ?? 'en',
+    targetBand: formatTargetBand(profile?.target_band),
+    examDate: profile?.exam_date?.slice?.(0, 10) ?? '',
+  };
+}
+
+export function getProfileInitials(fullName: string): string {
+  return fullName.trim() ? fullName.trim()[0]!.toUpperCase() : 'U';
+}
+
+export function validateProfileForm(
+  values: ProfileFormValues,
+  languageOptions: ProfileLanguageOption[],
+  t: (key: string, fallback: string) => string,
+): {
+  isValid: boolean;
+  parsedTarget: number | null;
+  trimmedName: string;
+  errors: ProfileFieldErrors;
+} {
+  const errors: ProfileFieldErrors = {};
+  const trimmedName = values.fullName.trim();
+
+  if (!trimmedName) {
+    errors.fullName = t('profile.form.name.required', 'Name is required.');
+  }
+
+  if (!values.preferredLanguage) {
+    errors.preferredLanguage = t('profile.form.language.pick', 'Select a language.');
+  } else if (!languageOptions.some((option) => option.value === values.preferredLanguage)) {
+    errors.preferredLanguage = t('profile.form.language.supported', 'Select a supported language.');
+  }
+
+  let parsedTarget: number | null = null;
+  if (values.targetBand.trim()) {
+    parsedTarget = Number(values.targetBand);
+    const isValidNumber = Number.isFinite(parsedTarget);
+    const isInRange = parsedTarget >= 4 && parsedTarget <= 9;
+    const isHalfStep = Math.abs(parsedTarget * 2 - Math.round(parsedTarget * 2)) < 0.001;
+
+    if (!isValidNumber || !isInRange || !isHalfStep) {
+      errors.targetBand = t(
+        'profile.form.band.range',
+        'Target band must be between 4.0 and 9.0 in 0.5 steps.',
+      );
+    }
+  }
+
+  if (values.examDate) {
+    const parsedDate = new Date(values.examDate);
+    if (Number.isNaN(parsedDate.getTime())) {
+      errors.examDate = t('profile.form.date.valid', 'Enter a valid exam date.');
+    } else if (parsedDate < new Date()) {
+      errors.examDate = t('profile.form.date.future', 'Exam date must be in the future.');
+    }
+  }
+
+  return { isValid: Object.keys(errors).length === 0, parsedTarget, trimmedName, errors };
 }

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
 import Head from 'next/head';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
@@ -12,234 +10,49 @@ import { Input } from '@/components/design-system/Input';
 import { Select } from '@/components/design-system/Select';
 import { Alert } from '@/components/design-system/Alert';
 import { useToast } from '@/components/design-system/Toaster';
-import { useStreak } from '@/hooks/useStreak';
-import { fetchProfile, upsertProfile } from '@/lib/profile';
-import type { Profile } from '@/types/profile';
-import { languageOptions as onboardingLanguages } from '@/lib/onboarding/schema';
-import { useLocale } from '@/lib/locale';
 import { VocabInsightsCards } from '@/components/quiz/VocabInsightsCards';
-
-type FieldErrors = {
-  fullName?: string;
-  preferredLanguage?: string;
-  targetBand?: string;
-  examDate?: string;
-};
-
-const LANGUAGE_LABELS: Record<string, string> = {
-  en: 'English',
-  ur: 'اردو',
-};
-
-type OnboardingLanguageOption = { value: string; label?: string };
+import { useProfile } from '@/hooks/useProfile';
+import { useStreak } from '@/hooks/useStreak';
+import { useLocale } from '@/lib/locale';
 
 export default function ProfilePage() {
-  const router = useRouter();
   const { t } = useLocale();
   const { success: toastSuccess, error: toastError } = useToast();
+  const { current: streak, longest, loading: streakLoading, shields } = useStreak();
   const {
-    current: streak,
-    longest,
-    loading: streakLoading,
-    shields,
-  } = useStreak();
-
-  const [profile, setProfile] = useState<Profile | null>(null);
-  const [fullName, setFullName] = useState('');
-  const [preferredLanguage, setPreferredLanguage] = useState('en');
-  const [targetBand, setTargetBand] = useState('');
-  const [examDate, setExamDate] = useState('');
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
-
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
-
-  const languageOptions = useMemo(() => {
-    const src = onboardingLanguages as unknown;
-
-    if (Array.isArray(src) && src.length > 0 && typeof src[0] === 'string') {
-      return (src as string[]).map((value) => ({
-        value,
-        label: LANGUAGE_LABELS[value] ?? value.toUpperCase(),
-      }));
-    }
-
-    if (
-      Array.isArray(src) &&
-      src.length > 0 &&
-      typeof src[0] === 'object' &&
-      src[0] !== null &&
-      'value' in (src[0] as OnboardingLanguageOption)
-    ) {
-      return (src as OnboardingLanguageOption[]).map((opt) => ({
-        value: opt.value,
-        label: LANGUAGE_LABELS[opt.value] ?? opt.label ?? opt.value.toUpperCase(),
-      }));
-    }
-
-    return ['en', 'ur'].map((value) => ({
-      value,
-      label: LANGUAGE_LABELS[value] ?? value.toUpperCase(),
-    }));
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    (async () => {
-      setLoading(true);
-      try {
-        const nextProfile = await fetchProfile();
-        if (cancelled) return;
-
-        if (!nextProfile || nextProfile.draft) {
-          await router.replace('/profile/setup');
-          return;
-        }
-
-        setProfile(nextProfile);
-        setFullName(nextProfile.full_name ?? '');
-        setPreferredLanguage(nextProfile.preferred_language ?? 'en');
-        setTargetBand(
-          typeof nextProfile.target_band === 'number'
-            ? nextProfile.target_band.toFixed(
-                Number.isInteger(nextProfile.target_band) ? 0 : 1,
-              )
-            : '',
-        );
-        setExamDate(nextProfile.exam_date?.slice?.(0, 10) ?? '');
-        setAvatarUrl(nextProfile.avatar_url ?? null);
-        setError(null);
-      } catch (err) {
-        if (cancelled) return;
-
-        if (err instanceof Error && err.message === 'Not authenticated') {
-          await router.replace('/login');
-          return;
-        }
-
-        setError(
-          t('profile.load.error', 'Unable to load your profile right now.'),
-        );
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const validate = () => {
-    const errors: FieldErrors = {};
-    const trimmedName = fullName.trim();
-
-    if (!trimmedName) {
-      errors.fullName = t('profile.form.name.required', 'Name is required.');
-    }
-
-    if (!preferredLanguage) {
-      errors.preferredLanguage = t(
-        'profile.form.language.pick',
-        'Select a language.',
-      );
-    } else if (!languageOptions.some((option) => option.value === preferredLanguage)) {
-      errors.preferredLanguage = t(
-        'profile.form.language.supported',
-        'Select a supported language.',
-      );
-    }
-
-    let parsedTarget: number | null = null;
-    if (targetBand.trim()) {
-      parsedTarget = Number(targetBand);
-      const isValidNumber = Number.isFinite(parsedTarget);
-      const isInRange = parsedTarget >= 4 && parsedTarget <= 9;
-      const isHalfStep =
-        Math.abs(parsedTarget * 2 - Math.round(parsedTarget * 2)) < 0.001;
-
-      if (!isValidNumber || !isInRange || !isHalfStep) {
-        errors.targetBand = t(
-          'profile.form.band.range',
-          'Target band must be between 4.0 and 9.0 in 0.5 steps.',
-        );
-      }
-    }
-
-    if (examDate) {
-      const parsedDate = new Date(examDate);
-      if (Number.isNaN(parsedDate.getTime())) {
-        errors.examDate = t(
-          'profile.form.date.valid',
-          'Enter a valid exam date.',
-        );
-      } else if (parsedDate < new Date()) {
-        errors.examDate = t(
-          'profile.form.date.future',
-          'Exam date must be in the future.',
-        );
-      }
-    }
-
-    setFieldErrors(errors);
-    return { isValid: Object.keys(errors).length === 0, parsedTarget, trimmedName };
-  };
+    form,
+    setField,
+    loading,
+    saving,
+    error,
+    fieldErrors,
+    avatarUrl,
+    languageOptions,
+    initials,
+    goToFullSetup,
+    save,
+  } = useProfile(t);
 
   const handleSave = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!profile) return;
+    const result = await save();
 
-    const { isValid, parsedTarget, trimmedName } = validate();
-    if (!isValid) {
+    if (result.ok) {
+      toastSuccess(t('profile.save.ok', 'Profile updated'));
+      return;
+    }
+
+    if (result.validationFailed) {
       toastError(t('profile.form.fix', 'Please fix the highlighted fields.'));
       return;
     }
 
-    setSaving(true);
-    try {
-      const updated = await upsertProfile({
-        full_name: trimmedName,
-        preferred_language: preferredLanguage,
-        target_band: parsedTarget ?? undefined,
-        exam_date: examDate || null,
-      });
-
-      setProfile(updated);
-      setFullName(updated.full_name ?? trimmedName);
-      setPreferredLanguage(updated.preferred_language ?? preferredLanguage);
-      setTargetBand(
-        typeof updated.target_band === 'number'
-          ? updated.target_band.toFixed(
-              Number.isInteger(updated.target_band) ? 0 : 1,
-            )
-          : '',
-      );
-      setExamDate(updated.exam_date?.slice?.(0, 10) ?? '');
-      setAvatarUrl(updated.avatar_url ?? avatarUrl ?? null);
-
-      toastSuccess(t('profile.save.ok', 'Profile updated'));
-    } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : t(
-              'profile.save.fail',
-              'Unable to save your profile right now.',
-            );
-      toastError(message);
-    } finally {
-      setSaving(false);
-    }
+    toastError(result.message ?? t('profile.save.fail', 'Unable to save your profile right now.'));
   };
 
-  const initials = fullName.trim() ? fullName.trim()[0]!.toUpperCase() : 'U';
   const currentStreak = streak ?? 0;
   const longestStreak = longest ?? 0;
-  const shieldCount = shields?.length ?? 0;
+  const shieldCount = typeof shields === 'number' ? shields : 0;
 
   if (loading) {
     return (
@@ -271,7 +84,6 @@ export default function ProfilePage() {
       <section className="py-10 bg-background text-foreground">
         <Container>
           <div className="mx-auto flex max-w-2xl flex-col gap-6">
-            {/* Compact header + streak in one card */}
             <Card className="flex flex-col gap-4 rounded-ds-2xl p-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary sm:h-14 sm:w-14">
@@ -284,14 +96,12 @@ export default function ProfilePage() {
                       className="h-12 w-12 rounded-full object-cover sm:h-14 sm:w-14"
                     />
                   ) : (
-                    <span className="text-base font-semibold sm:text-lg">
-                      {initials}
-                    </span>
+                    <span className="text-base font-semibold sm:text-lg">{initials}</span>
                   )}
                 </div>
                 <div className="space-y-0.5">
                   <p className="text-sm font-medium">
-                    {fullName || t('profile.name.placeholder', 'Your name')}
+                    {form.fullName || t('profile.name.placeholder', 'Your name')}
                   </p>
                   <p className="text-[11px] text-muted-foreground">
                     {t(
@@ -303,13 +113,10 @@ export default function ProfilePage() {
               </div>
 
               <div className="flex flex-wrap items-center gap-3 sm:justify-end">
-                {/* Streak summary – compact */}
                 <div className="flex items-center gap-2 rounded-full bg-muted px-3 py-1 text-[11px] text-muted-foreground">
                   <span className="text-xs">🔥</span>
                   {streakLoading ? (
-                    <span>
-                      {t('profile.streak.loading', 'Calculating streak…')}
-                    </span>
+                    <span>{t('profile.streak.loading', 'Calculating streak…')}</span>
                   ) : (
                     <span>
                       {t('profile.streak.current', '{{days}} day streak', {
@@ -317,11 +124,7 @@ export default function ProfilePage() {
                       })}
                       {longestStreak > 0 && (
                         <span className="ml-1 text-[10px] text-muted-foreground/80">
-                          {t(
-                            'profile.streak.longest',
-                            'max {{days}}',
-                            { days: longestStreak },
-                          )}
+                          {t('profile.streak.longest', 'max {{days}}', { days: longestStreak })}
                         </span>
                       )}
                     </span>
@@ -340,7 +143,7 @@ export default function ProfilePage() {
                   type="button"
                   variant="ghost"
                   className="rounded-ds-xl px-3 py-1 text-xs"
-                  onClick={() => router.push('/profile/setup')}
+                  onClick={goToFullSetup}
                 >
                   {t('profile.actions.fullSetup', 'Full setup')}
                 </Button>
@@ -355,32 +158,25 @@ export default function ProfilePage() {
               </Alert>
             )}
 
-            {/* Form – minimal, app-style */}
             <Card className="rounded-ds-2xl p-5 sm:p-6">
               <form className="space-y-5" onSubmit={handleSave} noValidate>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <Input
                     label={t('profile.form.name.label', 'Full name')}
-                    value={fullName}
-                    onChange={(event) => setFullName(event.target.value)}
+                    value={form.fullName}
+                    onChange={(event) => setField('fullName', event.target.value)}
                     error={fieldErrors.fullName ?? null}
                     required
                   />
                   <Select
-                    label={t(
-                      'profile.form.language.label',
-                      'Preferred language',
-                    )}
-                    value={preferredLanguage}
-                    onChange={(event) => setPreferredLanguage(event.target.value)}
+                    label={t('profile.form.language.label', 'Preferred language')}
+                    value={form.preferredLanguage}
+                    onChange={(event) => setField('preferredLanguage', event.target.value)}
                     error={fieldErrors.preferredLanguage ?? null}
                     required
                   >
                     <option value="" disabled>
-                      {t(
-                        'profile.form.language.select',
-                        'Select language',
-                      )}
+                      {t('profile.form.language.select', 'Select language')}
                     </option>
                     {languageOptions.map((option) => (
                       <option key={option.value} value={option.value}>
@@ -393,35 +189,23 @@ export default function ProfilePage() {
                 <div className="grid gap-4 sm:grid-cols-2">
                   <Input
                     type="number"
-                    label={t(
-                      'profile.form.band.label',
-                      'Target IELTS band',
-                    )}
-                    placeholder={t(
-                      'profile.form.band.placeholder',
-                      'e.g. 7.5',
-                    )}
+                    label={t('profile.form.band.label', 'Target IELTS band')}
+                    placeholder={t('profile.form.band.placeholder', 'e.g. 7.5')}
                     min={4}
                     max={9}
                     step={0.5}
-                    value={targetBand}
-                    onChange={(event) => setTargetBand(event.target.value)}
+                    value={form.targetBand}
+                    onChange={(event) => setField('targetBand', event.target.value)}
                     error={fieldErrors.targetBand ?? null}
-                    helperText={t(
-                      'profile.form.band.helper',
-                      '4.0 – 9.0 in 0.5 steps',
-                    )}
+                    helperText={t('profile.form.band.helper', '4.0 – 9.0 in 0.5 steps')}
                   />
                   <Input
                     type="date"
                     label={t('profile.form.date.label', 'Exam date')}
-                    value={examDate}
-                    onChange={(event) => setExamDate(event.target.value)}
+                    value={form.examDate}
+                    onChange={(event) => setField('examDate', event.target.value)}
                     error={fieldErrors.examDate ?? null}
-                    helperText={t(
-                      'profile.form.date.optional',
-                      'Optional',
-                    )}
+                    helperText={t('profile.form.date.optional', 'Optional')}
                   />
                 </div>
 


### PR DESCRIPTION
### Motivation
- Centralize profile data loading, save flow, and validation away from the route component to improve separation of concerns and testability. 
- Move profile business rules and transforms into a single domain module so other consumers can reuse consistent logic. 
- Keep the route file focused on composition/layout and rendering child components without direct Supabase queries or subscription logic.

### Description
- Added a new hook `hooks/useProfile.ts` that owns profile loading, redirect behavior, form state, save flow, and field-level errors. 
- Moved business transforms and validation into `lib/profile.ts`, including `buildLanguageOptions`, `formatTargetBand`, `toProfileFormValues`, `getProfileInitials`, `validateProfileForm`, and related types. 
- Refactored `pages/profile/index.tsx` to consume `useProfile` and removed inline calls to `fetchProfile`/`upsertProfile` and local validation/formatting logic. 
- Updated imports and adapted UI wiring (form values, setters, save handler, and full-setup navigation) to use the new hook and domain helpers.

### Testing
- Ran `npx prettier --write pages/profile/index.tsx hooks/useProfile.ts lib/profile.ts` which succeeded. 
- Verified formatting with `npx prettier --check pages/profile/index.tsx hooks/useProfile.ts lib/profile.ts` which passed. 
- Attempted `npx eslint pages/profile/index.tsx hooks/useProfile.ts lib/profile.ts` which failed in this environment due to the project ESLint config referencing a missing package (`@eslint/eslintrc`). 
- Attempted `npx tsc --noEmit --pretty false` which failed because of pre-existing unrelated TypeScript/syntax issues in other files in this repository, not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eac4592c832fafd77c253e206b98)