### PR TITLE
Refactor AI calls into centralized aiService and add usage helpers

### DIFF
--- a/components/innovation/AICoachPanel.tsx
+++ b/components/innovation/AICoachPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { runCoach as runCoachRequest, trackCoachAction } from '@/services/aiService';
 
 type Profile = {
   user_id?: string;
@@ -19,7 +20,11 @@ type AICoachResponse = {
   reasoning?: string;
 };
 
-export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
+export default function AICoachPanel({
+  profile,
+  onClose,
+  onOpenStudyBuddy,
+}: {
   profile?: Profile | null;
   onClose: () => void;
   onOpenStudyBuddy?: () => void;
@@ -27,7 +32,9 @@ export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [response, setResponse] = useState<AICoachResponse | null>(null);
-  const [context, setContext] = useState('Show me five things I should focus on to improve my IELTS writing band by 0.5');
+  const [context, setContext] = useState(
+    'Show me five things I should focus on to improve my IELTS writing band by 0.5',
+  );
   const [running, setRunning] = useState(false);
 
   useEffect(() => {
@@ -46,18 +53,7 @@ export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
         goal: 'Improve writing by 0.5 band',
       };
 
-      const res = await fetch('/api/ai/coach', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-
-      if (!res.ok) {
-        const txt = await res.text();
-        throw new Error(txt || 'AI coach failed');
-      }
-
-      const json = (await res.json()) as AICoachResponse;
+      const json = await runCoachRequest<AICoachResponse>(payload);
       setResponse(json);
     } catch (e: any) {
       setError(e?.message ?? 'Unexpected error');
@@ -75,11 +71,7 @@ export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
   const handleDoSuggestion = async (id: string) => {
     // Simple action: send an event and optionally open Study Buddy for that suggestion
     try {
-      await fetch('/api/ai/coach/action', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ suggestionId: id, userId: profile?.user_id ?? null }),
-      });
+      await trackCoachAction({ suggestionId: id, userId: profile?.user_id ?? null });
       if (onOpenStudyBuddy) onOpenStudyBuddy();
     } catch (_) {
       // ignore
@@ -91,7 +83,9 @@ export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
       <div className="flex items-center justify-between p-4 border-b border-border">
         <div>
           <h3 className="font-slab text-h3">AI Coach</h3>
-          <div className="text-sm text-muted-foreground">Personalized feedback & next-step micro-actions</div>
+          <div className="text-sm text-muted-foreground">
+            Personalized feedback & next-step micro-actions
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <button
@@ -121,7 +115,13 @@ export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
           <button className="btn-primary" onClick={handleRun} disabled={loading || running}>
             {loading ? 'Thinking…' : 'Ask Coach'}
           </button>
-          <button className="btn-ghost" onClick={() => { setResponse(null); setError(null); }}>
+          <button
+            className="btn-ghost"
+            onClick={() => {
+              setResponse(null);
+              setError(null);
+            }}
+          >
             Clear
           </button>
         </div>
@@ -141,16 +141,23 @@ export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
                     <div className="flex items-start justify-between gap-2">
                       <div>
                         <div className="font-medium">{s.title}</div>
-                        {s.detail && <div className="text-sm text-muted-foreground mt-1">{s.detail}</div>}
+                        {s.detail && (
+                          <div className="text-sm text-muted-foreground mt-1">{s.detail}</div>
+                        )}
                         {s.estimatedMinutes && (
-                          <div className="text-xs text-muted-foreground mt-1">~{s.estimatedMinutes} mins</div>
+                          <div className="text-xs text-muted-foreground mt-1">
+                            ~{s.estimatedMinutes} mins
+                          </div>
                         )}
                       </div>
                       <div className="flex flex-col gap-2">
                         <button className="btn" onClick={() => handleDoSuggestion(s.id)}>
                           Do it
                         </button>
-                        <button className="btn-ghost" onClick={() => navigator.clipboard?.writeText(s.title)}>
+                        <button
+                          className="btn-ghost"
+                          onClick={() => navigator.clipboard?.writeText(s.title)}
+                        >
                           Copy
                         </button>
                       </div>
@@ -163,7 +170,9 @@ export default function AICoachPanel({ profile, onClose, onOpenStudyBuddy }: {
             {response.reasoning && (
               <div className="mt-4">
                 <div className="text-small text-muted-foreground">How the coach thought</div>
-                <pre className="mt-2 p-3 rounded bg-muted/20 text-xs overflow-auto">{response.reasoning}</pre>
+                <pre className="mt-2 p-3 rounded bg-muted/20 text-xs overflow-auto">
+                  {response.reasoning}
+                </pre>
               </div>
             )}
           </div>

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -13,6 +13,14 @@ export type IncrementRes =
   | { ok: true; key: UsageKey; dateISO: string; count: number }
   | { ok: false; error: string };
 
+export type UsageDecision = {
+  allowed: boolean;
+  count: number;
+  limit: number;
+  remaining: number;
+  reason?: 'limit_reached' | 'counter_unavailable';
+};
+
 export function todayISO(d = new Date()) {
   // YYYY-MM-DD in UTC (server groups by calendar day)
   return d.toISOString().slice(0, 10);
@@ -29,10 +37,7 @@ async function authHeader(): Promise<Record<string, string>> {
   }
 }
 
-const base =
-  typeof window === 'undefined'
-    ? env.SITE_URL || env.NEXT_PUBLIC_BASE_URL || ''
-    : '';
+const base = typeof window === 'undefined' ? env.SITE_URL || env.NEXT_PUBLIC_BASE_URL || '' : '';
 
 export async function increment(
   key: UsageKey,
@@ -63,12 +68,39 @@ export async function getCount(key: UsageKey, dateISO = todayISO()): Promise<num
 }
 
 /** Quick “can I use this?” guard. */
-export async function canUse(
-  key: UsageKey,
-  limit: number,
-): Promise<{ allowed: boolean; count: number; limit: number }> {
+export async function canUse(key: UsageKey, limit: number): Promise<UsageDecision> {
   // Step=0 returns current count without increment (API supports it).
   const res = await increment(key, 0);
   const count = res.ok ? res.count : 0;
-  return { allowed: count < limit, count, limit };
+  const remaining = Math.max(0, limit - count);
+  if (!res.ok) {
+    return { allowed: false, count, limit, remaining, reason: 'counter_unavailable' };
+  }
+
+  const allowed = count < limit;
+  return {
+    allowed,
+    count,
+    limit,
+    remaining,
+    reason: allowed ? undefined : 'limit_reached',
+  };
+}
+
+export async function ensureUsageAllowed(key: UsageKey, limit: number): Promise<UsageDecision> {
+  const decision = await canUse(key, limit);
+  if (!decision.allowed) {
+    throw new Error(
+      decision.reason === 'limit_reached' ? 'usage_limit_reached' : 'usage_unavailable',
+    );
+  }
+  return decision;
+}
+
+export async function incrementUsage(key: UsageKey, step = 1): Promise<number> {
+  const res = await increment(key, step);
+  if (!res.ok) {
+    throw new Error(res.error || 'usage_increment_failed');
+  }
+  return res.count;
 }

--- a/pages/labs/ai-tutor.tsx
+++ b/pages/labs/ai-tutor.tsx
@@ -1,125 +1,235 @@
 // ================================
 // File: pages/labs/ai-tutor.tsx
 // ================================
-import * as React from 'react'
-import Head from 'next/head'
-import Link from 'next/link'
-import { Button } from '@/components/design-system/Button'
-import { Input } from '@/components/design-system/Input'
-import { Skeleton } from '@/components/design-system/Skeleton'
-import { scoreSpeaking } from '@/lib/ai/speaking_v2'
-import { scoreWriting } from '@/lib/ai/writing_v2'
+import * as React from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { Button } from '@/components/design-system/Button';
+import { Input } from '@/components/design-system/Input';
+import { Skeleton } from '@/components/design-system/Skeleton';
+import { scoreSpeaking } from '@/lib/ai/speaking_v2';
+import { scoreWriting } from '@/lib/ai/writing_v2';
+import { askTutor, uploadAudio } from '@/services/aiService';
 
 // ---- Types ----
-type Role = 'user' | 'assistant' | 'system'
+type Role = 'user' | 'assistant' | 'system';
 
 type Msg = {
-  id: string
-  role: Role
-  text?: string
-  module?: 'listening' | 'reading' | 'writing' | 'speaking'
-  ts: string
-  meta?: Record<string, unknown>
-}
+  id: string;
+  role: Role;
+  text?: string;
+  module?: 'listening' | 'reading' | 'writing' | 'speaking';
+  ts: string;
+  meta?: Record<string, unknown>;
+};
 
 // ---- Helpers ----
-function uid() { return Math.random().toString(36).slice(2) }
-function nowIso() { return new Date().toISOString() }
-function cls(...xs: Array<string | false | null | undefined>) { return xs.filter(Boolean).join(' ') }
+function uid() {
+  return Math.random().toString(36).slice(2);
+}
+function nowIso() {
+  return new Date().toISOString();
+}
+function cls(...xs: Array<string | false | null | undefined>) {
+  return xs.filter(Boolean).join(' ');
+}
 
-export default function AiTutorPage(){
-  const [module, setModule] = React.useState<'listening'|'reading'|'writing'|'speaking'>('writing')
-  const [input, setInput] = React.useState('')
-  const [busy, setBusy] = React.useState(false)
-  const [msgs, setMsgs] = React.useState<Msg[]>([{
-    id: uid(), role: 'assistant', ts: nowIso(), module,
-    text: 'Hi! I\'m your IELTS AI Tutor. Pick a module and send your answer or question. I\'ll analyze and coach you to the next band.'
-  }])
+export default function AiTutorPage() {
+  const [module, setModule] = React.useState<'listening' | 'reading' | 'writing' | 'speaking'>(
+    'writing',
+  );
+  const [input, setInput] = React.useState('');
+  const [busy, setBusy] = React.useState(false);
+  const [msgs, setMsgs] = React.useState<Msg[]>([
+    {
+      id: uid(),
+      role: 'assistant',
+      ts: nowIso(),
+      module,
+      text: "Hi! I'm your IELTS AI Tutor. Pick a module and send your answer or question. I'll analyze and coach you to the next band.",
+    },
+  ]);
 
   // speaking: record
-  const mediaRef = React.useRef<MediaRecorder | null>(null)
-  const chunksRef = React.useRef<Blob[]>([])
-  const [recState, setRecState] = React.useState<'idle'|'recording'|'processing'>('idle')
+  const mediaRef = React.useRef<MediaRecorder | null>(null);
+  const chunksRef = React.useRef<Blob[]>([]);
+  const [recState, setRecState] = React.useState<'idle' | 'recording' | 'processing'>('idle');
 
-  async function onSend(){
-    if (!input.trim()) return
-    const userMsg: Msg = { id: uid(), role: 'user', text: input, ts: nowIso(), module }
-    setMsgs((m) => [...m, userMsg])
-    setInput('')
-    setBusy(true)
+  async function onSend() {
+    if (!input.trim()) return;
+    const userMsg: Msg = { id: uid(), role: 'user', text: input, ts: nowIso(), module };
+    setMsgs((m) => [...m, userMsg]);
+    setInput('');
+    setBusy(true);
 
     try {
       if (module === 'writing') {
         // Score & feedback for writing
-        const res = await scoreWriting({ attemptId: uid(), text: userMsg.text!, rubric: 'band_ielts_v2' })
+        const res = await scoreWriting({
+          attemptId: uid(),
+          text: userMsg.text!,
+          rubric: 'band_ielts_v2',
+        });
         if (res.ok) {
-          const fb = JSON.stringify(res.feedback, null, 2)
-          const score = JSON.stringify(res.score, null, 2)
-          setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module, text: `**Writing feedback**\n\nScore: ${score}\n\nFeedback: ${fb}` }])
+          const fb = JSON.stringify(res.feedback, null, 2);
+          const score = JSON.stringify(res.score, null, 2);
+          setMsgs((m) => [
+            ...m,
+            {
+              id: uid(),
+              role: 'assistant',
+              ts: nowIso(),
+              module,
+              text: `**Writing feedback**\n\nScore: ${score}\n\nFeedback: ${fb}`,
+            },
+          ]);
         } else {
-          setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module, text: `Couldn\'t score this attempt: ${res.error}` }])
+          setMsgs((m) => [
+            ...m,
+            {
+              id: uid(),
+              role: 'assistant',
+              ts: nowIso(),
+              module,
+              text: `Couldn\'t score this attempt: ${res.error}`,
+            },
+          ]);
         }
       } else {
         // Generic tutor endpoint (assumes /api/ai/tutor/ask exists)
-        const r = await fetch('/api/ai/tutor/ask', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ module, prompt: userMsg.text }) })
-        const j = await r.json()
-        if (j.ok) setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module, text: j.reply }])
-        else setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module, text: j.error || 'Tutor failed to respond.' }])
+        const j = await askTutor({ module, prompt: userMsg.text || '' });
+        if (j.ok)
+          setMsgs((m) => [
+            ...m,
+            { id: uid(), role: 'assistant', ts: nowIso(), module, text: j.reply },
+          ]);
+        else
+          setMsgs((m) => [
+            ...m,
+            {
+              id: uid(),
+              role: 'assistant',
+              ts: nowIso(),
+              module,
+              text: j.error || 'Tutor failed to respond.',
+            },
+          ]);
       }
     } catch (e: any) {
-      setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module, text: e?.message || 'Unexpected error' }])
-    } finally { setBusy(false) }
-  }
-
-  async function startRecording(){
-    setRecState('recording')
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-    const mr = new MediaRecorder(stream)
-    chunksRef.current = []
-    mr.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data) }
-    mr.onstop = async () => {
-      setRecState('processing')
-      const blob = new Blob(chunksRef.current, { type: 'audio/webm' })
-      // Upload to a temp URL (assume api/content/upload returns {ok,url})
-      const form = new FormData()
-      form.append('file', blob, `speaking-${Date.now()}.webm`)
-      const up = await fetch('/api/content/upload', { method: 'POST', body: form as any })
-      const upj = await up.json()
-      if (!upj.ok) { setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module: 'speaking', text: 'Upload failed.' }]); setRecState('idle'); return }
-
-      const res = await scoreSpeaking({ attemptId: uid(), audioUrl: upj.url, rubric: 'band_ielts_v2' })
-      if (res.ok) {
-        setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module: 'speaking', text: `**Speaking feedback**\n\n${JSON.stringify(res.feedback, null, 2)}` }])
-      } else {
-        setMsgs((m) => [...m, { id: uid(), role: 'assistant', ts: nowIso(), module: 'speaking', text: `Couldn\'t score speaking attempt: ${res.error}` }])
-      }
-      setRecState('idle')
+      setMsgs((m) => [
+        ...m,
+        {
+          id: uid(),
+          role: 'assistant',
+          ts: nowIso(),
+          module,
+          text: e?.message || 'Unexpected error',
+        },
+      ]);
+    } finally {
+      setBusy(false);
     }
