### PR TITLE
Refactor auth checks to shared server helpers

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,60 @@
+import type { NextApiResponse } from 'next';
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+import { resolveUserRole } from '@/lib/serverRole';
+import type { AppRole } from '@/lib/roles';
+import type { AuthErrorCode, AuthErrorResponse } from '@/types/auth';
+
+export class AuthError extends Error {
+  code: AuthErrorCode;
+
+  constructor(code: AuthErrorCode, message?: string) {
+    super(message ?? (code === 'unauthorized' ? 'Unauthorized' : 'Forbidden'));
+    this.name = 'AuthError';
+    this.code = code;
+  }
+}
+
+export function writeAuthError(
+  res: NextApiResponse,
+  code: AuthErrorCode,
+  message?: string,
+): NextApiResponse<AuthErrorResponse> {
+  return res
+    .status(code === 'unauthorized' ? 401 : 403)
+    .json({
+      ok: false,
+      error: code,
+      message: message ?? (code === 'unauthorized' ? 'Unauthorized' : 'Forbidden'),
+    });
+}
+
+export async function getAuthenticatedUser(supabase: SupabaseClient): Promise<User | null> {
+  const { data, error } = await supabase.auth.getUser();
+  if (error) {
+    throw new AuthError('unauthorized', error.message);
+  }
+  return data.user ?? null;
+}
+
+export async function requireAuth(supabase: SupabaseClient): Promise<User> {
+  const user = await getAuthenticatedUser(supabase);
+  if (!user) {
+    throw new AuthError('unauthorized');
+  }
+  return user;
+}
+
+export async function requireRole(
+  supabase: SupabaseClient,
+  allowedRoles: AppRole | AppRole[],
+): Promise<{ user: User; role: AppRole }> {
+  const user = await requireAuth(supabase);
+  const role = await resolveUserRole(user);
+  const allowList = Array.isArray(allowedRoles) ? allowedRoles : [allowedRoles];
+
+  if (!role || !allowList.includes(role)) {
+    throw new AuthError('forbidden');
+  }
+
+  return { user, role };
+}

