### PR TITLE
Establish shared typed contracts for auth, subscription, and usage domains

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,9 @@
 import type { NextApiResponse } from 'next';
-import type { SupabaseClient, User } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { resolveUserRole } from '@/lib/serverRole';
 import type { AppRole } from '@/lib/roles';
 import type { AuthErrorCode, AuthErrorResponse } from '@/types/auth';
+import type { User } from '@/types/user';
 
 export class AuthError extends Error {
   code: AuthErrorCode;

--- a/lib/hooks/useQuotaGate.ts
+++ b/lib/hooks/useQuotaGate.ts
@@ -1,15 +1,8 @@
 // hooks/useQuotaGuard.ts
 import { useRouter } from 'next/router';
 import { useCallback } from 'react';
-import { toast } from '@/components/design-system/Toaster'; // your DS toaster
-
-type GXErrorPayload = {
-  error?: {
-    code: string;
-    message: string;
-    meta?: Record<string, any>;
-  };
-};
+import { toast } from '@/components/design-system/Toaster';
+import type { GXErrorPayload } from '@/types/usage';
 
 export function useQuotaGuard() {
   const router = useRouter();
@@ -17,47 +10,44 @@ export function useQuotaGuard() {
   const handleResponse = useCallback(async (res: Response, context?: { module?: string }) => {
     if (res.ok) return res;
 
-    // Try to parse GX error
     let payload: GXErrorPayload | null = null;
     try {
-      payload = await res.json();
-    } catch { /* ignore */ }
+      payload = (await res.json()) as GXErrorPayload;
+    } catch {
+      payload = null;
+    }
 
     const code = payload?.error?.code || res.headers.get('X-GX-Error-Code') || '';
     const message = payload?.error?.message || 'Action unavailable.';
-    const meta = payload?.error?.meta || {};
+    const meta = payload?.error?.meta ?? {};
 
     if (res.status === 402 && code === 'QUOTA_EXCEEDED') {
       const module = String(meta.module || context?.module || 'writing');
       const remaining = Number(meta.remaining ?? 0);
-      const resetAt = meta.resetAt ? new Date(meta.resetAt) : null;
+      const resetAtValue = typeof meta.resetAt === 'string' ? meta.resetAt : null;
+      const resetAt = resetAtValue ? new Date(resetAtValue) : null;
 
-      toast.error(
-        `No ${module} attempts left on your plan.`,
-        {
-          description: resetAt
-            ? `Quota resets ${resetAt.toLocaleDateString()} ${resetAt.toLocaleTimeString()}.`
-            : `Upgrade to continue immediately.`,
-          duration: 5000
-        }
-      );
+      toast.error(`No ${module} attempts left on your plan.`, {
+        description: resetAt
+          ? `Quota resets ${resetAt.toLocaleDateString()} ${resetAt.toLocaleTimeString()}.`
+          : 'Upgrade to continue immediately.',
+        duration: 5000,
+      });
 
       const params = new URLSearchParams({
         reason: 'quota_exhausted',
         module,
         remaining: String(remaining),
         ...(resetAt ? { resetAt: resetAt.toISOString() } : {}),
-        from: router.asPath
+        from: router.asPath,
       }).toString();
 
-      // Give the toast a moment, then redirect
       setTimeout(() => {
         router.push(`/pricing?${params}`);
       }, 300);
-      throw new Error(message); // stop caller flow
+      throw new Error(message);
     }
 
-    // Generic error
     toast.error('Request failed', { description: message });
     throw new Error(message);
   }, [router]);

--- a/lib/repositories/subscriptionRepository.ts
+++ b/lib/repositories/subscriptionRepository.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { SubscriptionTier } from '@/lib/navigation/types';
 
-export type RepoClient = SupabaseClient<any, 'public', any>;
+export type RepoClient = SupabaseClient;
 export type PlanId = 'free' | 'starter' | 'booster' | 'master';
 
 type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due' | 'unpaid' | null;

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -1,26 +1,6 @@
-import type { PlanId } from '@/types/pricing';
+import type { SubscriptionPlan, SubscriptionPlanKey, SubscriptionStatus, PlanDisplay, SubscriptionSummary, StripeSubscriptionLike } from '@/types/subscription';
 
-export type SubscriptionPlan = PlanId;
-
-export type SubscriptionStatus =
-  | 'active'
-  | 'trialing'
-  | 'canceled'
-  | 'incomplete'
-  | 'past_due'
-  | 'unpaid'
-  | 'paused'
-  | 'inactive'
-  | 'expired'
-  | 'none';
-
-export type SubscriptionPlanKey = 'free' | 'starter' | 'booster' | 'master';
-
-export type PlanDisplay = {
-  name: string;
-  features: string[];
-  price?: string;
-};
+export type { SubscriptionPlan, SubscriptionPlanKey, SubscriptionStatus, PlanDisplay, SubscriptionSummary };
 
 export const PLAN_DISPLAY: Record<SubscriptionPlanKey, PlanDisplay> = {
   free: {
@@ -111,4 +91,56 @@ export function formatDateLabel(value?: string | null): string | null {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return null;
   return date.toLocaleDateString();
+}
+
+export function getActiveSubscription<T extends { status?: string | null }>(subscriptions: T[]): T | null {
+  if (!subscriptions.length) return null;
+  return (
+    subscriptions.find((sub) => {
+      const status = normalizeStatus(sub.status);
+      return status === 'active' || status === 'trialing' || status === 'past_due';
+    }) ?? null
+  );
+}
+
+export function summarizeStripeSubscription(
+  subscription: StripeSubscriptionLike,
+  fallbackPlan: SubscriptionPlan = 'free',
+): Readonly<{
+  plan: SubscriptionPlanKey;
+  status: SubscriptionStatus;
+  renewsAt?: string;
+  trialEndsAt?: string;
+}> {
+  if (!subscription) {
+    return {
+      plan: normalizePlan(fallbackPlan),
+      status: 'inactive',
+    };
+  }
+
+  const priceId = subscription.items?.data?.[0]?.price?.id;
+  const mappedPlan =
+    typeof priceId === 'string' && priceId.includes('starter')
+      ? 'starter'
+      : typeof priceId === 'string' && priceId.includes('booster')
+      ? 'booster'
+      : typeof priceId === 'string' && priceId.includes('master')
+      ? 'master'
+      : normalizePlan(fallbackPlan);
+
+  const status = normalizeStatus(subscription.status);
+  const renewsAt = subscription.current_period_end
+    ? new Date(subscription.current_period_end * 1000).toISOString()
+    : undefined;
+  const trialEndsAt = subscription.trial_end
+    ? new Date(subscription.trial_end * 1000).toISOString()
+    : undefined;
+
+  return {
+    plan: mappedPlan,
+    status,
+    renewsAt,
+    trialEndsAt,
+  };
 }

--- a/lib/subscriptions.ts
+++ b/lib/subscriptions.ts
@@ -1,29 +1,16 @@
-// lib/subscriptions.ts
 import type Stripe from 'stripe';
 import { summarizeStripeSubscription } from '@/lib/subscription';
+import type {
+  BillingInvoice as Invoice,
+  SubscriptionPlan,
+  SubscriptionSummary,
+} from '@/types/subscription';
 
-export type SubscriptionPlan = 'starter' | 'booster' | 'master' | 'free';
-export type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
-
-export type Invoice = Readonly<{
-  id: string;
-  amount: number;
-  currency: string;
-  createdAt: string;
-  hostedInvoiceUrl?: string;
-  status: 'paid' | 'open' | 'void' | 'uncollectible';
-}>;
-
-export type SubscriptionSummary = Readonly<{
-  plan: SubscriptionPlan;
-  status: SubscriptionStatus;
-  renewsAt?: string;
-  trialEndsAt?: string;
-}>;
+export type { Invoice, SubscriptionPlan, SubscriptionSummary };
 
 export function summarizeFromStripe(
   sub: Stripe.Subscription | null | undefined,
-  fallbackPlan: SubscriptionPlan = 'free'
+  fallbackPlan: SubscriptionPlan = 'free',
 ): SubscriptionSummary {
   const summary = summarizeStripeSubscription(sub, fallbackPlan);
   return {

--- a/lib/usage.ts
+++ b/lib/usage.ts
@@ -1,37 +1,18 @@
 // lib/usage.ts
 import { env } from './env';
+import type {
+  IncrementReq,
+  IncrementRes,
+  LimitExceededPayload,
+  UsageDecision,
+  UsageKey,
+} from '@/types/usage';
 
-export type UsageKey =
-  | 'ai.writing.grade'
-  | 'ai.speaking.grade'
-  | 'ai.explain'
-  | 'mock.start'
-  | 'mock.submit';
-
-export type IncrementReq = { key: UsageKey; step?: number; dateISO?: string };
-
-export type IncrementRes =
-  | { ok: true; key: UsageKey; dateISO: string; count: number }
-  | { ok: false; error: string };
-
-export type UsageDecision = {
-  allowed: boolean;
-  count: number;
-  limit: number;
-  remaining: number;
-  reason?: 'limit_reached' | 'counter_unavailable';
-};
-
-export type LimitExceededPayload = { error: string; limit: number };
+export type { IncrementReq, IncrementRes, LimitExceededPayload, UsageDecision, UsageKey };
 
 export function todayISO(d = new Date()) {
-  // YYYY-MM-DD in UTC
   return d.toISOString().slice(0, 10);
 }
-
-/* --------------------------------------------------------
-   Auth Helper
--------------------------------------------------------- */
 
 async function authHeader(): Promise<Record<string, string>> {
   try {
@@ -44,24 +25,9 @@ async function authHeader(): Promise<Record<string, string>> {
   }
 }
 
-/* --------------------------------------------------------
-   API Base URL
--------------------------------------------------------- */
+const base = typeof window === 'undefined' ? env.SITE_URL || env.NEXT_PUBLIC_BASE_URL || '' : '';
 
-const base =
-  typeof window === 'undefined'
-    ? env.SITE_URL || env.NEXT_PUBLIC_BASE_URL || ''
-    : '';
-
-/* --------------------------------------------------------
-   Core API Call
--------------------------------------------------------- */
-
-export async function increment(
-  key: UsageKey,
-  step = 1,
-  dateISO = todayISO(),
-): Promise<IncrementRes> {
+export async function increment(key: UsageKey, step = 1, dateISO = todayISO()): Promise<IncrementRes> {
   try {
     const headers = {
       'Content-Type': 'application/json',
@@ -74,33 +40,19 @@ export async function increment(
       body: JSON.stringify({ key, step, dateISO } satisfies IncrementReq),
     });
 
-    const j = (await r.json()) as IncrementRes;
-    return j;
-  } catch (e: any) {
-    return { ok: false, error: e?.message || 'network_error' };
+    return (await r.json()) as IncrementRes;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'network_error';
+    return { ok: false, error: message };
   }
 }
 
-/* --------------------------------------------------------
-   Read-only count (step=0)
--------------------------------------------------------- */
-
-export async function getCount(
-  key: UsageKey,
-  dateISO = todayISO(),
-): Promise<number> {
+export async function getCount(key: UsageKey, dateISO = todayISO()): Promise<number> {
   const res = await increment(key, 0, dateISO);
   return res.ok ? res.count : 0;
 }
 
-/* --------------------------------------------------------
-   Guard: can I use?
--------------------------------------------------------- */
-
-export async function canUse(
-  key: UsageKey,
-  limit: number,
-): Promise<UsageDecision> {
+export async function canUse(key: UsageKey, limit: number): Promise<UsageDecision> {
   const res = await increment(key, 0);
 
   const count = res.ok ? res.count : 0;
@@ -127,35 +79,17 @@ export async function canUse(
   };
 }
 
-/* --------------------------------------------------------
-   Strict guard (throws)
--------------------------------------------------------- */
-
-export async function ensureUsageAllowed(
-  key: UsageKey,
-  limit: number,
-): Promise<UsageDecision> {
+export async function ensureUsageAllowed(key: UsageKey, limit: number): Promise<UsageDecision> {
   const decision = await canUse(key, limit);
 
   if (!decision.allowed) {
-    throw new Error(
-      decision.reason === 'limit_reached'
-        ? 'usage_limit_reached'
-        : 'usage_unavailable',
-    );
+    throw new Error(decision.reason === 'limit_reached' ? 'usage_limit_reached' : 'usage_unavailable');
   }
 
   return decision;
 }
 
-/* --------------------------------------------------------
-   Increment wrapper (public)
--------------------------------------------------------- */
-
-export async function incrementUsage(
-  key: UsageKey,
-  step = 1,
-): Promise<number> {
+export async function incrementUsage(key: UsageKey, step = 1): Promise<number> {
   const res = await increment(key, step);
 
   if (!res.ok) {
@@ -165,13 +99,11 @@ export async function incrementUsage(
   return res.count;
 }
 
-/* --------------------------------------------------------
-   Error helper
--------------------------------------------------------- */
-
-export function limitExceeded(
-  error: string,
-  limit: number,
-): LimitExceededPayload {
+export function limitExceeded(error: string, limit: number): LimitExceededPayload {
   return { error, limit };
+}
+
+export async function checkLimit(key: UsageKey, limit: number): Promise<boolean> {
+  const decision = await canUse(key, limit);
+  return decision.allowed;
 }

--- a/pages/api/billing/summary.ts
+++ b/pages/api/billing/summary.ts
@@ -2,29 +2,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { stripe } from '@/lib/stripe';
 import { summarizeFromStripe, mapStripeInvoice, type SubscriptionSummary } from '@/lib/subscriptions';
+import type { BillingSummaryResponse, DueRow } from '@/types/subscription';
 import { getActiveSubscription } from '@/lib/subscription';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-
-type DueRow = Readonly<{
-  id: string;
-  amount_cents: number;
-  currency: string;
-  created_at: string;
-  status: 'due' | 'collected' | 'canceled';
-  plan_key: 'starter' | 'booster' | 'master';
-  cycle: 'monthly' | 'annual';
-}>;
-
-type BillingSummaryResponse =
-  | {
-      ok: true;
-      summary: SubscriptionSummary;
-      invoices: ReturnType<typeof mapStripeInvoice>[];
-      dues: DueRow[];
-      customerId?: string;
-      needsStripeSetup?: boolean;
-    }
-  | { ok: false; error: string };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<BillingSummaryResponse>) {
   if (req.method !== 'GET') return res.status(405).json({ ok: false, error: 'method_not_allowed' });

--- a/pages/api/subscriptions/portal.ts
+++ b/pages/api/subscriptions/portal.ts
@@ -1,33 +1,11 @@
 // pages/api/subscriptions/portal.ts
-import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiHandler, NextApiRequest } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { env } from '@/lib/env';
 import { getSubscriptionSummary } from '@/lib/repositories/subscriptionRepository';
 import { getActiveSubscription, summarizeStripeSubscription } from '@/lib/subscription';
 import { mapStripeInvoice } from '@/lib/subscriptions';
-
-type Invoice = Readonly<{
-  id: string;
-  amount: number;
-  currency: string;
-  createdAt: string;
-  hostedInvoiceUrl?: string;
-  status: 'paid' | 'open' | 'void' | 'uncollectible';
-}>;
-
-type SubscriptionSummary = Readonly<{
-  plan: 'starter' | 'booster' | 'master' | 'free';
-  status: 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
-  renewsAt?: string;
-  trialEndsAt?: string;
-}>;
-
-type SummaryResponse = Readonly<{
-  subscription: SubscriptionSummary;
-  invoices: Invoice[];
-}>;
-
-type ResBody = SummaryResponse | Readonly<{ ok: false; error: string }>;
+import type { BillingInvoice as Invoice, SubscriptionApiResponse, PortalSummaryResponse, SubscriptionSummary } from '@/types/subscription';
 
 const getOrigin = (req: NextApiRequest) => {
   const proto = (req.headers['x-forwarded-proto'] as string) || 'https';
@@ -35,13 +13,13 @@ const getOrigin = (req: NextApiRequest) => {
   return `${proto}://${host}`;
 };
 
-const handler: NextApiHandler<ResBody> = async (req, res) => {
+const handler: NextApiHandler<SubscriptionApiResponse> = async (req, res) => {
   const supabase = createSupabaseServerClient({ req });
   const { data: userResp } = await supabase.auth.getUser();
   const userId = userResp.user?.id;
   if (!userId) return res.status(401).json({ ok: false, error: 'Unauthorized' });
 
-  const dbSummary = await getSubscriptionSummary(supabase as any, userId);
+  const dbSummary = await getSubscriptionSummary(supabase, userId);
   const customerId = dbSummary.customerId;
 
   // If the request is a form POST (no JSON) we assume "Open customer portal" and redirect.
@@ -73,7 +51,7 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
 
   // JSON summary mode (used by pages/account/billing.tsx)
   if (!stripe || !customerId) {
-    const fallback: SummaryResponse = {
+    const fallback: PortalSummaryResponse = {
       subscription: {
         plan: dbSummary.plan,
         status: dbSummary.status,

--- a/types/subscription.ts
+++ b/types/subscription.ts
@@ -1,0 +1,81 @@
+import type Stripe from 'stripe';
+import type { PlanId } from '@/types/pricing';
+
+export type SubscriptionPlan = PlanId;
+
+export type SubscriptionPlanKey = 'free' | 'starter' | 'booster' | 'master';
+
+export type SubscriptionStatus =
+  | 'active'
+  | 'trialing'
+  | 'canceled'
+  | 'incomplete'
+  | 'past_due'
+  | 'unpaid'
+  | 'paused'
+  | 'inactive'
+  | 'expired'
+  | 'none';
+
+export type StripeSubscriptionStatus = Exclude<SubscriptionStatus, 'inactive' | 'expired' | 'none'>;
+
+export type PlanDisplay = Readonly<{
+  name: string;
+  features: string[];
+  price?: string;
+}>;
+
+export type Plan = Readonly<{
+  id: SubscriptionPlanKey;
+  status: SubscriptionStatus;
+  renewsAt?: string;
+  trialEndsAt?: string;
+}>;
+
+export type SubscriptionSummary = Readonly<{
+  plan: SubscriptionPlanKey;
+  status: StripeSubscriptionStatus;
+  renewsAt?: string;
+  trialEndsAt?: string;
+}>;
+
+export type BillingInvoiceStatus = 'paid' | 'open' | 'void' | 'uncollectible';
+
+export type BillingInvoice = Readonly<{
+  id: string;
+  amount: number;
+  currency: string;
+  createdAt: string;
+  hostedInvoiceUrl?: string;
+  status: BillingInvoiceStatus;
+}>;
+
+export type DueRow = Readonly<{
+  id: string;
+  amount_cents: number;
+  currency: string;
+  created_at: string;
+  status: 'due' | 'collected' | 'canceled';
+  plan_key: Exclude<SubscriptionPlanKey, 'free'>;
+  cycle: 'monthly' | 'annual';
+}>;
+
+export type BillingSummaryResponse =
+  | {
+      ok: true;
+      summary: SubscriptionSummary;
+      invoices: BillingInvoice[];
+      dues: DueRow[];
+      customerId?: string;
+      needsStripeSetup?: boolean;
+    }
+  | { ok: false; error: string };
+
+export type PortalSummaryResponse = Readonly<{
+  subscription: SubscriptionSummary;
+  invoices: BillingInvoice[];
+}>;
+
+export type SubscriptionApiResponse = PortalSummaryResponse | Readonly<{ ok: false; error: string }>;
+
+export type StripeSubscriptionLike = Stripe.Subscription | null | undefined;

--- a/types/usage.ts
+++ b/types/usage.ts
@@ -1,0 +1,45 @@
+export type UsageKey =
+  | 'ai.writing.grade'
+  | 'ai.speaking.grade'
+  | 'ai.explain'
+  | 'mock.start'
+  | 'mock.submit';
+
+export type UsageRecord = Readonly<{
+  key: UsageKey;
+  count: number;
+  dateISO: string;
+}>;
+
+export type UsageLimit = Readonly<{
+  key: UsageKey;
+  limit: number;
+}>;
+
+export type IncrementReq = Readonly<{ key: UsageKey; step?: number; dateISO?: string }>;
+
+export type IncrementSuccessResponse = Readonly<{ ok: true; key: UsageKey; dateISO: string; count: number }>;
+
+export type IncrementErrorResponse = Readonly<{ ok: false; error: string }>;
+
+export type IncrementRes = IncrementSuccessResponse | IncrementErrorResponse;
+
+export type UsageDecisionReason = 'limit_reached' | 'counter_unavailable';
+
+export type UsageDecision = Readonly<{
+  allowed: boolean;
+  count: number;
+  limit: number;
+  remaining: number;
+  reason?: UsageDecisionReason;
+}>;
+
+export type LimitExceededPayload = Readonly<{ error: string; limit: number }>;
+
+export type GXErrorPayload = Readonly<{
+  error?: {
+    code: string;
+    message: string;
+    meta?: Record<string, unknown>;
+  };
+}>;

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,0 +1,12 @@
+import type { User as SupabaseUser } from '@supabase/supabase-js';
+
+export type UserId = string;
+
+export type UserRole = 'admin' | 'teacher' | 'student' | 'guest';
+
+export type User = SupabaseUser;
+
+export type AuthenticatedUser = Readonly<{
+  user: User;
+  role?: UserRole | null;
+}>;


### PR DESCRIPTION
### Motivation
- Consolidate duplicated inline type literals across auth, subscription/billing and usage/quota code paths into shared domain contracts so handlers, hooks and services consume canonical types.
- Remove `any`/implicit typing from business-critical auth/subscription/usage modules for Phase 0 scope to improve type-safety and maintainability.

### Description
- Added shared contract files `types/user.ts`, `types/subscription.ts`, and `types/usage.ts` that define `User`, `Subscription`/billing types, and usage/quota request/response/decision types respectively.
- Refactored `lib/auth.ts` to consume `User` from `types/user.ts` and updated auth helpers to use the shared type.
- Refactored `lib/subscription.ts` / `lib/subscriptions.ts` and `lib/repositories/subscriptionRepository.ts` to import and expose subscription/billing types, and moved duplicated billing API inline types into `types/subscription.ts` used by `pages/api/billing/summary.ts` and `pages/api/subscriptions/portal.ts`.
- Refactored `lib/usage.ts` and `lib/hooks/useQuotaGate.ts` to import usage contracts from `types/usage.ts`, remove `any` in error handling, and expose typed quota helper functions used across services and components.

### Testing
- Ran a focused search to ensure no `any` remains in the touched auth/subscription/usage critical files using `rg -n "\bany\b"` over the modified paths, which showed no matches in the Phase 0 scope files.
- Ran `npx tsc --noEmit` locally which surfaced unrelated existing parse errors in `pages/writing/index.tsx` and `scripts/dev-next.mjs` so a full type-check of the repo could not complete in this environment.
- Ran `eslint` on the changed files but the lint run failed in this environment due to missing runtime resolution for `@eslint/eslintrc`, which is an environment/tooling issue unrelated to these changes.
- All modified files were committed with the message `Establish shared typed contracts for auth subscription and usage` and are ready for review; the key business paths in auth/subscription/usage were converted to use the new shared types.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a618c7184883339a5264e83713ca05)