-    mr.start()
-    mediaRef.current = mr
   }
 
-  function stopRecording(){ mediaRef.current?.stop() }
+  async function startRecording() {
+    setRecState('recording');
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const mr = new MediaRecorder(stream);
+    chunksRef.current = [];
+    mr.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data);
+    };
+    mr.onstop = async () => {
+      setRecState('processing');
+      const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+      const upj = await uploadAudio(blob);
+      if (!upj.ok) {
+        setMsgs((m) => [
+          ...m,
+          {
+            id: uid(),
+            role: 'assistant',
+            ts: nowIso(),
+            module: 'speaking',
+            text: 'Upload failed.',
+          },
+        ]);
+        setRecState('idle');
+        return;
+      }
 
-  const suggestions = module === 'writing'
-    ? ['Task 2: Some people think children should begin their formal education at a very early age. Discuss both views and give your opinion.', 'Task 1: Summarize the bar chart trends.']
-    : module === 'speaking'
-    ? ['Describe a person who inspired you.', 'Talk about a challenge you overcame.']
-    : module === 'reading'
-    ? ['Help me skim this passage and identify keywords.', 'Explain this True/False/Not Given reasoning.']
-    : ['Practice listening gap-fill strategies.', 'Shadow this sentence with me.']
+      const res = await scoreSpeaking({
+        attemptId: uid(),
+        audioUrl: upj.url,
+        rubric: 'band_ielts_v2',
+      });
+      if (res.ok) {
+        setMsgs((m) => [
+          ...m,
+          {
+            id: uid(),
+            role: 'assistant',
+            ts: nowIso(),
+            module: 'speaking',
+            text: `**Speaking feedback**\n\n${JSON.stringify(res.feedback, null, 2)}`,
+          },
+        ]);
+      } else {
+        setMsgs((m) => [
+          ...m,
+          {
+            id: uid(),
+            role: 'assistant',
+            ts: nowIso(),
+            module: 'speaking',
+            text: `Couldn\'t score speaking attempt: ${res.error}`,
+          },
+        ]);
+      }
+      setRecState('idle');
+    };
+    mr.start();
+    mediaRef.current = mr;
+  }
+
+  function stopRecording() {
+    mediaRef.current?.stop();
+  }
+
+  const suggestions =
+    module === 'writing'
+      ? [
+          'Task 2: Some people think children should begin their formal education at a very early age. Discuss both views and give your opinion.',
+          'Task 1: Summarize the bar chart trends.',
+        ]
+      : module === 'speaking'
+        ? ['Describe a person who inspired you.', 'Talk about a challenge you overcame.']
+        : module === 'reading'
+          ? [
+              'Help me skim this passage and identify keywords.',
+              'Explain this True/False/Not Given reasoning.',
+            ]
+          : ['Practice listening gap-fill strategies.', 'Shadow this sentence with me.'];
 
   return (
     <>
-      <Head><title>AI Tutor · Labs</title></Head>
+      <Head>
+        <title>AI Tutor · Labs</title>
+      </Head>
       <main className="min-h-screen bg-background">
         <section className="border-b border-border bg-background/80 backdrop-blur">
           <div className="mx-auto max-w-7xl px-4 py-6">
             <div className="flex items-center justify-between">
               <h1 className="font-slab text-h2 md:text-h1">AI Tutor (IELTS)</h1>
-              <Link href="/reports/band-analytics" className="inline-flex"><Button variant="outline" className="border-border">Band Analytics</Button></Link>
+              <Link href="/reports/band-analytics" className="inline-flex">
+                <Button variant="outline" className="border-border">
+                  Band Analytics
+                </Button>
+              </Link>
             </div>
-            <p className="mt-1 text-small text-mutedText">Practice and get instant AI feedback across modules.</p>
+            <p className="mt-1 text-small text-mutedText">
+              Practice and get instant AI feedback across modules.
+            </p>
           </div>
         </section>
 
@@ -128,44 +238,94 @@ export default function AiTutorPage(){
           <div className="rounded-2xl border border-lightBorder bg-card p-4">
             {/* Module chips */}
             <div className="mb-3 inline-flex rounded-xl border border-border p-1">
-              {(['listening','reading','writing','speaking'] as const).map((m) => (
-                <button key={m} onClick={()=>setModule(m)} className={cls('px-3 py-1 rounded-lg capitalize', module===m ? 'bg-primary text-primary-foreground' : 'hover:bg-lightBg')}>{m}</button>
+              {(['listening', 'reading', 'writing', 'speaking'] as const).map((m) => (
+                <button
+                  key={m}
+                  onClick={() => setModule(m)}
+                  className={cls(
+                    'px-3 py-1 rounded-lg capitalize',
+                    module === m ? 'bg-primary text-primary-foreground' : 'hover:bg-lightBg',
+                  )}
+                >
+                  {m}
+                </button>
               ))}
             </div>
 
             {/* Messages */}
             <div className="h-[56vh] overflow-y-auto rounded-xl border border-border bg-background p-3">
               {msgs.map((msg) => (
-                <div key={msg.id} className={cls('mb-3 max-w-[80%] rounded-2xl p-3 text-small',
-                  msg.role==='user' ? 'ml-auto bg-electricBlue/10 text-foreground' : 'mr-auto bg-lightBg text-foreground')
-                }>
+                <div
+                  key={msg.id}
+                  className={cls(
+                    'mb-3 max-w-[80%] rounded-2xl p-3 text-small',
+                    msg.role === 'user'
+                      ? 'ml-auto bg-electricBlue/10 text-foreground'
+                      : 'mr-auto bg-lightBg text-foreground',
+                  )}
+                >
                   {msg.text}
                 </div>
               ))}
               {busy && (
-                <div className="mr-auto max-w-[80%] rounded-2xl bg-lightBg p-3"><Skeleton className="h-4 w-40" /></div>
+                <div className="mr-auto max-w-[80%] rounded-2xl bg-lightBg p-3">
+                  <Skeleton className="h-4 w-40" />
+                </div>
               )}
             </div>
 
             {/* Composer */}
             <div className="mt-3 grid gap-2 md:grid-cols-[1fr_auto]">
-              <Input value={input} onChange={(e)=>setInput(e.target.value)} placeholder={module==='writing' ? 'Paste your Task 1/2 answer…' : 'Type your question or prompt…'} className="rounded-xl border border-border bg-background px-3 py-2" />
-              <Button onClick={onSend} disabled={busy || !input.trim()} className="bg-accent text-accent-foreground">Send</Button>
+              <Input
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder={
+                  module === 'writing'
+                    ? 'Paste your Task 1/2 answer…'
+                    : 'Type your question or prompt…'
+                }
+                className="rounded-xl border border-border bg-background px-3 py-2"
+              />
+              <Button
+                onClick={onSend}
+                disabled={busy || !input.trim()}
+                className="bg-accent text-accent-foreground"
+              >
+                Send
+              </Button>
             </div>
 
             {/* Speaking controls */}
-            {module==='speaking' && (
+            {module === 'speaking' && (
               <div className="mt-2 flex flex-wrap items-center gap-2">
-                {recState==='idle' && <Button onClick={startRecording} className="bg-primary text-primary-foreground">Start recording</Button>}
-                {recState==='recording' && <Button onClick={stopRecording} className="bg-sunsetRed text-lightText">Stop</Button>}
-                {recState==='processing' && <div className="text-small text-mutedText">Processing…</div>}
+                {recState === 'idle' && (
+                  <Button onClick={startRecording} className="bg-primary text-primary-foreground">
+                    Start recording
+                  </Button>
+                )}
+                {recState === 'recording' && (
+                  <Button onClick={stopRecording} className="bg-sunsetRed text-lightText">
+                    Stop
+                  </Button>
+                )}
+                {recState === 'processing' && (
+                  <div className="text-small text-mutedText">Processing…</div>
+                )}
               </div>
             )}
 
             {/* Quick suggestions */}
             <div className="mt-3 flex flex-wrap gap-2">
               {suggestions.map((s, i) => (
-                <button key={i} onClick={()=>{ setInput(s) }} className="rounded-xl border border-border bg-background px-3 py-2 text-caption hover:bg-lightBg">{s}</button>
+                <button
+                  key={i}
+                  onClick={() => {
+                    setInput(s);
+                  }}
+                  className="rounded-xl border border-border bg-background px-3 py-2 text-caption hover:bg-lightBg"
+                >
+                  {s}
+                </button>
               ))}
             </div>
           </div>
@@ -174,15 +334,25 @@ export default function AiTutorPage(){
           <aside className="rounded-2xl border border-lightBorder bg-card p-4">
             <h3 className="font-slab text-h4">My Plan</h3>
             <ul className="mt-2 space-y-2 text-small">
-              <li className="rounded-xl border border-border bg-background p-3">Writing: 3 tasks / week</li>
-              <li className="rounded-xl border border-border bg-background p-3">Speaking: 2 recordings / week</li>
-              <li className="rounded-xl border border-border bg-background p-3">Reading: 4 passages / week</li>
-              <li className="rounded-xl border border-border bg-background p-3">Listening: 4 sections / week</li>
+              <li className="rounded-xl border border-border bg-background p-3">
+                Writing: 3 tasks / week
+              </li>
+              <li className="rounded-xl border border-border bg-background p-3">
+                Speaking: 2 recordings / week
+              </li>
+              <li className="rounded-xl border border-border bg-background p-3">
+                Reading: 4 passages / week
+              </li>
+              <li className="rounded-xl border border-border bg-background p-3">
+                Listening: 4 sections / week
+              </li>
             </ul>
-            <div className="mt-3 text-small text-mutedText">Progress updates appear as you practice.</div>
+            <div className="mt-3 text-small text-mutedText">
+              Progress updates appear as you practice.
+            </div>
           </aside>
         </section>
       </main>
     </>
-  )
+  );
 }

--- a/pages/learning/drills.tsx
+++ b/pages/learning/drills.tsx
@@ -2,52 +2,7 @@ import { useEffect, useState } from 'react';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
-
-type Drill = { question: string; options: string[]; answer: number; explanation: string };
-
-async function generateDrill(): Promise<Drill | null> {
-  try {
-    const res = await fetch('/api/ai/chat', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        messages: [
-          {
-            role: 'system',
-            content:
-              'Return a JSON object with keys question, options (array), answer (index), explanation. Create a short English grammar multiple-choice drill.',
-          },
-          { role: 'user', content: 'Create a drill.' },
-        ],
-      }),
-    });
-    if (!res.body) return null;
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let text = '';
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      const chunk = decoder.decode(value, { stream: true });
-      for (const line of chunk.split('\n\n')) {
-        if (line.startsWith('data: ')) {
-          const data = line.slice(6);
-          if (data === '[DONE]') continue;
-          try {
-            const json = JSON.parse(data);
-            const delta = json?.choices?.[0]?.delta?.content;
-            if (delta) text += delta;
-          } catch {
-            /* ignore */
-          }
-        }
-      }
-    }
-    return JSON.parse(text) as Drill;
-  } catch {
-    return null;
-  }
-}
+import { generateDrill, type Drill } from '@/services/aiService';
 
 export default function DrillsPage() {
   const [drill, setDrill] = useState<Drill | null>(null);

--- a/pages/review/speaking/[id].tsx
+++ b/pages/review/speaking/[id].tsx
@@ -2,17 +2,31 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { gradeSpeaking } from '@/services/aiService';
 
-type AIFeedback = { bandOverall: number; fluency: number; lexical: number; grammar: number; pronunciation: number; notes: string[] };
+type AIFeedback = {
+  bandOverall: number;
+  fluency: number;
+  lexical: number;
+  grammar: number;
+  pronunciation: number;
+  notes: string[];
+};
 
-const Shell: React.FC<{ title: string; children: React.ReactNode; right?: React.ReactNode }> = ({ title, children, right }) => (
+const Shell: React.FC<{ title: string; children: React.ReactNode; right?: React.ReactNode }> = ({
+  title,
+  children,
+  right,
+}) => (
   <div className="min-h-screen bg-background text-foreground">
     <div className="mx-auto max-w-3xl px-4 py-6">
       <header className="mb-4 flex items-center justify-between gap-4">
         <h1 className="text-h3 font-semibold">{title}</h1>
         <div className="flex items-center gap-3">{right}</div>
       </header>
-      <div className="rounded-2xl border border-border p-4 sm:p-6 bg-background/50 shadow-sm">{children}</div>
+      <div className="rounded-2xl border border-border p-4 sm:p-6 bg-background/50 shadow-sm">
+        {children}
+      </div>
     </div>
   </div>
 );
@@ -29,10 +43,16 @@ export default function SpeakingReviewPage() {
     (async () => {
       // Try Supabase storage path from DB
       try {
-        const { data } = await supabase.from('attempts_speaking').select('recording_path').eq('id', attempt).single();
+        const { data } = await supabase
+          .from('attempts_speaking')
+          .select('recording_path')
+          .eq('id', attempt)
+          .single();
         const path = data?.recording_path as string | undefined;
         if (path) {
-          const { data: signed, error } = await supabase.storage.from('speaking-recordings').createSignedUrl(path, 60 * 60);
+          const { data: signed, error } = await supabase.storage
+            .from('speaking-recordings')
+            .createSignedUrl(path, 60 * 60);
           if (!error && signed?.signedUrl) setAudioUrl(signed.signedUrl);
         }
       } catch {}
@@ -43,25 +63,43 @@ export default function SpeakingReviewPage() {
       }
       // AI feedback
       try {
-        const res = await fetch('/api/ai/speaking/grade', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ attemptId: attempt }) });
-        if (res.ok) setAI(await res.json() as AIFeedback);
-        else setAI(heuristic());
-      } catch { setAI(heuristic()); }
+        const result = await gradeSpeaking({ attemptId: attempt });
+        setAI(result as AIFeedback);
+      } catch {
+        setAI(heuristic());
+      }
       setLoading(false);
     })();
   }, [attempt]);
 
   return (
-    <Shell title="Speaking Review" right={ai ? <div className="rounded-full border border-border px-3 py-1 text-small">Band: {ai.bandOverall.toFixed(1)}</div> : <div className="text-small">Analyzing…</div>}>
+    <Shell
+      title="Speaking Review"
+      right={
+        ai ? (
+          <div className="rounded-full border border-border px-3 py-1 text-small">
+            Band: {ai.bandOverall.toFixed(1)}
+          </div>
+        ) : (
+          <div className="text-small">Analyzing…</div>
+        )
+      }
+    >
       <div className="grid gap-6">
         <section className="rounded-xl border border-border p-4">
           <h2 className="mb-2 text-body font-semibold">Your recording</h2>
-          {audioUrl ? <audio src={audioUrl} controls className="w-full" /> : <div className="text-small text-foreground/70">No audio found.</div>}
+          {audioUrl ? (
+            <audio src={audioUrl} controls className="w-full" />
+          ) : (
+            <div className="text-small text-foreground/70">No audio found.</div>
+          )}
         </section>
 
         <section className="rounded-xl border border-border p-4">
           <h2 className="mb-2 text-body font-semibold">AI Feedback</h2>
-          {loading ? <div className="text-small text-foreground/70">Analyzing…</div> : ai ? (
+          {loading ? (
+            <div className="text-small text-foreground/70">Analyzing…</div>
+          ) : ai ? (
             <div className="grid gap-3">
               <div className="flex flex-wrap gap-2 text-small">
                 <Badge label="Fluency" val={ai.fluency} />
@@ -69,21 +107,36 @@ export default function SpeakingReviewPage() {
                 <Badge label="Grammar" val={ai.grammar} />
                 <Badge label="Pronunciation" val={ai.pronunciation} />
               </div>
-              <ul className="list-inside list-disc text-small text-foreground/80">{ai.notes.map((n, i) => <li key={i}>{n}</li>)}</ul>
+              <ul className="list-inside list-disc text-small text-foreground/80">
+                {ai.notes.map((n, i) => (
+                  <li key={i}>{n}</li>
+                ))}
+              </ul>
             </div>
-          ) : <div className="text-small text-foreground/70">AI feedback unavailable.</div>}
+          ) : (
+            <div className="text-small text-foreground/70">AI feedback unavailable.</div>
+          )}
         </section>
 
         <div className="flex items-center justify-between">
-          <Link href="/speaking" className="text-small underline underline-offset-4">Try another speaking</Link>
-          <Link href="/dashboard" className="rounded-xl border border-border px-4 py-2 hover:border-primary">Go to dashboard</Link>
+          <Link href="/speaking" className="text-small underline underline-offset-4">
+            Try another speaking
+          </Link>
+          <Link
+            href="/dashboard"
+            className="rounded-xl border border-border px-4 py-2 hover:border-primary"
+          >
+            Go to dashboard
+          </Link>
         </div>
       </div>
     </Shell>
   );
 }
 const Badge: React.FC<{ label: string; val: number }> = ({ label, val }) => (
-  <div className="rounded border border-border px-3 py-1">{label}: <strong>{val.toFixed(1)}</strong></div>
+  <div className="rounded border border-border px-3 py-1">
+    {label}: <strong>{val.toFixed(1)}</strong>
+  </div>
 );
 const heuristic = (): AIFeedback => ({
   bandOverall: 6.5,
@@ -91,6 +144,9 @@ const heuristic = (): AIFeedback => ({
   lexical: 6.0,
   grammar: 6.5,
   pronunciation: 6.5,
-  notes: ['Maintain steady pace; avoid long pauses.', 'Use more topic-specific vocabulary.', 'Vary sentence structures; watch articles.'],
+  notes: [
+    'Maintain steady pace; avoid long pauses.',
+    'Use more topic-specific vocabulary.',
+    'Vary sentence structures; watch articles.',
+  ],
 });
-  

--- a/pages/review/writing/[id].tsx
+++ b/pages/review/writing/[id].tsx
@@ -2,22 +2,37 @@ import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { gradeWriting } from '@/services/aiService';
 
 type AIFeedback = {
   bandOverall: number;
   criteria: { taskAchievement: number; coherence: number; lexical: number; grammar: number };
   notes: string[];
 };
-type Attempt = { id: string; task1: string; task2: string; wordcount1: number; wordcount2: number; submitted_at: string; ai_feedback?: AIFeedback | null };
+type Attempt = {
+  id: string;
+  task1: string;
+  task2: string;
+  wordcount1: number;
+  wordcount2: number;
+  submitted_at: string;
+  ai_feedback?: AIFeedback | null;
+};
 
-const Shell: React.FC<{ title: string; right?: React.ReactNode; children: React.ReactNode }> = ({ title, right, children }) => (
+const Shell: React.FC<{ title: string; right?: React.ReactNode; children: React.ReactNode }> = ({
+  title,
+  right,
+  children,
+}) => (
   <div className="min-h-screen bg-background text-foreground">
     <div className="mx-auto max-w-4xl px-4 py-6">
       <header className="mb-4 flex items-center justify-between gap-4">
         <h1 className="text-h3 font-semibold">{title}</h1>
         <div className="flex items-center gap-3">{right}</div>
       </header>
-      <div className="rounded-2xl border border-border p-4 sm:p-6 bg-background/50 shadow-sm">{children}</div>
+      <div className="rounded-2xl border border-border p-4 sm:p-6 bg-background/50 shadow-sm">
+        {children}
+      </div>
     </div>
   </div>
 );
@@ -34,7 +49,11 @@ export default function WritingReviewPage() {
     (async () => {
       // Load attempt
       try {
-        const { data } = await supabase.from('attempts_writing').select('*').eq('id', attempt).single();
+        const { data } = await supabase
+          .from('attempts_writing')
+          .select('*')
+          .eq('id', attempt)
+          .single();
         if (data) setAtt(data as Attempt);
       } catch {
         // local fallback
@@ -42,7 +61,15 @@ export default function WritingReviewPage() {
           const raw = localStorage.getItem(`write:attempt-res:${attempt}`);
           if (raw) {
             const parsed = JSON.parse(raw);
-            setAtt({ id: attempt, task1: parsed.task1, task2: parsed.task2, wordcount1: parsed.task1?.split(/\s+/).length ?? 0, wordcount2: parsed.task2?.split(/\s+/).length ?? 0, submitted_at: new Date().toISOString(), ai_feedback: null });
+            setAtt({
+              id: attempt,
+              task1: parsed.task1,
+              task2: parsed.task2,
+              wordcount1: parsed.task1?.split(/\s+/).length ?? 0,
+              wordcount2: parsed.task2?.split(/\s+/).length ?? 0,
+              submitted_at: new Date().toISOString(),
+              ai_feedback: null,
+            });
           }
         } catch {}
       }
@@ -54,13 +81,8 @@ export default function WritingReviewPage() {
     (async () => {
       setLoadingAI(true);
       try {
-        const res = await fetch('/api/ai/writing/grade', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ task1: att.task1, task2: att.task2 }) });
-        if (res.ok) {
-          const data = await res.json();
-          setAI(data as AIFeedback);
-        } else {
-          setAI(heuristic(att.task1, att.task2));
-        }
+        const data = await gradeWriting({ task1: att.task1, task2: att.task2 });
+        setAI(data as AIFeedback);
       } catch {
         setAI(heuristic(att.task1, att.task2));
       } finally {
@@ -69,12 +91,25 @@ export default function WritingReviewPage() {
     })();
   }, [att]);
 
-  if (!att) return <Shell title="Writing Review"><div>Loading attempt…</div></Shell>;
+  if (!att)
+    return (
+      <Shell title="Writing Review">
+        <div>Loading attempt…</div>
+      </Shell>
+    );
 
   return (
     <Shell
       title="Writing Review"
-      right={!loadingAI && ai ? <div className="rounded-full border border-border px-3 py-1 text-small">Band (AI): {ai.bandOverall.toFixed(1)}</div> : <div className="text-small">Getting AI feedback…</div>}
+      right={
+        !loadingAI && ai ? (
+          <div className="rounded-full border border-border px-3 py-1 text-small">
+            Band (AI): {ai.bandOverall.toFixed(1)}
+          </div>
+        ) : (
+          <div className="text-small">Getting AI feedback…</div>
+        )
+      }
     >
       <div className="grid gap-6">
         <section className="rounded-xl border border-border p-4">
@@ -102,7 +137,9 @@ export default function WritingReviewPage() {
                 <Badge label="Grammar & Accuracy" val={ai.criteria.grammar} />
               </div>
               <ul className="list-inside list-disc text-small text-foreground/80">
-                {ai.notes.map((n, i) => <li key={i}>{n}</li>)}
+                {ai.notes.map((n, i) => (
+                  <li key={i}>{n}</li>
+                ))}
               </ul>
             </div>
           ) : (
@@ -111,20 +148,33 @@ export default function WritingReviewPage() {
         </section>
 
         <div className="flex items-center justify-between">
-          <Link href="/writing" className="text-small underline underline-offset-4">Try another writing</Link>
-          <Link href="/dashboard" className="rounded-xl border border-border px-4 py-2 hover:border-primary">Go to dashboard</Link>
+          <Link href="/writing" className="text-small underline underline-offset-4">
+            Try another writing
+          </Link>
+          <Link
+            href="/dashboard"
+            className="rounded-xl border border-border px-4 py-2 hover:border-primary"
+          >
+            Go to dashboard
+          </Link>
         </div>
       </div>
     </Shell>
   );
 }
 const Badge: React.FC<{ label: string; val: number }> = ({ label, val }) => (
-  <div className="rounded border border-border px-3 py-1">{label}: <strong>{val.toFixed(1)}</strong></div>
+  <div className="rounded border border-border px-3 py-1">
+    {label}: <strong>{val.toFixed(1)}</strong>
+  </div>
 );
 function heuristic(t1: string, t2: string): AIFeedback {
   const wc = (s: string) => (s.trim() ? s.trim().split(/\s+/).length : 0);
-  const w1 = wc(t1), w2 = wc(t2);
-  const base = 5.5 + Math.min(1.0, Math.max(0, (w1 - 150) / 300)) + Math.min(1.5, Math.max(0, (w2 - 250) / 500));
+  const w1 = wc(t1),
+    w2 = wc(t2);
+  const base =
+    5.5 +
+    Math.min(1.0, Math.max(0, (w1 - 150) / 300)) +
+    Math.min(1.5, Math.max(0, (w2 - 250) / 500));
   const band = Math.max(4, Math.min(9, Math.round(base * 2) / 2));
   return {
     bandOverall: band,

--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -1,0 +1,120 @@
+import { ensureUsageAllowed, incrementUsage, type UsageKey } from '@/lib/usage';
+
+export type WritingGradePayload = { task1: string; task2: string };
+export type SpeakingGradePayload = { attemptId: string };
+export type TutorAskPayload = {
+  module: 'listening' | 'reading' | 'writing' | 'speaking';
+  prompt: string;
+};
+
+export type AICoachRequest = {
+  userId?: string | null;
+  context?: string;
+  goal?: string;
+};
+
+export type Drill = {
+  question: string;
+  options: string[];
+  answer: number;
+  explanation: string;
+};
+
+const DEFAULT_LIMITS: Record<UsageKey, number> = {
+  'ai.writing.grade': 3,
+  'ai.speaking.grade': 3,
+  'ai.explain': 5,
+  'mock.start': 1,
+  'mock.submit': 1,
+};
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error((await res.text()) || `Request failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function gradeWriting(payload: WritingGradePayload) {
+  await ensureUsageAllowed('ai.writing.grade', DEFAULT_LIMITS['ai.writing.grade']);
+  const result = await postJson('/api/ai/writing/grade', payload);
+  await incrementUsage('ai.writing.grade');
+  return result;
+}
+
+export async function gradeSpeaking(payload: SpeakingGradePayload) {
+  await ensureUsageAllowed('ai.speaking.grade', DEFAULT_LIMITS['ai.speaking.grade']);
+  const result = await postJson('/api/ai/speaking/grade', payload);
+  await incrementUsage('ai.speaking.grade');
+  return result;
+}
+
+export async function askTutor(
+  payload: TutorAskPayload,
+): Promise<{ ok: boolean; reply?: string; error?: string }> {
+  return postJson('/api/ai/tutor/ask', payload);
+}
+
+export async function runCoach<T>(payload: AICoachRequest): Promise<T> {
+  return postJson<T>('/api/ai/coach', payload);
+}
+
+export async function trackCoachAction(payload: { suggestionId: string; userId?: string | null }) {
+  return postJson('/api/ai/coach/action', payload);
+}
+
+export async function uploadAudio(blob: Blob): Promise<{ ok: boolean; url?: string }> {
+  const form = new FormData();
+  form.append('file', blob, `speaking-${Date.now()}.webm`);
+  const res = await fetch('/api/content/upload', { method: 'POST', body: form });
+  if (!res.ok) return { ok: false };
+  return (await res.json()) as { ok: boolean; url?: string };
+}
+
+export async function generateDrill(): Promise<Drill | null> {
+  await ensureUsageAllowed('ai.explain', DEFAULT_LIMITS['ai.explain']);
+  const res = await fetch('/api/ai/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Return a JSON object with keys question, options (array), answer (index), explanation. Create a short English grammar multiple-choice drill.',
+        },
+        { role: 'user', content: 'Create a drill.' },
+      ],
+    }),
+  });
+  if (!res.body) return null;
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value, { stream: true });
+    for (const line of chunk.split('\n\n')) {
+      if (!line.startsWith('data: ')) continue;
+      const data = line.slice(6);
+      if (data === '[DONE]') continue;
+      try {
+        const json = JSON.parse(data);
+        const delta = json?.choices?.[0]?.delta?.content;
+        if (delta) text += delta;
+      } catch {
+        // no-op
+      }
+    }
+  }
+
+  await incrementUsage('ai.explain');
+  return JSON.parse(text) as Drill;
+}


### PR DESCRIPTION
### Motivation
- Replace scattered inline AI fetch/limit logic with a single service layer so UI components only request actions and render state.
- Centralize usage/limit decisions to avoid duplication and make policy easier to maintain and audit.

### Description
- Added a new `services/aiService.ts` that centralizes AI/provider API calls (`gradeWriting`, `gradeSpeaking`, `askTutor`, `runCoach`, `trackCoachAction`, `uploadAudio`, `generateDrill`) and performs usage gating where appropriate. 
- Extended `lib/usage.ts` with a richer `UsageDecision` shape and helper APIs: `canUse`, `ensureUsageAllowed`, and `incrementUsage` to encapsulate limit checks and increments. 
- Replaced component-level raw fetch/streaming calls with service calls in `pages/review/writing/[id].tsx`, `pages/review/speaking/[id].tsx`, `pages/learning/drills.tsx`, `components/innovation/AICoachPanel.tsx`, and `pages/labs/ai-tutor.tsx` so components now call `aiService` methods and render results. 
- Kept streaming/parsing logic (for drill generation) inside the `aiService` and added default per-key limits (`DEFAULT_LIMITS`) and post-call increments when a call succeeds.

### Testing
- `npx prettier --write` was run on all changed files and succeeded. 
- Attempted lint via `npm run lint` but it could not run in this environment because the `next` binary is not available, so linting was not validated here. 
- Ran `npx tsc --noEmit` which failed due to pre-existing unrelated TypeScript errors in other files (`pages/writing/index.tsx`, `scripts/dev-next.mjs`), not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eaecf21c832f9c6241b6a1c968e7)