### PR TITLE
Phase 1: auth hardening — middleware role gates, session expiry, and re-auth for sensitive APIs

### DIFF
--- a/docs/auth-security-test-checklist.md
+++ b/docs/auth-security-test-checklist.md
@@ -1,0 +1,27 @@
+# Authentication Security Test Checklist (Phase 1.6.1)
+
+## Scope
+
+- Middleware protected routes
+- Role-based route restrictions
+- API auth guards
+- Session expiry behavior
+- Sensitive action re-auth checks
+
+## Manual test matrix
+
+1. Access `/dashboard` without login → redirected to `/login`.
+2. Access `/profile` without login → redirected to `/login`.
+3. Access `/admin` as non-admin role → redirected to `/403`.
+4. Access `/teacher` as non-teacher/non-admin role → redirected to `/403`.
+5. Call protected API without token (`/api/account/delete`) → `401` JSON auth error.
+6. Call billing portal endpoint without recent auth (`/api/billing/create-portal-session`) → `403 reauthentication_required`.
+7. Call subscription portal in open-portal mode without recent auth (`/api/subscriptions/portal`) → `403`.
+8. Expired access token cookie on protected route → redirected to `/login?reason=session_expired`.
+9. Attempt role escalation via frontend route change (`/admin/*` with student token) → middleware blocks.
+
+## Result summary
+
+- Core protections implemented in middleware and API utilities.
+- Sensitive operations now include recent-auth checks.
+- Logout events are now audit logged.

--- a/docs/middleware-gap-report.md
+++ b/docs/middleware-gap-report.md
@@ -1,0 +1,85 @@
+# Middleware Gap Report (Phase 1.1.1)
+
+This report audits protected route coverage against `middleware.ts`.
+
+## /dashboard
+
+- Route count: **24**
+- Middleware prefix protection: **Covered** (`/dashboard` in `PROTECTED_PREFIXES`).
+- Sample routes:
+  - `/dashboard/activity`
+  - `/dashboard/ai-reports`
+  - `/dashboard/billing`
+  - `/dashboard/components/shared/FeaturePreviewWrapper`
+  - `/dashboard/components/shared/NotificationCenter`
+  - `/dashboard/components/shared/UpgradeModal`
+  - `/dashboard/components/tiers/FreeView`
+  - `/dashboard/components/tiers/OwlView`
+  - `/dashboard/components/tiers/RocketView`
+  - `/dashboard/components/tiers/SeedlingView`
+  - `... +14 more`
+
+## /profile
+
+- Route count: **10**
+- Middleware prefix protection: **Covered** (`/profile` in `PROTECTED_PREFIXES`).
+- Sample routes:
+  - `/profile/account/activity`
+  - `/profile/account/billing`
+  - `/profile/account`
+  - `/profile/account/redeem`
+  - `/profile/account/referrals`
+  - `/profile/billing`
+  - `/profile`
+  - `/profile/setup`
+  - `/profile/streak`
+  - `/profile/subscription`
+
+## /settings
+
+- Route count: **8**
+- Middleware prefix protection: **Covered** (`/settings` in `PROTECTED_PREFIXES`).
+- Sample routes:
+  - `/settings/accessibility`
+  - `/settings/account`
+  - `/settings/billing`
+  - `/settings`
+  - `/settings/language`
+  - `/settings/notifications`
+  - `/settings/profile`
+  - `/settings/security`
+
+## /admin
+
+- Route count: **24**
+- Middleware prefix protection: **Covered** (`/admin` in `PROTECTED_PREFIXES`).
+- Sample routes:
+  - `/admin/content/reading`
+  - `/admin/imp-as`
+  - `/admin`
+  - `/admin/listening`
+  - `/admin/listening/articles`
+  - `/admin/listening/media`
+  - `/admin/partners`
+  - `/admin/premium/pin`
+  - `/admin/premium/promo-codes`
+  - `/admin/premium/promo-usage`
+  - `... +14 more`
+
+## /teacher
+
+- Route count: **6**
+- Middleware prefix protection: **Covered** (`/teacher` in `PROTECTED_PREFIXES`).
+- Sample routes:
+  - `/teacher/Welcome`
+  - `/teacher/cohorts/<id>`
+  - `/teacher`
+  - `/teacher/onboarding`
+  - `/teacher/pending`
+  - `/teacher/register`
+
+## Findings
+
+- All required phase-1 route groups are protected by middleware prefix matching.
+- Added server-side role checks in middleware for `/admin/*` and `/teacher/*` with redirect to `/403`.
+- Added expired-session redirect handling to `/login?reason=session_expired` to prevent stale-cookie access.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,11 @@
 import type { NextApiResponse } from 'next';
