### PR TITLE
Refactor billing/subscription pages to consume shared subscription hook

### DIFF
--- a/hooks/useSubscription.ts
+++ b/hooks/useSubscription.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { fetchProfile } from '@/lib/profile';
+import {
+  PLAN_DISPLAY,
+  formatDateLabel,
+  hasActiveSubscription,
+  isTrialActive,
+  normalizePlan,
+  normalizeStatus,
+} from '@/lib/subscription';
+import type { Profile } from '@/types/profile';
+
+export function useSubscription() {
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const fetchedProfile = await fetchProfile();
+      if (!fetchedProfile) throw new Error('Profile not found');
+      setProfile(fetchedProfile);
+      return fetchedProfile;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to load subscription details.';
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load().catch((err) => {
+      if (err instanceof Error && err.message === 'Not authenticated') return;
+    });
+  }, [load]);
+
+  const plan = useMemo(() => normalizePlan(profile?.tier), [profile?.tier]);
+  const status = useMemo(() => normalizeStatus(profile?.subscription_status), [profile?.subscription_status]);
+  const expiresAt = profile?.subscription_expires_at ?? profile?.premium_until ?? null;
+
+  return {
+    profile,
+    plan,
+    status,
+    displayPlan: PLAN_DISPLAY[plan],
+    expiresAt,
+    expiresAtLabel: formatDateLabel(expiresAt),
+    isPremium: hasActiveSubscription(plan, status),
+    isTrial: isTrialActive(profile?.premium_until),
+    hasBillingHistory: Boolean(profile?.stripe_customer_id) && status === 'active',
+    loading,
+    error,
+    refresh: load,
+  };
+}
+
+export default useSubscription;

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -1,0 +1,114 @@
+import type { PlanId } from '@/types/pricing';
+
+export type SubscriptionPlan = PlanId;
+
+export type SubscriptionStatus =
+  | 'active'
+  | 'trialing'
+  | 'canceled'
+  | 'incomplete'
+  | 'past_due'
+  | 'unpaid'
+  | 'paused'
+  | 'inactive'
+  | 'expired'
+  | 'none';
+
+export type SubscriptionPlanKey = 'free' | 'starter' | 'booster' | 'master';
+
+export type PlanDisplay = {
+  name: string;
+  features: string[];
+  price?: string;
+};
+
+export const PLAN_DISPLAY: Record<SubscriptionPlanKey, PlanDisplay> = {
+  free: {
+    name: 'Free',
+    features: ['Basic access', 'Limited mocks', 'Community support'],
+    price: '$0',
+  },
+  starter: {
+    name: 'Starter',
+    features: ['More mocks', 'Basic analytics', 'Email reminders'],
+    price: '$5.99/month',
+  },
+  booster: {
+    name: 'Booster',
+    features: ['Full mocks', 'Band analytics', 'AI feedback'],
+    price: '$9.99/month',
+  },
+  master: {
+    name: 'Master',
+    features: ['Everything in Booster', 'Teacher tools', 'Priority support'],
+    price: '$14.99/month',
+  },
+};
+
+export function normalizePlan(plan?: string | null): SubscriptionPlanKey {
+  if (plan === 'starter' || plan === 'booster' || plan === 'master') return plan;
+  return 'free';
+}
+
+export function normalizeStatus(status?: string | null): SubscriptionStatus {
+  if (!status) return 'inactive';
+  if (
+    status === 'active' ||
+    status === 'trialing' ||
+    status === 'canceled' ||
+    status === 'incomplete' ||
+    status === 'past_due' ||
+    status === 'unpaid' ||
+    status === 'paused' ||
+    status === 'inactive' ||
+    status === 'expired' ||
+    status === 'none'
+  ) {
+    return status;
+  }
+  return 'inactive';
+}
+
+export function hasActiveSubscription(plan: SubscriptionPlanKey, status: SubscriptionStatus): boolean {
+  return plan !== 'free' && (status === 'active' || status === 'trialing');
+}
+
+export function isTrialActive(trialEndsAt?: string | null): boolean {
+  if (!trialEndsAt) return false;
+  const date = new Date(trialEndsAt);
+  return !Number.isNaN(date.getTime()) && date > new Date();
+}
+
+export function formatSubscriptionLabel(value?: string | null): string {
+  if (!value) return 'None';
+  return value.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function getSubscriptionStatusVariant(status: SubscriptionStatus) {
+  switch (status) {
+    case 'active':
+      return 'success' as const;
+    case 'trialing':
+      return 'info' as const;
+    case 'past_due':
+    case 'incomplete':
+      return 'warning' as const;
+    case 'unpaid':
+      return 'danger' as const;
+    case 'paused':
+      return 'secondary' as const;
+    case 'canceled':
+    case 'expired':
+    case 'none':
+    case 'inactive':
+    default:
+      return 'neutral' as const;
+  }
+}
+
+export function formatDateLabel(value?: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString();
+}

--- a/pages/profile/account/billing.tsx
+++ b/pages/profile/account/billing.tsx
@@ -15,6 +15,11 @@ import { Heading } from '@/components/design-system/Heading';
 import { Section } from '@/components/design-system/Section';
 import { SectionLabel } from '@/components/design-system/SectionLabel';
 import { Skeleton } from '@/components/design-system/Skeleton';
+import {
+  formatDateLabel,
+  formatSubscriptionLabel,
+  getSubscriptionStatusVariant,
+} from '@/lib/subscription';
 
 type Invoice = {
   id: string;
@@ -52,28 +57,6 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   }
 
   return { props: {} };
-};
-
-const toTitleCase = (value: string) =>
-  value.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
-
-const getStatusVariant = (status: Summary['status']) => {
-  switch (status) {
-    case 'active':
-      return 'success';
-    case 'trialing':
-      return 'info';
-    case 'past_due':
-    case 'incomplete':
-      return 'warning';
-    case 'unpaid':
-      return 'danger';
-    case 'paused':
-      return 'secondary';
-    case 'canceled':
-    default:
-      return 'neutral';
-  }
 };
 
 const getInvoiceVariant = (status: Invoice['status']) => {
@@ -153,10 +136,6 @@ export default function BillingPage() {
   const showSafepayFailed = safepayStatus === 'failed';
   const showSafepayError = safepayStatus === 'error';
 
-  const dateFormatter = React.useMemo(
-    () => new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }),
-    [],
-  );
   const dateTimeFormatter = React.useMemo(
     () =>
       new Intl.DateTimeFormat(undefined, {
@@ -174,10 +153,6 @@ export default function BillingPage() {
     [],
   );
 
-  const formatDate = React.useCallback(
-    (value?: string | null) => (value ? dateFormatter.format(new Date(value)) : null),
-    [dateFormatter],
-  );
   const formatDateTime = React.useCallback(
     (value: string) => dateTimeFormatter.format(new Date(value)),
     [dateTimeFormatter],
@@ -222,8 +197,8 @@ export default function BillingPage() {
   }
 
   const renderPlanMeta = () => {
-    const renews = formatDate(summary?.renewsAt);
-    const trialEnds = formatDate(summary?.trialEndsAt);
+    const renews = formatDateLabel(summary?.renewsAt);
+    const trialEnds = formatDateLabel(summary?.trialEndsAt);
     if (!renews && !trialEnds) return null;
     return (
       <p className="text-small text-muted-foreground">
@@ -354,10 +329,10 @@ export default function BillingPage() {
                         id="current-plan-heading"
                         className="capitalize text-foreground"
                       >
-                        {toTitleCase(summary.plan)}
+                        {formatSubscriptionLabel(summary.plan)}
                       </Heading>
-                      <Badge variant={getStatusVariant(summary.status)}>
-                        {toTitleCase(summary.status)}
+                      <Badge variant={getSubscriptionStatusVariant(summary.status)}>
+                        {formatSubscriptionLabel(summary.status)}
                       </Badge>
                     </div>
                     {renderPlanMeta()}
@@ -440,10 +415,10 @@ export default function BillingPage() {
                           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                             <div className="space-y-2">
                               <Badge variant={getDueVariant(d.status)}>
-                                {toTitleCase(d.status)}
+                                {formatSubscriptionLabel(d.status)}
                               </Badge>
                               <div className="text-small text-muted-foreground">
-                                {toTitleCase(d.plan_key)} · {toTitleCase(d.cycle)}
+                                {formatSubscriptionLabel(d.plan_key)} · {formatSubscriptionLabel(d.cycle)}
                               </div>
                               <div className="text-caption text-muted-foreground">
                                 {formatDateTime(d.created_at)}
@@ -485,7 +460,7 @@ export default function BillingPage() {
                           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                             <div className="space-y-2">
                               <Badge variant={getInvoiceVariant(inv.status)}>
-                                {toTitleCase(inv.status)}
+                                {formatSubscriptionLabel(inv.status)}
                               </Badge>
                               <p className="text-caption text-muted-foreground">
                                 {formatDateTime(inv.createdAt)}

--- a/pages/profile/billing.tsx
+++ b/pages/profile/billing.tsx
@@ -12,11 +12,9 @@ import { Alert } from '@/components/design-system/Alert';
 import { Badge } from '@/components/design-system/Badge';
 import { withPageAuth } from '@/lib/requirePageAuth';
 import { useToast } from '@/components/design-system/Toaster';
-import { fetchProfile } from '@/lib/profile';
-import type { Profile } from '@/types/profile';
+import { useSubscription } from '@/hooks/useSubscription';
 import { GlobalPlanGuard } from '@/components/GlobalPlanGuard';
 import { useLocale } from '@/lib/locale';
-import type { PlanId } from '@/types/pricing';
 
 type Invoice = {
   id: string;
@@ -32,23 +30,17 @@ export default function BillingHistoryPage() {
   const router = useRouter();
   const { t } = useLocale();
   const { error: toastError } = useToast();
-  const [profile, setProfile] = useState<Profile | null>(null);
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const { plan, hasBillingHistory, error: subscriptionError } = useSubscription();
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       setLoading(true);
       try {
-        const fetchedProfile = await fetchProfile();
-        if (cancelled) return;
-        if (!fetchedProfile) {
-          throw new Error('Profile not found');
-        }
-        setProfile(fetchedProfile);
-
         // Fetch billing history via API route (server-side Stripe call)
         const response = await fetch('/api/billing/history', {
           headers: { 'Content-Type': 'application/json' },
@@ -79,8 +71,14 @@ export default function BillingHistoryPage() {
     };
   }, [router, t, toastError]);
 
-  const currentPlan: PlanId = profile?.tier ?? 'free';
-  const hasSubscription = !!profile?.stripe_customer_id && profile.subscription_status === 'active';
+  const currentPlan = plan;
+  const hasSubscription = hasBillingHistory;
+
+  useEffect(() => {
+    if (subscriptionError === 'Not authenticated') {
+      void router.replace('/login');
+    }
+  }, [subscriptionError, router]);
 
   if (loading) {
     return (

--- a/pages/profile/subscription.tsx
+++ b/pages/profile/subscription.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useRouter } from 'next/router';
 
 import { Container } from '@/components/design-system/Container';
@@ -8,116 +8,38 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
 import { useToast } from '@/components/design-system/Toaster';
-import { fetchProfile } from '@/lib/profile';
-import type { Profile } from '@/types/profile';
 import { GlobalPlanGuard } from '@/components/GlobalPlanGuard';
 import { useLocale } from '@/lib/locale';
-import type { PlanId } from '@/types/pricing';
-
-type SubscriptionStatus =
-  | 'active'
-  | 'trialing'
-  | 'canceled'
-  | 'incomplete'
-  | 'past_due'
-  | 'unpaid'
-  | 'paused'
-  | 'inactive'
-  | 'expired';
-
-type SubscriptionPlanKey = 'free' | 'starter' | 'booster' | 'master';
-
-type PlanDisplay = {
-  name: string;
-  features: string[];
-  price?: string;
-};
-
-const PLAN_DISPLAY: Record<SubscriptionPlanKey, PlanDisplay> = {
-  free: {
-    name: 'Free',
-    features: ['Basic access', 'Limited mocks', 'Community support'],
-    price: '$0',
-  },
-  starter: {
-    name: 'Starter',
-    features: ['More mocks', 'Basic analytics', 'Email reminders'],
-    price: '$5.99/month',
-  },
-  booster: {
-    name: 'Booster',
-    features: ['Full mocks', 'Band analytics', 'AI feedback'],
-    price: '$9.99/month',
-  },
-  master: {
-    name: 'Master',
-    features: ['Everything in Booster', 'Teacher tools', 'Priority support'],
-    price: '$14.99/month',
-  },
-};
+import { useSubscription } from '@/hooks/useSubscription';
 
 export default function SubscriptionPage() {
   const router = useRouter();
   const { t } = useLocale();
   const { error: toastError } = useToast();
-  const [profile, setProfile] = useState<Profile | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    plan,
+    profile,
+    status,
+    displayPlan,
+    expiresAtLabel,
+    isPremium,
+    isTrial,
+    hasBillingHistory,
+    loading,
+    error,
+  } = useSubscription();
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      try {
-        const fetchedProfile = await fetchProfile();
-        if (cancelled) return;
-        if (!fetchedProfile) {
-          throw new Error('Profile not found');
-        }
-        setProfile(fetchedProfile);
-        setError(null);
-      } catch (err) {
-        if (cancelled) return;
-        if (err instanceof Error && err.message === 'Not authenticated') {
-          await router.replace('/login');
-          return;
-        }
-        console.error('Failed to load subscription info', err);
-        const message = t(
-          'subscription.load.error',
-          'Unable to load subscription details.',
-        );
-        setError(message);
-        toastError(message);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [router, t, toastError]);
+  React.useEffect(() => {
+    if (!error || error === 'Not authenticated') return;
+    const message = t('subscription.load.error', 'Unable to load subscription details.');
+    toastError(message);
+  }, [error, t, toastError]);
 
-  const currentPlan: PlanId = profile?.tier ?? 'free';
-  const planKey: SubscriptionPlanKey =
-    (currentPlan as SubscriptionPlanKey) ?? 'free';
-
-  const status: SubscriptionStatus =
-    (profile?.subscription_status as SubscriptionStatus) ?? 'inactive';
-
-  const expiresAt =
-    profile?.subscription_expires_at ?? profile?.premium_until ?? null;
-  const expiresAtLabel =
-    expiresAt && !Number.isNaN(new Date(expiresAt).getTime())
-      ? new Date(expiresAt).toLocaleDateString()
-      : null;
-
-  const isPremium = currentPlan !== 'free' && status === 'active';
-  const isTrial =
-    !!profile?.premium_until &&
-    new Date(profile.premium_until) > new Date();
-
-  const displayPlan = PLAN_DISPLAY[planKey];
+  React.useEffect(() => {
+    if (error === 'Not authenticated') {
+      void router.replace('/login');
+    }
+  }, [error, router]);
 
   if (loading) {
     return (
@@ -132,27 +54,23 @@ export default function SubscriptionPage() {
   }
 
   return (
-    <GlobalPlanGuard min="free" userPlan={currentPlan}>
+    <GlobalPlanGuard min="free" userPlan={plan}>
       <section className="py-24 bg-background text-foreground">
         <Container>
           <div className="mx-auto max-w-2xl space-y-6">
-            {error && (
+            {error && error !== 'Not authenticated' && (
               <Alert variant="error" role="alert" className="rounded-ds-2xl">
-                {error}
+                {t('subscription.load.error', 'Unable to load subscription details.')}
               </Alert>
             )}
             <Card className="rounded-ds-2xl p-4 sm:p-6">
               <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <h1 className="font-slab text-display">
-                  {t('subscription.title', 'Subscription')}
-                </h1>
+                <h1 className="font-slab text-display">{t('subscription.title', 'Subscription')}</h1>
               </div>
               <div className="space-y-6">
                 <div className="flex flex-col items-center justify-center space-y-4 text-center">
                   <div className="rounded-full bg-primary/10 px-4 py-2 text-primary">
-                    <span className="font-semibold">
-                      {displayPlan.name} Plan
-                    </span>
+                    <span className="font-semibold">{displayPlan.name} Plan</span>
                   </div>
                   {isTrial && (
                     <Alert variant="warning" className="w-full">
@@ -166,11 +84,9 @@ export default function SubscriptionPage() {
                   </div>
                   {expiresAtLabel && (
                     <p className="text-caption text-muted-foreground">
-                      {t(
-                        'subscription.expires',
-                        'Access valid until {{date}}.',
-                        { date: expiresAtLabel },
-                      )}
+                      {t('subscription.expires', 'Access valid until {{date}}.', {
+                        date: expiresAtLabel,
+                      })}
                     </p>
                   )}
                   <p className="text-small text-muted-foreground max-w-md">
@@ -191,25 +107,17 @@ export default function SubscriptionPage() {
                 </ul>
 
                 <div className="flex flex-col gap-3">
-                  {isPremium ? (
-                    <Button
-                      variant="outline"
-                      className="rounded-ds-xl"
-                      onClick={() => router.push('/pricing/overview')}
-                    >
-                      {t('subscription.manage', 'Manage subscription')}
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="primary"
-                      className="rounded-ds-xl"
-                      onClick={() => router.push('/pricing/overview')}
-                    >
-                      {t('subscription.upgrade', 'Upgrade to Premium')}
-                    </Button>
-                  )}
+                  <Button
+                    variant={isPremium ? 'outline' : 'primary'}
+                    className="rounded-ds-xl"
+                    onClick={() => router.push('/pricing/overview')}
+                  >
+                    {isPremium
+                      ? t('subscription.manage', 'Manage subscription')
+                      : t('subscription.upgrade', 'Upgrade to Premium')}
+                  </Button>
 
-                  {profile?.stripe_customer_id && status === 'active' && (
+                  {hasBillingHistory && status === 'active' && (
                     <Button
                       variant="ghost"
                       className="rounded-ds-xl"

--- a/pages/settings/billing.tsx
+++ b/pages/settings/billing.tsx
@@ -10,6 +10,12 @@ import { Alert } from '@/components/design-system/Alert';
 import { Skeleton } from '@/components/design-system/Skeleton';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { withPageAuth } from '@/lib/requirePageAuth';
+import {
+  formatSubscriptionLabel,
+  getSubscriptionStatusVariant,
+  normalizePlan,
+  normalizeStatus,
+} from '@/lib/subscription';
 
 type BillingState = {
   plan?: 'free' | 'starter' | 'booster' | 'master';
@@ -18,25 +24,6 @@ type BillingState = {
   paymentMethod?: 'card' | 'none';
 };
 
-const statusVariant = (status: BillingState['status']) => {
-  switch (status) {
-    case 'active':
-      return 'success' as const;
-    case 'past_due':
-      return 'warning' as const;
-    case 'canceled':
-      return 'neutral' as const;
-    case 'none':
-    default:
-      return 'secondary' as const;
-  }
-};
-
-const formatStatus = (status: BillingState['status']) =>
-  status ? status.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()) : 'None';
-
-const formatPlan = (plan: BillingState['plan']) =>
-  plan ? plan.replace(/\b\w/g, (char) => char.toUpperCase()) : 'Free';
 
 const formatPaymentMethod = (method: BillingState['paymentMethod']) =>
   method === 'card' ? 'Card on file' : 'No payment method';
@@ -151,10 +138,10 @@ export default function BillingPage() {
                   </p>
                   <div className="mt-2 flex flex-wrap items-center gap-3">
                     <h2 id="current-plan-heading" className="text-h3 font-semibold capitalize">
-                      {formatPlan(billing.plan)}
+                      {formatSubscriptionLabel(normalizePlan(billing.plan))}
                     </h2>
-                    <Badge variant={statusVariant(billing.status)}>
-                      {formatStatus(billing.status)}
+                    <Badge variant={getSubscriptionStatusVariant(normalizeStatus(billing.status))}>
+                      {formatSubscriptionLabel(billing.status)}
                     </Badge>
                   </div>
                   {renewalLabel ? (


### PR DESCRIPTION
### Motivation

- Centralize Stripe/subscription business logic and normalize plan/status handling to avoid duplicated checks across pages.
- Expose a single UI-friendly hook so route components only render view markup and rely on a consistent subscription API.

### Description

- Added `lib/subscription.ts` containing types, plan display metadata, normalization helpers (`normalizePlan`, `normalizeStatus`), label/variant/format helpers, trial and active checks, and date formatting.
- Added `hooks/useSubscription.ts` which fetches the authenticated profile and exposes derived UI state (`plan`, `status`, `displayPlan`, `isPremium`, `isTrial`, `hasBillingHistory`, `expiresAtLabel`, `loading`, `error`, `refresh`).
- Refactored pages to consume the new helpers/hooks and remove inline subscription decision logic in favor of the shared helpers; modified files include `pages/profile/subscription.tsx`, `pages/profile/billing.tsx`, `pages/profile/account/billing.tsx`, and `pages/settings/billing.tsx`.
- Replaced duplicated plan/status formatting and badge-variant logic with `lib/subscription.ts` helpers and ensured pages focus on rendering and calling `useSubscription`.

### Testing

- Ran a targeted lint command (`npm run lint -- --file pages/profile/subscription.tsx --file pages/profile/billing.tsx --file pages/profile/account/billing.tsx --file pages/settings/billing.tsx --file hooks/useSubscription.ts --file lib/subscription.ts`) which failed in this environment because `next` is not available on PATH (`sh: 1: next: not found`).
- No additional automated tests were added; manual static inspection and grep checks were used to verify references were updated and duplicated logic removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eadd09a0832faded5b0427c071af)