### PR TITLE
fix(rls): guard account_audit_log policy creation when table is absent

### DIFF
--- a/supabase/migrations/20260303020000_phase4_rls_completion.sql
+++ b/supabase/migrations/20260303020000_phase4_rls_completion.sql
@@ -283,21 +283,24 @@ END $$;
 -- Account audit log policies (owner + admin)
 -- ---------------------------------------------------------------------------
 DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_audit_log' AND policyname='phase4_account_audit_select_own') THEN
+  IF to_regclass('public.account_audit_log') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_audit_log' AND policyname='phase4_account_audit_select_own') THEN
     CREATE POLICY "phase4_account_audit_select_own" ON public.account_audit_log
       FOR SELECT USING (auth.uid() = user_id);
   END IF;
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_audit_log' AND policyname='phase4_account_audit_insert_own') THEN
+  IF to_regclass('public.account_audit_log') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_audit_log' AND policyname='phase4_account_audit_insert_own') THEN
     CREATE POLICY "phase4_account_audit_insert_own" ON public.account_audit_log
       FOR INSERT WITH CHECK (auth.uid() = user_id);
   END IF;
 END $$;
 
 DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_audit_log' AND policyname='phase4_account_audit_admin_select_all') THEN
+  IF to_regclass('public.account_audit_log') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname='public' AND tablename='account_audit_log' AND policyname='phase4_account_audit_admin_select_all') THEN
     CREATE POLICY "phase4_account_audit_admin_select_all" ON public.account_audit_log
       FOR SELECT USING (public.is_admin());
   END IF;


### PR DESCRIPTION
### Motivation
- The Phase 4 RLS migration errored with `relation "public.account_audit_log" does not exist` when run in environments where the `account_audit_log` table hasn't been created, causing the migration to fail instead of proceeding idempotently.

### Description
- Added `to_regclass('public.account_audit_log') IS NOT NULL` guards to the three `DO $$ ... $$` policy blocks that create `phase4_account_audit_select_own`, `phase4_account_audit_insert_own`, and `phase4_account_audit_admin_select_all` in `supabase/migrations/20260303020000_phase4_rls_completion.sql` so policies are only created when the table exists and behavior remains unchanged when it does.

### Testing
- Verified the change by reviewing the SQL diff with `git diff -- supabase/migrations/20260303020000_phase4_rls_completion.sql`, inspecting the updated lines with `nl -ba supabase/migrations/20260303020000_phase4_rls_completion.sql | sed -n '280,315p'`, and confirming the commit succeeded; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a64ae52e24833383613bb01fc73731)