+import type { NextApiRequest } from 'next';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { resolveUserRole } from '@/lib/serverRole';
 import type { AppRole } from '@/lib/roles';
 import type { AuthErrorCode, AuthErrorResponse } from '@/types/auth';
 import type { User } from '@/types/user';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
 
 export class AuthError extends Error {
   code: AuthErrorCode;
@@ -20,13 +22,11 @@ export function writeAuthError(
   code: AuthErrorCode,
   message?: string,
 ): NextApiResponse<AuthErrorResponse> {
-  return res
-    .status(code === 'unauthorized' ? 401 : 403)
-    .json({
-      ok: false,
-      error: code,
-      message: message ?? (code === 'unauthorized' ? 'Unauthorized' : 'Forbidden'),
-    });
+  return res.status(code === 'unauthorized' ? 401 : 403).json({
+    ok: false,
+    error: code,
+    message: message ?? (code === 'unauthorized' ? 'Unauthorized' : 'Forbidden'),
+  });
 }
 
 export async function getAuthenticatedUser(supabase: SupabaseClient): Promise<User | null> {
@@ -58,4 +58,18 @@ export async function requireRole(
   }
 
   return { user, role };
+}
+
+export async function requireApiAuth(req: NextApiRequest, res: NextApiResponse): Promise<User> {
+  const supabase = createSupabaseServerClient({ req, res });
+  return requireAuth(supabase);
+}
+
+export async function requireApiRole(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  allowedRoles: AppRole | AppRole[],
+): Promise<{ user: User; role: AppRole }> {
+  const supabase = createSupabaseServerClient({ req, res });
+  return requireRole(supabase, allowedRoles);
 }

--- a/lib/auth/cookies.ts
+++ b/lib/auth/cookies.ts
@@ -22,7 +22,7 @@ function append(res: NextApiResponse, cookie: string) {
 }
 
 export function setAuthCookies(res: NextApiResponse, payload: AuthCookiePayload) {
-  const common = { httpOnly: true, secure: isProd, sameSite: 'lax' as const, path: '/' };
+  const common = { httpOnly: true, secure: isProd, sameSite: 'strict' as const, path: '/' };
 
   append(
     res,

--- a/lib/auth/recentAuth.ts
+++ b/lib/auth/recentAuth.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest } from 'next';
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  const payload = parts[1];
+  if (!payload) return null;
+
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+    const text = Buffer.from(padded, 'base64').toString('utf8');
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function pickAuthCookie(req: NextApiRequest): string | null {
+  const direct = req.cookies['sb-access-token'];
+  if (typeof direct === 'string' && direct.length > 0) return direct;
+
+  const dynamicKey = Object.keys(req.cookies).find((name) =>
+    /^sb-[a-z0-9-]+-auth-token(?:\.\d+)?$/i.test(name),
+  );
+
+  if (!dynamicKey) return null;
+  const raw = req.cookies[dynamicKey];
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw)) as
+      | { access_token?: string; currentSession?: { access_token?: string } }
+      | [{ access_token?: string }?, { access_token?: string }?]
+      | null;
+
+    if (Array.isArray(parsed)) {
+      return parsed[0]?.access_token ?? parsed[1]?.access_token ?? null;
+    }
+
+    return parsed?.access_token ?? parsed?.currentSession?.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isRecentAuthentication(req: NextApiRequest, maxAgeSeconds = 900): boolean {
+  const token = pickAuthCookie(req);
+  if (!token) return false;
+
+  const payload = decodeJwtPayload(token);
+  if (!payload) return false;
+
+  const now = Math.floor(Date.now() / 1000);
+  const authTime =
+    typeof payload.auth_time === 'number'
+      ? payload.auth_time
+      : typeof payload.iat === 'number'
+        ? payload.iat
+        : null;
+
+  if (!authTime) return false;
+  return now - authTime <= maxAgeSeconds;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -45,6 +45,73 @@ function hasAuthCookie(req: NextRequest) {
     .some((cookie) => /^sb-[a-z0-9-]+-auth-token(?:\.\d+)?$/i.test(cookie.name));
 }
 
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  const payload = parts[1];
+  if (!payload) return null;
+
+  try {
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+    const text = atob(padded);
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function getAccessTokenFromCookie(req: NextRequest): string | null {
+  const direct = req.cookies.get('sb-access-token')?.value;
+  if (direct) return direct;
+
+  const authCookie = req.cookies
+    .getAll()
+    .find((cookie) => /^sb-[a-z0-9-]+-auth-token(?:\.\d+)?$/i.test(cookie.name));
+
+  if (!authCookie?.value) return null;
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(authCookie.value)) as
+      | { access_token?: string; currentSession?: { access_token?: string } }
+      | [{ access_token?: string }?, { access_token?: string }?]
+      | null;
+
+    if (Array.isArray(parsed)) {
+      return parsed[0]?.access_token ?? parsed[1]?.access_token ?? null;
+    }
+
+    return parsed?.access_token ?? parsed?.currentSession?.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getRoleFromRequest(req: NextRequest): string | null {
+  const token = getAccessTokenFromCookie(req);
+  if (!token) return null;
+
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+
+  const appMeta = payload.app_metadata as { role?: unknown } | undefined;
+  const userMeta = payload.user_metadata as { role?: unknown } | undefined;
+  const role = appMeta?.role ?? userMeta?.role;
+
+  return typeof role === 'string' ? role.toLowerCase() : null;
+}
+
+function hasExpiredSession(req: NextRequest) {
+  const token = getAccessTokenFromCookie(req);
+  if (!token) return false;
+  const payload = decodeJwtPayload(token);
+  if (!payload) return false;
+
+  const exp = payload.exp;
+  if (typeof exp !== 'number') return false;
+  return exp <= Math.floor(Date.now() / 1000);
+}
+
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
@@ -73,6 +140,37 @@ export async function middleware(req: NextRequest) {
     url.pathname = targetPath;
     url.search = query ? `?${query}` : '';
     return NextResponse.redirect(url);
+  }
+
+  if (authed && isProtected && hasExpiredSession(req)) {
+    const url = req.nextUrl.clone();
+    const destination = createLoginDestination(pathname + (search || ''));
+    const separator = destination.includes('?') ? '&' : '?';
+    const withMessage = `${destination}${separator}reason=session_expired`;
+    const [targetPath, query = ''] = withMessage.split('?');
+    url.pathname = targetPath;
+    url.search = query ? `?${query}` : '';
+    return NextResponse.redirect(url);
+  }
+
+  if (authed && pathname.startsWith('/admin')) {
+    const role = getRoleFromRequest(req);
+    if (role !== 'admin') {
+      const url = req.nextUrl.clone();
+      url.pathname = '/403';
+      url.search = '';
+      return NextResponse.redirect(url);
+    }
+  }
+
+  if (authed && pathname.startsWith('/teacher')) {
+    const role = getRoleFromRequest(req);
+    if (role !== 'teacher' && role !== 'admin') {
+      const url = req.nextUrl.clone();
+      url.pathname = '/403';
+      url.search = '';
+      return NextResponse.redirect(url);
+    }
   }
 
   if (authed && isAuthPage) {

--- a/pages/api/account/delete.ts
+++ b/pages/api/account/delete.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { logAccountAudit } from '@/lib/audit';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { isRecentAuthentication } from '@/lib/auth/recentAuth';
+import { requireAuth, writeAuthError, AuthError } from '@/lib/auth';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -10,12 +12,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const supabase = createSupabaseServerClient({ req, res });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) return writeAuthError(res, error.code);
+    throw error;
+  }
 
-  if (!user) {
-    return res.status(401).json({ error: 'Unauthorized' });
+  if (!isRecentAuthentication(req, 15 * 60)) {
+    return res.status(403).json({ error: 'Re-authentication required before deleting account' });
   }
 
   const { confirm, acknowledge } = (req.body ?? {}) as { confirm?: string; acknowledge?: boolean };
@@ -26,7 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const ipHeader = req.headers['x-forwarded-for'] ?? req.socket.remoteAddress ?? null;
   const ip = Array.isArray(ipHeader) ? ipHeader[0] : ipHeader;
   const uaHeader = req.headers['user-agent'];
-  const userAgent = Array.isArray(uaHeader) ? uaHeader[0] : uaHeader ?? null;
+  const userAgent = Array.isArray(uaHeader) ? uaHeader[0] : (uaHeader ?? null);
 
   const now = new Date();
   const purgeAfter = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);

--- a/pages/api/auth/signout.ts
+++ b/pages/api/auth/signout.ts
@@ -2,6 +2,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { enforceSameOrigin } from '@/lib/security/csrf';
 import { clearSession } from '@/lib/auth/server';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { logAccountAudit } from '@/lib/audit';
 
 /**
  * Clears Supabase auth cookies set by the Next.js helpers (if used).
@@ -10,6 +12,19 @@ import { clearSession } from '@/lib/auth/server';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
   if (!enforceSameOrigin(req, res)) return;
+
+  const supabase = createSupabaseServerClient({ req, res });
+  const { data } = await supabase.auth.getUser();
+  const user = data.user;
+
+  const ipHeader = req.headers['x-forwarded-for'] ?? req.socket.remoteAddress ?? null;
+  const ip = Array.isArray(ipHeader) ? ipHeader[0] : ipHeader;
+  const uaHeader = req.headers['user-agent'];
+  const userAgent = Array.isArray(uaHeader) ? uaHeader[0] : (uaHeader ?? null);
+
+  if (user?.id) {
+    await logAccountAudit(supabase, user.id, 'logout', {}, { ip, userAgent });
+  }
 
   clearSession(res);
 

--- a/pages/api/billing/create-portal-session.ts
+++ b/pages/api/billing/create-portal-session.ts
@@ -4,6 +4,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { stripe } from '@/lib/stripe';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { enforceSameOrigin } from '@/lib/security/csrf';
+import { isRecentAuthentication } from '@/lib/auth/recentAuth';
+import { requireAuth, writeAuthError, AuthError } from '@/lib/auth';
 
 type PortalResponse = { url: string } | { error: string };
 
@@ -18,10 +20,7 @@ const getOrigin = (req: NextApiRequest) => {
   return `${proto}://${host}`;
 };
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<PortalResponse>,
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<PortalResponse>) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
     return res.status(405).json({ error: 'method_not_allowed' });
@@ -32,10 +31,17 @@ export default async function handler(
   if (!stripe) return res.status(400).json({ error: 'stripe_not_configured' });
 
   const supabase = createSupabaseServerClient({ req, res });
-  const { data: auth } = await supabase.auth.getUser();
-  const user = auth?.user;
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) return writeAuthError(res, error.code);
+    throw error;
+  }
 
-  if (!user) return res.status(401).json({ error: 'unauthorized' });
+  if (!isRecentAuthentication(req, 15 * 60)) {
+    return res.status(403).json({ error: 'reauthentication_required' });
+  }
 
   const { data: profile, error } = await supabase
     .from('profiles')

--- a/pages/api/subscriptions/portal.ts
+++ b/pages/api/subscriptions/portal.ts
@@ -5,7 +5,14 @@ import { env } from '@/lib/env';
 import { getSubscriptionSummary } from '@/lib/repositories/subscriptionRepository';
 import { getActiveSubscription, summarizeStripeSubscription } from '@/lib/subscription';
 import { mapStripeInvoice } from '@/lib/subscriptions';
-import type { BillingInvoice as Invoice, SubscriptionApiResponse, PortalSummaryResponse, SubscriptionSummary } from '@/types/subscription';
+import type {
+  BillingInvoice as Invoice,
+  SubscriptionApiResponse,
+  PortalSummaryResponse,
+  SubscriptionSummary,
+} from '@/types/subscription';
+import { isRecentAuthentication } from '@/lib/auth/recentAuth';
+import { requireAuth, writeAuthError, AuthError } from '@/lib/auth';
 
 const getOrigin = (req: NextApiRequest) => {
   const proto = (req.headers['x-forwarded-proto'] as string) || 'https';
@@ -14,10 +21,15 @@ const getOrigin = (req: NextApiRequest) => {
 };
 
 const handler: NextApiHandler<SubscriptionApiResponse> = async (req, res) => {
-  const supabase = createSupabaseServerClient({ req });
-  const { data: userResp } = await supabase.auth.getUser();
-  const userId = userResp.user?.id;
-  if (!userId) return res.status(401).json({ ok: false, error: 'Unauthorized' });
+  const supabase = createSupabaseServerClient({ req, res });
+  let user;
+  try {
+    user = await requireAuth(supabase);
+  } catch (error) {
+    if (error instanceof AuthError) return writeAuthError(res, error.code);
+    throw error;
+  }
+  const userId = user.id;
 
   const dbSummary = await getSubscriptionSummary(supabase, userId);
   const customerId = dbSummary.customerId;
@@ -27,6 +39,10 @@ const handler: NextApiHandler<SubscriptionApiResponse> = async (req, res) => {
   const openPortal =
     req.headers['x-open-portal'] === '1' ||
     (req.headers['content-type']?.includes('application/x-www-form-urlencoded') ?? false);
+
+  if (openPortal && !isRecentAuthentication(req, 15 * 60)) {
+    return res.status(403).json({ ok: false, error: 'Re-authentication required' });
+  }
 
   // @ts-expect-error TODO: add `stripe` dependency for full types
   const Stripe = (await import('stripe')).default ?? (await import('stripe'));


### PR DESCRIPTION
### Motivation

- Implement Phase 1 (Authentication Hardening) server-side protections so protected pages and sensitive operations cannot be accessed by stale or unauthorized clients.
- Ensure role-based route blocking for admin/teacher areas and require recent re-auth for high-risk actions (billing, account deletion, portal access).
- Centralize API auth helpers and add audit hooks to make enforcement consistent across route handlers.

### Description

- Expanded `middleware.ts` to detect expired sessions and redirect to `/login?reason=session_expired`, and added server-side role gates that redirect unauthorized access to `/403` for `/admin/*` and `/teacher/*`.
- Added API-facing auth helpers in `lib/auth.ts` (`requireApiAuth`, `requireApiRole`) and created `lib/auth/recentAuth.ts` which inspects JWT cookies to validate recent authentication (auth_time/iat) for sensitive operations.
- Tightened cookie security in `lib/auth/cookies.ts` by switching issued auth cookies to `SameSite=strict` (HTTP-only, secure in prod preserved).
- Hardened sensitive endpoints to use the new utilities and re-auth checks: `POST /api/account/delete`, `POST /api/billing/create-portal-session`, and subscriptions portal open-portal flow in `pages/api/subscriptions/portal.ts` now require recent authentication and use centralized auth handling.
- Added audit logging on sign-out (`pages/api/auth/signout.ts`) to write a `logout` event with IP/user-agent before clearing session cookies.
- Added documentation artifacts: `docs/middleware-gap-report.md` (coverage) and `docs/auth-security-test-checklist.md` (manual test matrix / expected outcomes).

### Testing

- Ran Prettier formatting and checks on changed files: `npx prettier --write ...` and `npx prettier --check ...` (pass).
- Attempted ESLint: `npx eslint ...` failed in this environment due to dependency resolution (`@eslint/eslintrc`) unrelated to these changes.
- Type-check attempt: `npx tsc --noEmit` failed due to pre-existing unrelated type/syntax errors in other files in the workspace (unchanged by this PR).
- Runtime import check with `tsx` could not run in CI-like environment due to npm registry/network policy (403) and is therefore skipped in this run.
- Created Phase 1 docs and a manual auth security checklist for follow-up manual verification (listed tests in `docs/auth-security-test-checklist.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a628fb6cd083338d584d3ebd91ea9d)