--- a/lib/onboarding/exam-date.ts
+++ b/lib/onboarding/exam-date.ts
@@ -1,15 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
 import { ExamDateBody } from '@/lib/onboarding/schema';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -26,19 +23,15 @@ export default async function handler(
   const { timeframe, examDate } = parse.data;
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const updatePayload: Record<string, unknown> = {
@@ -52,15 +45,10 @@ export default async function handler(
     updatePayload.exam_date = null;
   }
 
-  const { error } = await supabase
-    .from('profiles')
-    .update(updatePayload)
-    .eq('id', user.id);
+  const { error } = await supabase.from('profiles').update(updatePayload).eq('id', user.id);
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/lib/onboarding/notifications.ts
+++ b/lib/onboarding/notifications.ts
@@ -1,18 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
-import {
-  NotificationsBody,
-  NotificationChannelEnum,
-} from '@/lib/onboarding/schema';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
+import { NotificationsBody, NotificationChannelEnum } from '@/lib/onboarding/schema';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -29,24 +23,18 @@ export default async function handler(
   const { channels, preferredTime } = parse.data;
 
   // Extra safety: make sure channels are unique
-  const uniqueChannels = Array.from(new Set(channels)).map((c) =>
-    NotificationChannelEnum.parse(c)
-  );
+  const uniqueChannels = Array.from(new Set(channels)).map((c) => NotificationChannelEnum.parse(c));
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const updatePayload: Record<string, unknown> = {
@@ -58,15 +46,10 @@ export default async function handler(
     updatePayload.notification_time = preferredTime;
   }
 
-  const { error } = await supabase
-    .from('profiles')
-    .update(updatePayload)
-    .eq('id', user.id);
+  const { error } = await supabase.from('profiles').update(updatePayload).eq('id', user.id);
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/lib/onboarding/study-rhythm.ts
+++ b/lib/onboarding/study-rhythm.ts
@@ -1,15 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
 import { StudyRhythmBody } from '@/lib/onboarding/schema';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -26,19 +23,15 @@ export default async function handler(
   const { rhythm } = parse.data;
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const { error } = await supabase
@@ -47,9 +40,7 @@ export default async function handler(
     .eq('id', user.id);
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/lib/onboarding/target-band.ts
+++ b/lib/onboarding/target-band.ts
@@ -1,15 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
 import { TargetBandBody } from '@/lib/onboarding/schema';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -26,19 +23,15 @@ export default async function handler(
   const { targetBand } = parse.data;
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const { error } = await supabase
@@ -47,9 +40,7 @@ export default async function handler(
     .eq('id', user.id);
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -18,7 +18,7 @@ interface Row {
   last_sign_in_at: string | null;
 }
 
-const ROLES: Profile['role'][] = ['student','teacher','admin'];
+const ROLES: Profile['role'][] = ['student', 'teacher', 'admin'];
 
 function AdminUsers() {
   const [loading, setLoading] = useState(true);
@@ -30,14 +30,17 @@ function AdminUsers() {
   const [pinBusy, setPinBusy] = useState(false);
   const [pinMsg, setPinMsg] = useState<string | null>(null);
 
+  const getAuthHeaders = async (base: HeadersInit = {}) => {
+    const { data } = await supabaseBrowser.auth.getSession();
+    const token = data.session?.access_token;
+    return token ? { ...base, Authorization: `Bearer ${token}` } : base;
+  };
+
   const fetchUsers = async () => {
     setLoading(true);
     try {
-      const { data } = await supabaseBrowser.auth.getSession();
-      const tok = data?.session?.access_token;
-      if (!tok) throw new Error('No session');
       const r = await fetch('/api/admin/users/list', {
-        headers: { Authorization: `Bearer ${tok}` },
+        headers: await getAuthHeaders(),
       });
       const j = await r.json();
       if (!r.ok) throw new Error(j?.error || 'Failed');
@@ -56,11 +59,12 @@ function AdminUsers() {
   const filtered = useMemo(() => {
     const needle = q.trim().toLowerCase();
     if (!needle) return rows;
-    return rows.filter(r =>
-      (r.full_name ?? '').toLowerCase().includes(needle) ||
-      (r.email ?? '').toLowerCase().includes(needle) ||
-      r.id.toLowerCase().includes(needle) ||
-      r.role.toLowerCase().includes(needle)
+    return rows.filter(
+      (r) =>
+        (r.full_name ?? '').toLowerCase().includes(needle) ||
+        (r.email ?? '').toLowerCase().includes(needle) ||
+        r.id.toLowerCase().includes(needle) ||
+        r.role.toLowerCase().includes(needle),
     );
   }, [rows, q]);
 
@@ -73,7 +77,7 @@ function AdminUsers() {
       });
       if (error) throw error;
       // Optimistic update
-      setRows(prev => prev.map(p => (p.id === id ? { ...p, role: newRole } : p)));
+      setRows((prev) => prev.map((p) => (p.id === id ? { ...p, role: newRole } : p)));
     } catch (e) {
       console.error(e);
       alert('Failed to change role. Ensure you are admin and RPC/RLS are set.');
@@ -98,11 +102,8 @@ function AdminUsers() {
     setPinBusy(true);
     setPinMsg(null);
     try {
-      const { data } = await supabaseBrowser.auth.getSession();
-      const tok = data?.session?.access_token;
-      if (!tok) throw new Error('No session');
       const r = await fetch('/api/admin/premium/generate-pin', {
-        headers: { Authorization: `Bearer ${tok}` },
+        headers: await getAuthHeaders(),
       });
       const j = await r.json();
       if (!r.ok || !j?.pin) throw new Error(j?.error || 'Failed');
@@ -119,18 +120,11 @@ function AdminUsers() {
     setPinBusy(true);
     setPinMsg(null);
     try {
-      const { data } = await supabaseBrowser.auth.getSession();
-      const tok = data?.session?.access_token;
-      if (!tok) {
-        setPinMsg('No session');
-        return;
-      }
       const r = await fetch(path, {
         method: 'POST',
-        headers: {
+        headers: await getAuthHeaders({
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${tok}`,
-        },
+        }),
         body: JSON.stringify(body),
       });
       const j = await r.json();
@@ -163,10 +157,12 @@ function AdminUsers() {
             <div className="flex gap-3">
               <Input
                 value={q}
-                onChange={e => setQ(e.target.value)}
+                onChange={(e) => setQ(e.target.value)}
                 placeholder="Search by name, email, id, or role"
               />
-              <Button onClick={fetchUsers} variant="secondary">Refresh</Button>
+              <Button onClick={fetchUsers} variant="secondary">
+                Refresh
+              </Button>
             </div>
           </div>
         </Card>
@@ -181,7 +177,9 @@ function AdminUsers() {
                   <th className="px-5 py-3 text-caption uppercase tracking-wider">User ID</th>
                   <th className="px-5 py-3 text-caption uppercase tracking-wider">Role</th>
                   <th className="px-5 py-3 text-caption uppercase tracking-wider">Last Login</th>
-                  <th className="px-5 py-3 text-caption uppercase tracking-wider">Account Created</th>
+                  <th className="px-5 py-3 text-caption uppercase tracking-wider">
+                    Account Created
+                  </th>
                   <th className="px-5 py-3 text-caption uppercase tracking-wider">Premium PIN</th>
                   <th className="px-5 py-3 text-caption uppercase tracking-wider">Actions</th>
                 </tr>
@@ -195,16 +193,26 @@ function AdminUsers() {
                   </tr>
                 ) : filtered.length === 0 ? (
                   <tr>
-                    <td className="px-5 py-6 text-grayish" colSpan={8}>No users found.</td>
+                    <td className="px-5 py-6 text-grayish" colSpan={8}>
+                      No users found.
+                    </td>
                   </tr>
                 ) : (
-                  filtered.map(u => (
+                  filtered.map((u) => (
                     <tr key={u.id} className="border-t border-black/5 dark:border-white/10">
                       <td className="px-5 py-4 font-medium">{u.full_name ?? '–'}</td>
                       <td className="px-5 py-4 text-small text-grayish">{u.email ?? '–'}</td>
                       <td className="px-5 py-4 text-small text-grayish">{u.id}</td>
                       <td className="px-5 py-4">
-                        <Badge variant={u.role === 'admin' ? 'warning' : u.role === 'teacher' ? 'info' : 'secondary'}>
+                        <Badge
+                          variant={
+                            u.role === 'admin'
+                              ? 'warning'
+                              : u.role === 'teacher'
+                                ? 'info'
+                                : 'secondary'
+                          }
+                        >
                           {u.role}
                         </Badge>
                       </td>
@@ -228,11 +236,13 @@ function AdminUsers() {
                           <select
                             className="px-3 py-2 rounded-ds border border-black/10 dark:border-white/10 bg-white dark:bg-dark"
                             value={u.role}
-                            onChange={e => changeRole(u.id, e.target.value as Profile['role'])}
+                            onChange={(e) => changeRole(u.id, e.target.value as Profile['role'])}
                             disabled={changingId === u.id}
                           >
-                            {ROLES.map(r => (
-                              <option key={r} value={r}>{r}</option>
+                            {ROLES.map((r) => (
+                              <option key={r} value={r}>
+                                {r}
+                              </option>
                             ))}
                           </select>
                           <Button
@@ -257,10 +267,20 @@ function AdminUsers() {
           title="Manage Premium PIN"
           footer={
             <div className="flex justify-between items-center gap-2">
-              <Button variant="ghost" onClick={clearPin} disabled={pinBusy}>Clear PIN</Button>
+              <Button variant="ghost" onClick={clearPin} disabled={pinBusy}>
+                Clear PIN
+              </Button>
               <div className="flex gap-2">
-                <Button variant="secondary" onClick={generatePin} disabled={pinBusy}>Generate</Button>
-                <Button onClick={savePin} disabled={!/^\d{4,6}$/.test(pin) || pinBusy} loading={pinBusy}>Save</Button>
+                <Button variant="secondary" onClick={generatePin} disabled={pinBusy}>
+                  Generate
+                </Button>
+                <Button
+                  onClick={savePin}
+                  disabled={!/^\d{4,6}$/.test(pin) || pinBusy}
+                  loading={pinBusy}
+                >
+                  Save
+                </Button>
               </div>
             </div>
           }
@@ -268,7 +288,7 @@ function AdminUsers() {
           <Input
             label="New PIN"
             value={pin}
-            onChange={e => setPin(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            onChange={(e) => setPin(e.target.value.replace(/\D/g, '').slice(0, 6))}
             inputMode="numeric"
             type="password"
             placeholder="4-6 digits"

--- a/pages/api/listening/admin/create.ts
+++ b/pages/api/listening/admin/create.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
-import { assertRole } from '@/lib/requireRole';
+import { AuthError, requireRole, writeAuthError } from '@/lib/auth';
+import { supabaseServer } from '@/lib/supabaseServer';
 
 type SectionInput = {
   order?: number;
@@ -59,7 +60,9 @@ function coerceNumber(value: unknown): number | null {
   return null;
 }
 
-function safeJson(value: unknown): Record<string, unknown> | unknown[] | string | number | boolean | null {
+function safeJson(
+  value: unknown,
+): Record<string, unknown> | unknown[] | string | number | boolean | null {
   if (value === null || value === undefined) return null;
   if (typeof value === 'string') {
     try {
@@ -80,14 +83,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  let userId: string | null = null;
+  const authSupabase = supabaseServer(req);
+
+  let userId: string;
   try {
-    const { user } = await assertRole(req, ['admin', 'teacher']);
+    const { user } = await requireRole(authSupabase, ['admin', 'teacher']);
     userId = user.id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'unauthorized';
-    const status = message === 'unauthorized' ? 401 : 403;
-    return res.status(status).json({ error: message });
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const body = req.body as CreateListeningBody;
@@ -134,13 +140,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         transcript: section.transcript ?? null,
       };
     })
-    .filter((row): row is {
-      test_slug: string;
-      order_no: number;
-      start_ms: number;
-      end_ms: number;
-      transcript: string | null;
-    } => row !== null)
+    .filter(
+      (
+        row,
+      ): row is {
+        test_slug: string;
+        order_no: number;
+        start_ms: number;
+        end_ms: number;
+        transcript: string | null;
+      } => row !== null,
+    )
     .sort((a, b) => a.order_no - b.order_no);
 
   if (sectionRows.length === 0) {
@@ -170,17 +180,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         explanation: question.explanation ?? null,
       };
     })
-    .filter((row): row is {
-      test_slug: string;
-      qno: number;
-      type: string;
-      prompt: string;
-      options: ReturnType<typeof safeJson>;
-      answer_key: ReturnType<typeof safeJson>;
-      match_left: ReturnType<typeof safeJson>;
-      match_right: ReturnType<typeof safeJson>;
-      explanation: string | null;
-    } => row !== null)
+    .filter(
+      (
+        row,
+      ): row is {
+        test_slug: string;
+        qno: number;
+        type: string;
+        prompt: string;
+        options: ReturnType<typeof safeJson>;
+        answer_key: ReturnType<typeof safeJson>;
+        match_left: ReturnType<typeof safeJson>;
+        match_right: ReturnType<typeof safeJson>;
+        explanation: string | null;
+      } => row !== null,
+    )
     .sort((a, b) => a.qno - b.qno);
 
   if (questionRows.length === 0) {

--- a/pages/api/onboarding/exam-date.ts
+++ b/pages/api/onboarding/exam-date.ts
@@ -1,16 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
 import { ExamDateBody } from '@/lib/onboarding/schema';
 import { updateProfileForUser } from '@/lib/profile/update';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -27,18 +24,15 @@ export default async function handler(
   const { timeframe, examDate } = parse.data;
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const { error } = await updateProfileForUser(supabase, user.id, {
@@ -47,9 +41,7 @@ export default async function handler(
   });
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/pages/api/onboarding/notifications.ts
+++ b/pages/api/onboarding/notifications.ts
@@ -1,19 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
-import {
-  NotificationsBody,
-  NotificationChannelEnum,
-} from '@/lib/onboarding/schema';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
+import { NotificationsBody, NotificationChannelEnum } from '@/lib/onboarding/schema';
 import { updateProfileForUser } from '@/lib/profile/update';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -29,23 +23,18 @@ export default async function handler(
 
   const { channels, preferredTime } = parse.data;
 
-  const uniqueChannels = Array.from(new Set(channels)).map((c) =>
-    NotificationChannelEnum.parse(c)
-  );
+  const uniqueChannels = Array.from(new Set(channels)).map((c) => NotificationChannelEnum.parse(c));
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const { error } = await updateProfileForUser(supabase, user.id, {
@@ -55,9 +44,7 @@ export default async function handler(
   });
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/pages/api/onboarding/study-rhythm.ts
+++ b/pages/api/onboarding/study-rhythm.ts
@@ -1,16 +1,13 @@
-    import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
 import { StudyRhythmBody } from '@/lib/onboarding/schema';
 import { updateProfileForUser } from '@/lib/profile/update';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -27,18 +24,15 @@ export default async function handler(
   const { rhythm } = parse.data;
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const { error } = await updateProfileForUser(supabase, user.id, {
@@ -46,9 +40,7 @@ export default async function handler(
   });
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/pages/api/onboarding/target-band.ts
+++ b/pages/api/onboarding/target-band.ts
@@ -1,16 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
+import { AuthError, requireAuth, writeAuthError } from '@/lib/auth';
+import type { AuthErrorResponse } from '@/types/auth';
 import { TargetBandBody } from '@/lib/onboarding/schema';
 import { updateProfileForUser } from '@/lib/profile/update';
 
-type Data =
-  | { ok: true }
-  | { ok: false; error: string; details?: unknown };
+type Data = { ok: true } | { ok: false; error: string; details?: unknown } | AuthErrorResponse;
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, error: 'Method not allowed' });
   }
@@ -27,18 +24,15 @@ export default async function handler(
   const { targetBand } = parse.data;
 
   const supabase = getServerClient(req, res);
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser();
 
-  if (userError) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `Auth error: ${userError.message}` });
-  }
-  if (!user) {
-    return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return writeAuthError(res, error.code, error.message);
+    }
+    throw error;
   }
 
   const { error } = await updateProfileForUser(supabase, user.id, {
@@ -46,9 +40,7 @@ export default async function handler(
   });
 
   if (error) {
-    return res
-      .status(500)
-      .json({ ok: false, error: `DB error: ${error.message}` });
+    return res.status(500).json({ ok: false, error: `DB error: ${error.message}` });
   }
 
   return res.status(200).json({ ok: true });

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -1,0 +1,7 @@
+export type AuthErrorCode = 'unauthorized' | 'forbidden';
+
+export type AuthErrorResponse = {
+  ok: false;
+  error: AuthErrorCode;
+  message: string;
+};


### PR DESCRIPTION
### Motivation
- Reduce duplication and centralize server-side authentication/authorization logic so API routes and server helpers use a single, consistent mechanism for auth checks and error responses. 
- Make role checks reusable and uniform across admin endpoints and onboarding flows to avoid scattered session parsing and ad-hoc 401/403 handling. 

### Description
- Added `lib/auth.ts` which exports `getAuthenticatedUser()`, `requireAuth()`, `requireRole()` and `AuthError` plus `writeAuthError()` for consistent 401/403 JSON responses. 
- Added `types/auth.ts` containing `AuthErrorCode` and `AuthErrorResponse` to standardize auth error payloads. 
- Replaced duplicated `supabase.auth.getUser()` + manual unauthorized handling in onboarding API routes (`pages/api/onboarding/*`) and mirrored onboarding server helpers (`lib/onboarding/*`) with `requireAuth()` and `writeAuthError()` for unified behavior. 
- Updated `pages/api/listening/admin/create.ts` to use `requireRole()` (server-side Supabase client) and to return standardized unauthorized/forbidden responses via `writeAuthError()`. 
- Simplified UI-side session checks in `pages/admin/users.tsx` by removing direct session gating and adding a small `getAuthHeaders()` helper that attaches the bearer token to requests and relies on server-side authorization. 

### Testing
- Ran `prettier --write` across modified files, which completed successfully on all changed files. 
- Attempted `eslint` on the changed files but the run failed in this environment due to missing local ESLint runtime dependency (`@eslint/eslintrc`), not due to code errors. 
- Ran `npx tsc --noEmit` which surfaced unrelated pre-existing TypeScript errors in other project files (`pages/writing/index.tsx`, `scripts/dev-next.mjs`); the types introduced in this change type-check locally within edited files but global typecheck is blocked by those unrelated errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eb10efbc832f842e79cdf0b8014c)