### PR TITLE
Refactor daily usage checks into shared helpers

### DIFF
--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -18,6 +18,62 @@ export function todayISO(d = new Date()) {
   return d.toISOString().slice(0, 10);
 }
 
+const DAILY_EXPIRY_SECONDS = 60 * 60 * 24;
+
+export type LimitExceededPayload = { error: string; limit: number };
+
+function usageKey(userId: string, key: string, dateISO = todayISO()) {
+  return `${key}:${userId}:${dateISO}`;
+}
+
+export async function getTodayUsage(userId: string, key: string, dateISO = todayISO()): Promise<number> {
+  try {
+    const { redis } = await import('@/lib/redis');
+    const raw = await redis.get(usageKey(userId, key, dateISO));
+    const value = raw ? Number.parseInt(raw, 10) : 0;
+    if (Number.isNaN(value)) {
+      await redis.del(usageKey(userId, key, dateISO));
+      return 0;
+    }
+    return value;
+  } catch {
+    return 0;
+  }
+}
+
+export async function incrementUsage(userId: string, key: string, dateISO = todayISO()): Promise<number> {
+  const { redis } = await import('@/lib/redis');
+  const scopedKey = usageKey(userId, key, dateISO);
+  const next = await redis.incr(scopedKey);
+  if (next === 1) {
+    await redis.expire(scopedKey, DAILY_EXPIRY_SECONDS);
+  }
+  return next;
+}
+
+export async function checkLimit(input: {
+  userId: string;
+  key: string;
+  limit: number;
+  increment?: boolean;
+  dateISO?: string;
+}): Promise<{ allowed: boolean; current: number; limit: number }> {
+  const { userId, key, limit, increment = false, dateISO = todayISO() } = input;
+  const current = increment
+    ? await incrementUsage(userId, key, dateISO)
+    : await getTodayUsage(userId, key, dateISO);
+
+  return {
+    allowed: increment ? current <= limit : current < limit,
+    current,
+    limit,
+  };
+}
+
+export function limitExceeded(error: string, limit: number): LimitExceededPayload {
+  return { error, limit };
+}
+
 async function authHeader(): Promise<Record<string, string>> {
   try {
     const { supabaseBrowser } = await import('@/lib/supabaseBrowser');

--- a/pages/api/coach/chat.ts
+++ b/pages/api/coach/chat.ts
@@ -5,7 +5,6 @@ import type { ChatCompletionMessageParam } from 'openai/resources/chat/completio
 import { env } from '@/lib/env';
 import { flags } from '@/lib/flags';
 import { getServerClient } from '@/lib/supabaseServer';
-import { redis } from '@/lib/redis';
 import type { SubscriptionTier } from '@/lib/navigation/types';
 import { getUserTier } from '@/lib/repositories/subscriptionRepository';
 import {
@@ -14,6 +13,7 @@ import {
   truncateForModel,
   type CoachMessage,
 } from '@/lib/ai/guardrails';
+import { checkLimit, limitExceeded } from '@/lib/usage';
 
 export const config = {
   api: {
@@ -85,20 +85,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const tierResult = await getUserTier(supabase as any, userId);
   const tier = tierResult.tier as SubscriptionTier;
   const quota = DAILY_QUOTA[tier] ?? DAILY_QUOTA.free;
-  const todayKey = new Date().toISOString().slice(0, 10);
-  const quotaKey = `coach:quota:${userId}:${todayKey}`;
-
   try {
-    const count = await redis.incr(quotaKey);
-    if (count === 1) {
-      await redis.expire(quotaKey, 60 * 60 * 24);
-    }
-    if (count > quota) {
-      res.status(429).json({ error: 'quota_exceeded', limit: quota });
+    const quotaCheck = await checkLimit({
+      userId,
+      key: 'coach:quota',
+      limit: quota,
+      increment: true,
+    });
+
+    if (!quotaCheck.allowed) {
+      res.status(429).json(limitExceeded('quota_exceeded', quota));
       return;
     }
   } catch (error) {
-    console.warn('[coach.quota] redis error', error);
+    console.warn('[coach.quota] usage check failed', error);
   }
 
   const history = truncateForModel(messages);

--- a/pages/api/coach/writing/session.ts
+++ b/pages/api/coach/writing/session.ts
@@ -5,13 +5,11 @@ import { z } from 'zod';
 import { loadWritingAttemptContext, deserializeConversationState, serializeConversationState } from '@/lib/coach/writing-context';
 import { track } from '@/lib/analytics/track';
 import { flags } from '@/lib/flags';
-import { redis } from '@/lib/redis';
 import { getServerClient } from '@/lib/supabaseServer';
+import { checkLimit, limitExceeded } from '@/lib/usage';
 import type { WritingCoachAttemptState, WritingCoachSession, WritingCoachSessionResult } from '@/types/coach';
 
 const SESSION_CREATE_LIMIT = 16;
-const SESSION_WINDOW_SECONDS = 60 * 60 * 24;
-
 type SessionRow = {
   id: string;
   user_id: string;
@@ -76,16 +74,13 @@ async function getSessionByAttempt(client: SupabaseClient<Database>, userId: str
 }
 
 async function ensureSessionQuota(userId: string) {
-  const today = new Date().toISOString().slice(0, 10);
-  const key = `coach:writing:sessions:${userId}:${today}`;
-  const count = await redis.incr(key);
-  if (count === 1) {
-    await redis.expire(key, SESSION_WINDOW_SECONDS);
-  }
-  if (count > SESSION_CREATE_LIMIT) {
-    return false;
-  }
-  return true;
+  const result = await checkLimit({
+    userId,
+    key: 'coach:writing:sessions',
+    limit: SESSION_CREATE_LIMIT,
+    increment: true,
+  });
+  return result.allowed;
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<WritingCoachSessionResult | { error: string; details?: unknown }>) {
@@ -193,7 +188,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
       const allowed = await ensureSessionQuota(userId);
       if (!allowed) {
-        res.status(429).json({ error: 'session_limit_reached' });
+        res.status(429).json(limitExceeded('session_limit_reached', SESSION_CREATE_LIMIT));
         return;
       }
 

--- a/pages/api/speaking/start-attempt.ts
+++ b/pages/api/speaking/start-attempt.ts
@@ -1,9 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseFromRequest } from '@/lib/apiAuth';
-import { redis } from '@/lib/redis';
 import { trackor } from '@/lib/analytics/trackor.server';
+import { checkLimit, incrementUsage, limitExceeded } from '@/lib/usage';
 
-const DAILY_EXPIRY_SECONDS = 60 * 60 * 24;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
@@ -31,15 +30,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const freeLimit = Number(process.env.LIMIT_FREE_SPEAKING ?? 2) || 0;
   const enforceLimit = plan === 'free' && freeLimit > 0;
   const today = new Date().toISOString().slice(0, 10);
-  const redisKey = `speaking:attempts:${user.id}:${today}`;
 
   if (enforceLimit) {
     try {
-      const currentRaw = await redis.get(redisKey);
-      const currentCount = currentRaw ? Number.parseInt(currentRaw, 10) : 0;
-      if (Number.isNaN(currentCount)) {
-        await redis.del(redisKey);
-      } else if (currentCount >= freeLimit) {
+      const limitCheck = await checkLimit({
+        userId: user.id,
+        key: 'speaking:attempts',
+        limit: freeLimit,
+      });
+      if (!limitCheck.allowed) {
         await trackor.log('speaking_attempt_blocked', {
           reason: 'daily_limit',
           user_id: user.id,
@@ -47,10 +46,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           limit: freeLimit,
           date: today,
         });
-        return res.status(429).json({ error: 'speaking_attempts_limit_reached', limit: freeLimit });
+        return res.status(429).json(limitExceeded('speaking_attempts_limit_reached', freeLimit));
       }
     } catch (error) {
-      console.warn('[speaking.start] redis check failed', error);
+      console.warn('[speaking.start] usage check failed', error);
     }
   }
 
@@ -67,11 +66,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   let dailyCount: number | undefined;
   if (enforceLimit) {
     try {
-      const updated = await redis.incr(redisKey);
-      dailyCount = updated;
-      if (updated === 1) await redis.expire(redisKey, DAILY_EXPIRY_SECONDS);
+      dailyCount = await incrementUsage(user.id, 'speaking:attempts');
     } catch (err) {
-      console.warn('[speaking.start] redis increment failed', err);
+      console.warn('[speaking.start] usage increment failed', err);
     }
   }
 


### PR DESCRIPTION
### Motivation

- Centralize per-user, per-day usage counting and limit checks to avoid duplicated Redis logic across API routes and to standardize limit-exceeded responses.
- Replace ad-hoc inline increments/checks with a small reusable API so handlers can both check and optionally increment usage in a consistent way.

### Description

- Added shared utilities in `lib/usage.ts`: `getTodayUsage()`, `incrementUsage()`, `checkLimit()` and a `limitExceeded()` payload helper to standardize 429 responses and Redis key construction/expiry.
- Replaced inline Redis quota logic in `pages/api/coach/chat.ts` with `checkLimit()` + `limitExceeded()` to enforce the daily coach quota and increment usage.
- Replaced the session-creation quota logic in `pages/api/coach/writing/session.ts` with `checkLimit()` and return standardized limit-exceeded payloads when blocked.
- Replaced speaking attempt read/increment logic in `pages/api/speaking/start-attempt.ts` with `checkLimit()` (read) and `incrementUsage()` (increment) and standardized blocked responses via `limitExceeded()`.

### Testing

- Ran a targeted lint command `npm run lint -- --file lib/usage.ts --file pages/api/coach/chat.ts --file pages/api/coach/writing/session.ts --file pages/api/speaking/start-attempt.ts`, but it failed in this environment because the `next` CLI binary is not available (`sh: 1: next: not found`).
- No other automated tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5eb21802c832fadbcddf92c0c6133)