### PR TITLE
Guard AI Assist migration when ai_assist_logs table is absent

### DIFF
--- a/supabase/migrations/20260417000000_phase6_ai_assist_hardening.sql
+++ b/supabase/migrations/20260417000000_phase6_ai_assist_hardening.sql
@@ -10,15 +10,20 @@ ALTER TABLE IF EXISTS public.ai_assist_logs
   ADD COLUMN IF NOT EXISTS request_id text,
   ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
 
-CREATE INDEX IF NOT EXISTS ai_assist_logs_feature_created_idx
-  ON public.ai_assist_logs (feature, created_at DESC);
+DO $$
+BEGIN
+  IF to_regclass('public.ai_assist_logs') IS NOT NULL THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS ai_assist_logs_feature_created_idx
+      ON public.ai_assist_logs (feature, created_at DESC)';
 
-CREATE INDEX IF NOT EXISTS ai_assist_logs_user_feature_created_idx
-  ON public.ai_assist_logs (user_id, feature, created_at DESC);
+    EXECUTE 'CREATE INDEX IF NOT EXISTS ai_assist_logs_user_feature_created_idx
+      ON public.ai_assist_logs (user_id, feature, created_at DESC)';
+  END IF;
+END$$;
 
 DO $$
 BEGIN
-  IF NOT EXISTS (
+  IF to_regclass('public.ai_assist_logs') IS NOT NULL AND NOT EXISTS (
     SELECT 1 FROM pg_policies
     WHERE schemaname = 'public'
       AND tablename = 'ai_assist_logs'


### PR DESCRIPTION
### Motivation
- Prevent the Phase 6 AI Assist hardening migration from failing when the `public.ai_assist_logs` table does not exist by making index and policy creation no-ops if the base table is missing.

### Description
- Wrapped index creation in a `DO` block that checks `to_regclass('public.ai_assist_logs')` and uses `EXECUTE` to create indexes only when the table exists.
- Added the same `to_regclass('public.ai_assist_logs')` existence guard to the policy creation conditional so `CREATE POLICY` is only attempted when the table is present.
- Kept the `ALTER TABLE IF EXISTS` columns changes intact so columns are still added when the table exists.

### Testing
- Verified the migration file diff to ensure index creation and policy creation are now guarded using `git diff` and file listings, and the guarded blocks are present.
- Displayed the updated file with `nl -ba` to confirm the `DO` blocks and `to_regclass` checks are correctly placed and the file content is syntactically consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a65fad938083209063fc871c4bbb7d)