### PR TITLE
feat(phase9): add AI personalization, predictive scoring, admin analytics, and public API foundations

### DIFF
--- a/lib/apiKeyAuth.ts
+++ b/lib/apiKeyAuth.ts
@@ -1,0 +1,38 @@
+import crypto from 'crypto';
+import type { NextApiRequest } from 'next';
+import { supabaseService } from '@/lib/supabaseServer';
+
+export type ApiKeyAuthResult = { ok: true; userId: string; keyId: string; permissions: Record<string, unknown> } | { ok: false; error: string };
+
+function extractApiKey(req: NextApiRequest): string | null {
+  const auth = req.headers.authorization;
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) return auth.slice(7).trim();
+  const header = req.headers['x-api-key'];
+  if (typeof header === 'string') return header.trim();
+  return null;
+}
+
+export async function authenticateApiKey(req: NextApiRequest): Promise<ApiKeyAuthResult> {
+  const raw = extractApiKey(req);
+  if (!raw) return { ok: false, error: 'missing_api_key' };
+
+  const hash = crypto.createHash('sha256').update(raw).digest('hex');
+  const db = supabaseService() as any;
+  const { data, error } = await db
+    .from('api_keys')
+    .select('id, user_id, permissions, revoked_at')
+    .eq('key_hash', hash)
+    .is('revoked_at', null)
+    .maybeSingle();
+
+  if (error || !data) return { ok: false, error: 'invalid_api_key' };
+
+  await db.from('api_keys').update({ last_used: new Date().toISOString() }).eq('id', data.id);
+  return { ok: true, userId: data.user_id, keyId: data.id, permissions: data.permissions ?? {} };
+}
+
+export function issueApiKey(): { plainText: string; keyHash: string; keyPrefix: string } {
+  const plainText = `gx_${crypto.randomBytes(24).toString('hex')}`;
+  const keyHash = crypto.createHash('sha256').update(plainText).digest('hex');
+  return { plainText, keyHash, keyPrefix: plainText.slice(0, 10) };
+}

--- a/lib/prediction.ts
+++ b/lib/prediction.ts
@@ -1,0 +1,98 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabaseService } from '@/lib/supabaseServer';
+
+type DBClient = SupabaseClient<any>;
+
+export type PredictionResult = {
+  predictedBand: number;
+  confidenceInterval: number;
+  breakdown: Record<string, number>;
+  trend: 'up' | 'down' | 'stable';
+};
+
+function clampBand(value: number) {
+  return Math.max(0, Math.min(9, Math.round(value * 2) / 2));
+}
+
+function getClient(client?: DBClient): DBClient {
+  return client ?? (supabaseService() as DBClient);
+}
+
+export async function predictBandScore(userId: string, client?: DBClient): Promise<PredictionResult> {
+  const db = getClient(client);
+
+  const [{ data: history }, { data: profile }] = await Promise.all([
+    db
+      .from('score_history')
+      .select('band, occurred_at')
+      .eq('user_id', userId)
+      .not('band', 'is', null)
+      .order('occurred_at', { ascending: false })
+      .limit(20),
+    db.from('user_skill_profiles').select('proficiency, learning_pace').eq('user_id', userId).maybeSingle(),
+  ]);
+
+  const recent = (history ?? []).map((row: any, idx) => {
+    const weight = Math.max(0.2, 1 - idx * 0.06);
+    return Number(row.band ?? 0) * weight;
+  });
+  const totalWeight = recent.reduce((sum, _, idx) => sum + Math.max(0.2, 1 - idx * 0.06), 0) || 1;
+  const weightedRecent = recent.reduce((a, b) => a + b, 0) / totalWeight;
+
+  const proficiency = profile?.proficiency ?? {};
+  const skillValues = Object.values(proficiency).map((v) => Number(v)).filter((v) => Number.isFinite(v));
+  const skillAverage = skillValues.length ? skillValues.reduce((a, b) => a + b, 0) / skillValues.length : weightedRecent || 5.5;
+
+  const learningPace = Number(profile?.learning_pace ?? 0);
+  const paceFactor = Math.max(-0.4, Math.min(0.4, learningPace));
+
+  const predictedBand = clampBand(weightedRecent * 0.7 + skillAverage * 0.25 + paceFactor * 0.05);
+
+  const variance = skillValues.length
+    ? skillValues.reduce((acc, cur) => acc + Math.pow(cur - skillAverage, 2), 0) / skillValues.length
+    : 0.5;
+  const confidenceInterval = Math.max(0.25, Math.min(1, Number((Math.sqrt(variance) * 0.4 + 0.3).toFixed(2))));
+
+  const previousWindow = (history ?? []).slice(8, 16).map((row: any) => Number(row.band ?? 0));
+  const prevAverage = previousWindow.length
+    ? previousWindow.reduce((a: number, b: number) => a + b, 0) / previousWindow.length
+    : predictedBand;
+  const trend: PredictionResult['trend'] = predictedBand - prevAverage > 0.2 ? 'up' : prevAverage - predictedBand > 0.2 ? 'down' : 'stable';
+
+  return {
+    predictedBand,
+    confidenceInterval,
+    breakdown: {
+      recentPerformance: Number(weightedRecent.toFixed(2)),
+      skillAverage: Number(skillAverage.toFixed(2)),
+      learningPace: Number(learningPace.toFixed(3)),
+    },
+    trend,
+  };
+}
+
+export async function predictBandWhatIf(
+  userId: string,
+  adjustments: Partial<Record<'reading' | 'writing' | 'speaking' | 'listening', number>>,
+  client?: DBClient,
+): Promise<PredictionResult & { uplift: number }> {
+  const baseline = await predictBandScore(userId, client);
+  const db = getClient(client);
+
+  const { data: profile } = await db.from('user_skill_profiles').select('proficiency').eq('user_id', userId).maybeSingle();
+  const proficiency = { ...(profile?.proficiency ?? {}) } as Record<string, number>;
+
+  Object.entries(adjustments).forEach(([key, value]) => {
+    if (typeof value === 'number') proficiency[key] = value;
+  });
+
+  const skillValues = Object.values(proficiency).map((v) => Number(v)).filter((v) => Number.isFinite(v));
+  const skillAverage = skillValues.length ? skillValues.reduce((a, b) => a + b, 0) / skillValues.length : baseline.predictedBand;
+  const adjusted = clampBand(baseline.breakdown.recentPerformance * 0.7 + skillAverage * 0.3);
+
+  return {
+    ...baseline,
+    predictedBand: adjusted,
+    uplift: Number((adjusted - baseline.predictedBand).toFixed(2)),
+  };
+}

--- a/lib/recommendations.ts
+++ b/lib/recommendations.ts
@@ -1,0 +1,165 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabaseService } from '@/lib/supabaseServer';
+
+export * from '@/lib/recommendations/index';
+
+type DBClient = SupabaseClient<any>;
+
+export type ExerciseRecommendation = {
+  taskId: string;
+  type: string;
+  module: string;
+  difficulty: string | null;
+  title: string;
+  reason: string;
+};
+
+export type PersonalizedStudyDay = {
+  day: string;
+  focus: string;
+  tasks: ExerciseRecommendation[];
+};
+
+const CACHE_TTL_MS = 1000 * 60 * 15;
+const recommendationCache = new Map<string, { expiresAt: number; payload: unknown }>();
+
+function getClient(client?: DBClient): DBClient {
+  return client ?? (supabaseService() as DBClient);
+}
+
+function cacheKey(name: string, userId: string, extra?: string) {
+  return `${name}:${userId}:${extra ?? ''}`;
+}
+
+function getCached<T>(key: string): T | null {
+  const hit = recommendationCache.get(key);
+  if (!hit) return null;
+  if (Date.now() > hit.expiresAt) {
+    recommendationCache.delete(key);
+    return null;
+  }
+  return hit.payload as T;
+}
+
+function setCached<T>(key: string, payload: T) {
+  recommendationCache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, payload });
+}
+
+async function getSkillProfile(userId: string, client?: DBClient) {
+  const db = getClient(client);
+  const { data } = await db
+    .from('user_skill_profiles')
+    .select('proficiency, weakness_tags, preferred_exercise_types, learning_pace')
+    .eq('user_id', userId)
+    .maybeSingle();
+  return data ?? null;
+}
+
+export async function getWeaknessFocusedContent(userId: string, client?: DBClient): Promise<ExerciseRecommendation[]> {
+  const key = cacheKey('weakness-content', userId);
+  const cached = getCached<ExerciseRecommendation[]>(key);
+  if (cached) return cached;
+
+  const db = getClient(client);
+  const profile = await getSkillProfile(userId, db);
+  const weaknesses = (profile?.weakness_tags as string[] | undefined) ?? [];
+
+  const targetModules = new Set<string>();
+  weaknesses.forEach((w) => {
+    const lower = w.toLowerCase();
+    if (lower.includes('reading')) targetModules.add('reading');
+    if (lower.includes('writing')) targetModules.add('writing');
+    if (lower.includes('speaking')) targetModules.add('speaking');
+    if (lower.includes('listening')) targetModules.add('listening');
+  });
+
+  const modules = [...targetModules];
+  const query = db
+    .from('learning_tasks')
+    .select('id, type, module, difficulty, metadata')
+    .eq('is_active', true)
+    .limit(12);
+
+  const { data } = modules.length ? await query.in('module', modules) : await query;
+
+  const payload = (data ?? []).slice(0, 6).map((task: any) => ({
+    taskId: task.id,
+    type: task.type,
+    module: task.module,
+    difficulty: task.difficulty ?? null,
+    title: String(task.metadata?.title ?? 'Practice task'),
+    reason: weaknesses[0] ? `Targets: ${weaknesses[0]}` : 'Strengthen lower-performing skills',
+  }));
+
+  setCached(key, payload);
+  return payload;
+}
+
+function getTargetDifficulty(profile: any): 'easy' | 'medium' | 'hard' {
+  const proficiency = profile?.proficiency ?? {};
+  const scores = Object.values(proficiency).map((v) => Number(v)).filter((v) => Number.isFinite(v));
+  const avg = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 6;
+  if (avg < 5.5) return 'easy';
+  if (avg < 7) return 'medium';
+  return 'hard';
+}
+
+export async function getNextExercises(userId: string, count = 5, client?: DBClient): Promise<ExerciseRecommendation[]> {
+  const key = cacheKey('next-exercises', userId, String(count));
+  const cached = getCached<ExerciseRecommendation[]>(key);
+  if (cached) return cached;
+
+  const db = getClient(client);
+  const profile = await getSkillProfile(userId, db);
+  const preferredTypes = ((profile?.preferred_exercise_types as string[] | undefined) ?? []).slice(0, 3);
+  const weaknessContent = await getWeaknessFocusedContent(userId, db);
+  const targetDifficulty = getTargetDifficulty(profile);
+
+  let tasksQuery = db
+    .from('learning_tasks')
+    .select('id, type, module, difficulty, metadata')
+    .eq('is_active', true)
+    .limit(Math.max(12, count * 3));
+
+  if (preferredTypes.length) tasksQuery = tasksQuery.in('type', preferredTypes);
+  const { data: tasks } = await tasksQuery;
+
+  const normalized = (tasks ?? []).map((task: any) => ({
+    taskId: task.id,
+    type: task.type,
+    module: task.module,
+    difficulty: task.difficulty ?? null,
+    title: String(task.metadata?.title ?? 'Practice task'),
+    reason: task.difficulty === targetDifficulty ? `Adaptive difficulty: ${targetDifficulty}` : 'Recommended next practice',
+  }));
+
+  const merged = [...weaknessContent, ...normalized].filter(
+    (item, idx, arr) => arr.findIndex((x) => x.taskId === item.taskId) === idx,
+  );
+
+  const result = merged.slice(0, count);
+  setCached(key, result);
+  return result;
+}
+
+export async function getPersonalizedStudyPlan(userId: string, days = 7, client?: DBClient): Promise<PersonalizedStudyDay[]> {
+  const key = cacheKey('study-plan', userId, String(days));
+  const cached = getCached<PersonalizedStudyDay[]>(key);
+  if (cached) return cached;
+
+  const profile = await getSkillProfile(userId, client);
+  const weaknesses = (profile?.weakness_tags as string[] | undefined) ?? [];
+  const exercises = await getNextExercises(userId, Math.max(5, days), client);
+
+  const plan: PersonalizedStudyDay[] = Array.from({ length: days }).map((_, idx) => {
+    const date = new Date();
+    date.setDate(date.getDate() + idx);
+    const iso = date.toISOString().slice(0, 10);
+    const focus = weaknesses[idx % Math.max(1, weaknesses.length)] ?? 'balanced practice';
+    const dayTasks = exercises.slice(idx % Math.max(1, exercises.length), (idx % Math.max(1, exercises.length)) + 2);
+    return { day: iso, focus, tasks: dayTasks.length ? dayTasks : exercises.slice(0, 2) };
+  });
+
+  setCached(key, plan);
+  return plan;
+}

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,0 +1,59 @@
+import type { NextPage } from 'next';
+import useSWR from 'swr';
+import { DashboardLayout } from '@/components/layouts/DashboardLayout';
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error('fetch_failed');
+  return res.json();
+};
+
+const AdminAnalyticsPage: NextPage = () => {
+  const { data, error, isLoading } = useSWR('/api/admin/analytics', fetcher);
+  const metrics = (data?.metrics ?? []) as Array<any>;
+
+  return (
+    <DashboardLayout>
+      <section className="space-y-4">
+        <h1 className="text-2xl font-semibold">Admin Analytics</h1>
+        <p className="text-sm text-muted-foreground">Daily KPIs for growth, revenue, engagement, and AI usage.</p>
+
+        {error ? <p className="text-sm text-red-500">Failed to load analytics.</p> : null}
+        {isLoading ? <p className="text-sm text-muted-foreground">Loading…</p> : null}
+
+        <div className="overflow-x-auto rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="text-left text-muted-foreground">
+                <th className="px-2 py-2">Day</th>
+                <th className="px-2 py-2">DAU</th>
+                <th className="px-2 py-2">Signups</th>
+                <th className="px-2 py-2">Conversion</th>
+                <th className="px-2 py-2">Churn</th>
+                <th className="px-2 py-2">MRR</th>
+                <th className="px-2 py-2">AI Requests</th>
+                <th className="px-2 py-2">Avg Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {metrics.map((row) => (
+                <tr key={row.day} className="border-t border-border/50">
+                  <td className="px-2 py-2">{row.day}</td>
+                  <td className="px-2 py-2">{row.dau}</td>
+                  <td className="px-2 py-2">{row.new_signups}</td>
+                  <td className="px-2 py-2">{Number(row.conversion_rate ?? 0).toFixed(2)}%</td>
+                  <td className="px-2 py-2">{Number(row.churn_rate ?? 0).toFixed(2)}%</td>
+                  <td className="px-2 py-2">${Number(row.mrr ?? 0).toFixed(2)}</td>
+                  <td className="px-2 py-2">{row.total_ai_requests}</td>
+                  <td className="px-2 py-2">{Number(row.avg_test_score ?? 0).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </DashboardLayout>
+  );
+};
+
+export default AdminAnalyticsPage;

--- a/pages/api/admin/analytics.ts
+++ b/pages/api/admin/analytics.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+
+  const supabase = createSupabaseServerClient({ req, res });
+  try {
+    const user = await requireAuth(supabase);
+    const { data: profile } = await supabase.from('profiles').select('role').eq('id', user.id).maybeSingle();
+    if (!['admin', 'teacher'].includes(String((profile as any)?.role ?? ''))) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const { data } = await supabase
+      .from('analytics_daily')
+      .select('day, dau, new_signups, conversion_rate, churn_rate, mrr, total_ai_requests, avg_test_score')
+      .order('day', { ascending: false })
+      .limit(90);
+
+    return res.status(200).json({ metrics: data ?? [] });
+  } catch (error) {
+    if (error instanceof AuthError) return writeAuthError(res, error.code);
+    return res.status(500).json({ error: 'analytics_fetch_failed' });
+  }
+}

--- a/pages/api/prediction/index.ts
+++ b/pages/api/prediction/index.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { predictBandScore } from '@/lib/prediction';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+
+  const supabase = createSupabaseServerClient({ req, res });
+  try {
+    const user = await requireAuth(supabase);
+    const prediction = await predictBandScore(user.id, supabase as any);
+    return res.status(200).json(prediction);
+  } catch (error) {
+    if (error instanceof AuthError) return writeAuthError(res, error.code);
+    return res.status(500).json({ error: 'prediction_failed' });
+  }
+}

--- a/pages/api/prediction/what-if.ts
+++ b/pages/api/prediction/what-if.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { predictBandWhatIf } from '@/lib/prediction';
+
+const schema = z.object({
+  reading: z.number().min(0).max(9).optional(),
+  writing: z.number().min(0).max(9).optional(),
+  speaking: z.number().min(0).max(9).optional(),
+  listening: z.number().min(0).max(9).optional(),
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+
+  const parsed = schema.safeParse(req.body ?? {});
+  if (!parsed.success) return res.status(400).json({ error: 'invalid_payload', issues: parsed.error.flatten() });
+
+  const supabase = createSupabaseServerClient({ req, res });
+  try {
+    const user = await requireAuth(supabase);
+    const prediction = await predictBandWhatIf(user.id, parsed.data, supabase as any);
+    return res.status(200).json(prediction);
+  } catch (error) {
+    if (error instanceof AuthError) return writeAuthError(res, error.code);
+    return res.status(500).json({ error: 'prediction_what_if_failed' });
+  }
+}

--- a/pages/api/recommendations.ts
+++ b/pages/api/recommendations.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { getNextExercises, getPersonalizedStudyPlan, getWeaknessFocusedContent } from '@/lib/recommendations';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+
+  const supabase = createSupabaseServerClient({ req, res });
+  try {
+    const user = await requireAuth(supabase);
+    const count = Number(req.query.count ?? 5);
+    const days = Number(req.query.days ?? 7);
+
+    const [nextExercises, weaknessFocused, studyPlan] = await Promise.all([
+      getNextExercises(user.id, count, supabase as any),
+      getWeaknessFocusedContent(user.id, supabase as any),
+      getPersonalizedStudyPlan(user.id, days, supabase as any),
+    ]);
+
+    return res.status(200).json({ nextExercises, weaknessFocused, studyPlan, generatedAt: new Date().toISOString() });
+  } catch (error) {
+    if (error instanceof AuthError) return writeAuthError(res, error.code);
+    return res.status(500).json({ error: 'recommendations_failed' });
+  }
+}

--- a/pages/api/v1/speaking/feedback/[id].ts
+++ b/pages/api/v1/speaking/feedback/[id].ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { authenticateApiKey } from '@/lib/apiKeyAuth';
+import { supabaseService } from '@/lib/supabaseServer';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+  const auth = await authenticateApiKey(req);
+  if (!auth.ok) return res.status(401).json({ error: auth.error });
+
+  const id = String(req.query.id ?? '');
+  if (!id) return res.status(400).json({ error: 'missing_id' });
+
+  const db = supabaseService() as any;
+  const { data } = await db.from('speaking_attempts').select('id, user_id, metrics, feedback, created_at').eq('id', id).maybeSingle();
+
+  if (!data || data.user_id !== auth.userId) return res.status(404).json({ error: 'not_found' });
+  return res.status(200).json({ feedback: data });
+}

--- a/pages/api/v1/users/me/index.ts
+++ b/pages/api/v1/users/me/index.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { authenticateApiKey } from '@/lib/apiKeyAuth';
+import { supabaseService } from '@/lib/supabaseServer';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+
+  const auth = await authenticateApiKey(req);
+  if (!auth.ok) return res.status(401).json({ error: auth.error });
+
+  const db = supabaseService() as any;
+  const { data: profile } = await db.from('profiles').select('id, full_name, email, target_band').eq('id', auth.userId).maybeSingle();
+  return res.status(200).json({ user: profile ?? { id: auth.userId } });
+}

--- a/pages/api/v1/users/me/progress.ts
+++ b/pages/api/v1/users/me/progress.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { authenticateApiKey } from '@/lib/apiKeyAuth';
+import { supabaseService } from '@/lib/supabaseServer';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+  const auth = await authenticateApiKey(req);
+  if (!auth.ok) return res.status(401).json({ error: auth.error });
+
+  const db = supabaseService() as any;
+  const [scores, profile] = await Promise.all([
+    db.from('score_history').select('band, category, occurred_at').eq('user_id', auth.userId).order('occurred_at', { ascending: false }).limit(30),
+    db.from('user_skill_profiles').select('proficiency, weakness_tags, learning_pace').eq('user_id', auth.userId).maybeSingle(),
+  ]);
+
+  return res.status(200).json({ history: scores.data ?? [], skillProfile: profile.data ?? null });
+}

--- a/pages/api/v1/users/me/tests.ts
+++ b/pages/api/v1/users/me/tests.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { authenticateApiKey } from '@/lib/apiKeyAuth';
+import { supabaseService } from '@/lib/supabaseServer';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
+  const auth = await authenticateApiKey(req);
+  if (!auth.ok) return res.status(401).json({ error: auth.error });
+
+  const db = supabaseService() as any;
+  const { data } = await db
+    .from('score_history')
+    .select('id, category, band, occurred_at')
+    .eq('user_id', auth.userId)
+    .order('occurred_at', { ascending: false })
+    .limit(50);
+
+  return res.status(200).json({ tests: data ?? [] });
+}

--- a/pages/api/v1/writing/submit.ts
+++ b/pages/api/v1/writing/submit.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+import { authenticateApiKey } from '@/lib/apiKeyAuth';
+import { supabaseService } from '@/lib/supabaseServer';
+
+const schema = z.object({ prompt_id: z.string().min(1), response_text: z.string().min(20) });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const auth = await authenticateApiKey(req);
+  if (!auth.ok) return res.status(401).json({ error: auth.error });
+
+  const parsed = schema.safeParse(req.body ?? {});
+  if (!parsed.success) return res.status(400).json({ error: 'invalid_payload', issues: parsed.error.flatten() });
+
+  const db = supabaseService() as any;
+  const { data, error } = await db.from('writing_responses').insert({
+    user_id: auth.userId,
+    prompt_id: parsed.data.prompt_id,
+    response_text: parsed.data.response_text,
+    status: 'submitted',
+  }).select('id, created_at').maybeSingle();
+
+  if (error) return res.status(500).json({ error: 'submit_failed' });
+  return res.status(201).json({ submission: data });
+}

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,6 +1,8 @@
 import type { NextPage } from 'next';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
 import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import useDashboard, {
   useEstimatedBandScore,
@@ -25,12 +27,32 @@ const TrendChart = dynamic(
 );
 
 const DashboardPage: NextPage = () => {
+  const fetcher = async (url: string) => {
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) throw new Error('fetch_failed');
+    return res.json();
+  };
+
   const { isLoading, error } = useDashboard();
   const { score } = useEstimatedBandScore();
   const { heatmap } = useSkillHeatmap();
   const { strengths, weaknesses } = useStrengthsWeaknesses();
   const { streak } = useStudyStreak();
   const { points } = useImprovementGraph();
+  const { data: recommendations } = useSWR('/api/recommendations', fetcher);
+  const { data: prediction } = useSWR('/api/prediction', fetcher);
+  const [whatIfWriting, setWhatIfWriting] = useState(7);
+  const whatIfPayload = useMemo(() => ({ writing: whatIfWriting }), [whatIfWriting]);
+  const { data: whatIf } = useSWR(['/api/prediction/what-if', whatIfPayload], async ([url, payload]) => {
+    const res = await fetch(url, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error('what_if_failed');
+    return res.json();
+  });
 
   return (
     <DashboardLayout>
@@ -50,9 +72,11 @@ const DashboardPage: NextPage = () => {
 
         <div className="grid gap-4 md:grid-cols-3">
           <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Estimated Band Score</p>
-            <p className="mt-2 text-3xl font-semibold">{typeof score === 'number' ? score.toFixed(1) : '—'}</p>
-            <p className="mt-1 text-xs text-muted-foreground">Trend-aware estimate from your latest attempts.</p>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Predicted Band Score</p>
+            <p className="mt-2 text-3xl font-semibold">{typeof prediction?.predictedBand === 'number' ? prediction.predictedBand.toFixed(1) : typeof score === 'number' ? score.toFixed(1) : '—'}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Confidence ±{typeof prediction?.confidenceInterval === 'number' ? prediction.confidenceInterval : 0.5} · Trend: {prediction?.trend ?? 'stable'}
+            </p>
           </article>
 
           <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
@@ -116,6 +140,39 @@ const DashboardPage: NextPage = () => {
             title="Improvement Graph"
             points={(points.length ? points : [{ label: 'No data', band: 0 }]).map((p) => ({ label: p.label, value: p.band }))}
           />
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-3">
+          <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm lg:col-span-2">
+            <h2 className="text-base font-semibold">Recommended for You</h2>
+            <p className="mt-1 text-xs text-muted-foreground">Today&apos;s recommendations based on your latest skill profile.</p>
+            <div className="mt-3 space-y-2">
+              {(recommendations?.nextExercises ?? []).slice(0, 5).map((item: any) => (
+                <div key={item.taskId} className="rounded-lg border border-border/60 p-2 text-sm">
+                  <p className="font-medium">{item.title}</p>
+                  <p className="text-xs text-muted-foreground">{item.module} · {item.type} · {item.reason}</p>
+                </div>
+              ))}
+              {!(recommendations?.nextExercises ?? []).length ? <p className="text-xs text-muted-foreground">No personalized exercises yet.</p> : null}
+            </div>
+          </article>
+
+          <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+            <h2 className="text-base font-semibold">What-if simulator</h2>
+            <p className="mt-1 text-xs text-muted-foreground">If Writing improves to:</p>
+            <input
+              type="range"
+              min={4}
+              max={9}
+              step={0.5}
+              value={whatIfWriting}
+              onChange={(event) => setWhatIfWriting(Number(event.target.value))}
+              className="mt-3 w-full"
+            />
+            <p className="mt-2 text-sm">Writing target: <span className="font-semibold">{whatIfWriting.toFixed(1)}</span></p>
+            <p className="mt-1 text-sm">Predicted: <span className="font-semibold">{typeof whatIf?.predictedBand === 'number' ? whatIf.predictedBand.toFixed(1) : '—'}</span></p>
+            <p className="mt-1 text-xs text-emerald-600">Potential uplift: {typeof whatIf?.uplift === 'number' ? `${whatIf.uplift >= 0 ? '+' : ''}${whatIf.uplift.toFixed(2)}` : '—'}</p>
+          </article>
         </section>
 
         {isLoading ? <p className="text-xs text-muted-foreground">Loading dashboard analytics…</p> : null}

--- a/pages/developers/index.tsx
+++ b/pages/developers/index.tsx
@@ -1,0 +1,36 @@
+import type { NextPage } from 'next';
+
+const DevelopersPage: NextPage = () => {
+  return (
+    <main className="mx-auto max-w-4xl space-y-6 px-6 py-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">GramorX Developer Portal</h1>
+        <p className="text-sm text-muted-foreground">Versioned API docs for partners, schools, and integrators.</p>
+      </header>
+
+      <section className="rounded-2xl border p-4">
+        <h2 className="text-lg font-semibold">Authentication</h2>
+        <p className="mt-2 text-sm">Use <code>Authorization: Bearer gx_...</code> or <code>x-api-key</code> header for <code>/api/v1/*</code> routes.</p>
+      </section>
+
+      <section className="rounded-2xl border p-4 space-y-2">
+        <h2 className="text-lg font-semibold">Quickstart</h2>
+        <pre className="overflow-x-auto rounded bg-slate-900 p-3 text-xs text-slate-100">{`curl -H "Authorization: Bearer gx_xxx" \\
+  https://your-domain.com/api/v1/users/me`}</pre>
+      </section>
+
+      <section className="rounded-2xl border p-4 space-y-2">
+        <h2 className="text-lg font-semibold">Endpoints (v1)</h2>
+        <ul className="list-disc pl-5 text-sm">
+          <li>GET /api/v1/users/me</li>
+          <li>GET /api/v1/users/me/progress</li>
+          <li>GET /api/v1/users/me/tests</li>
+          <li>POST /api/v1/writing/submit</li>
+          <li>GET /api/v1/speaking/feedback/{'{id}'}</li>
+        </ul>
+      </section>
+    </main>
+  );
+};
+
+export default DevelopersPage;

--- a/supabase/migrations/20260415000001_phase9_ai_personalization.sql
+++ b/supabase/migrations/20260415000001_phase9_ai_personalization.sql
@@ -1,0 +1,238 @@
+-- Phase 9: AI personalization, predictive analytics, and public API foundations
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- 9.1.1 user skill profile model
+CREATE TABLE IF NOT EXISTS public.user_skill_profiles (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  proficiency jsonb NOT NULL DEFAULT '{}'::jsonb,
+  weakness_tags text[] NOT NULL DEFAULT '{}',
+  learning_pace numeric NOT NULL DEFAULT 0,
+  preferred_exercise_types text[] NOT NULL DEFAULT '{}',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  calculated_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS user_skill_profiles_gin_idx ON public.user_skill_profiles USING gin (proficiency);
+CREATE INDEX IF NOT EXISTS user_skill_profiles_weakness_idx ON public.user_skill_profiles USING gin (weakness_tags);
+
+ALTER TABLE public.user_skill_profiles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users read own skill profile" ON public.user_skill_profiles;
+CREATE POLICY "Users read own skill profile" ON public.user_skill_profiles
+  FOR SELECT USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Users upsert own skill profile" ON public.user_skill_profiles;
+CREATE POLICY "Users upsert own skill profile" ON public.user_skill_profiles
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Helper function to refresh one profile heuristically
+CREATE OR REPLACE FUNCTION public.refresh_user_skill_profile(p_user_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_reading numeric := 0;
+  v_writing numeric := 0;
+  v_speaking numeric := 0;
+  v_listening numeric := 0;
+  v_avg_recent numeric := 0;
+  v_avg_prev numeric := 0;
+  v_learning_pace numeric := 0;
+  v_pref_types text[] := '{}';
+  v_weaknesses text[] := '{}';
+BEGIN
+  SELECT COALESCE(AVG(CASE WHEN skill='reading' THEN score END), 0),
+         COALESCE(AVG(CASE WHEN skill='writing' THEN score END), 0),
+         COALESCE(AVG(CASE WHEN skill='speaking' THEN score END), 0),
+         COALESCE(AVG(CASE WHEN skill='listening' THEN score END), 0)
+  INTO v_reading, v_writing, v_speaking, v_listening
+  FROM (
+    SELECT lower(COALESCE(category, '')) AS skill, band AS score
+    FROM public.score_history
+    WHERE user_id = p_user_id AND band IS NOT NULL
+    ORDER BY occurred_at DESC
+    LIMIT 100
+  ) scores;
+
+  SELECT COALESCE(AVG(band), 0) INTO v_avg_recent
+  FROM (
+    SELECT band
+    FROM public.score_history
+    WHERE user_id = p_user_id AND band IS NOT NULL
+    ORDER BY occurred_at DESC
+    LIMIT 10
+  ) latest;
+
+  SELECT COALESCE(AVG(band), 0) INTO v_avg_prev
+  FROM (
+    SELECT band
+    FROM public.score_history
+    WHERE user_id = p_user_id AND band IS NOT NULL
+    ORDER BY occurred_at DESC
+    OFFSET 10
+    LIMIT 10
+  ) prev;
+
+  v_learning_pace := v_avg_recent - v_avg_prev;
+
+  SELECT COALESCE(array_agg(type ORDER BY cnt DESC), '{}') INTO v_pref_types
+  FROM (
+    SELECT t.type, COUNT(*) AS cnt
+    FROM public.task_runs tr
+    JOIN public.learning_tasks t ON t.id = tr.task_id
+    WHERE tr.user_id = p_user_id
+    GROUP BY t.type
+  ) pref;
+
+  IF v_reading < 6.5 THEN v_weaknesses := array_append(v_weaknesses, 'time management in reading'); END IF;
+  IF v_writing < 6.5 THEN v_weaknesses := array_append(v_weaknesses, 'lexical resource in writing'); END IF;
+  IF v_speaking < 6.5 THEN v_weaknesses := array_append(v_weaknesses, 'fluency and coherence in speaking'); END IF;
+  IF v_listening < 6.5 THEN v_weaknesses := array_append(v_weaknesses, 'detail detection in listening'); END IF;
+
+  INSERT INTO public.user_skill_profiles (
+    user_id,
+    proficiency,
+    weakness_tags,
+    learning_pace,
+    preferred_exercise_types,
+    metadata,
+    calculated_at,
+    updated_at
+  )
+  VALUES (
+    p_user_id,
+    jsonb_build_object(
+      'reading', ROUND(v_reading::numeric, 2),
+      'writing', ROUND(v_writing::numeric, 2),
+      'speaking', ROUND(v_speaking::numeric, 2),
+      'listening', ROUND(v_listening::numeric, 2)
+    ),
+    v_weaknesses,
+    ROUND(v_learning_pace::numeric, 3),
+    v_pref_types,
+    jsonb_build_object('source', 'phase9-nightly', 'band_window', 20),
+    timezone('utc', now()),
+    timezone('utc', now())
+  )
+  ON CONFLICT (user_id)
+  DO UPDATE SET
+    proficiency = EXCLUDED.proficiency,
+    weakness_tags = EXCLUDED.weakness_tags,
+    learning_pace = EXCLUDED.learning_pace,
+    preferred_exercise_types = EXCLUDED.preferred_exercise_types,
+    metadata = EXCLUDED.metadata,
+    calculated_at = EXCLUDED.calculated_at,
+    updated_at = EXCLUDED.updated_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_all_user_skill_profiles()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  u record;
+  processed integer := 0;
+BEGIN
+  FOR u IN SELECT id FROM auth.users LOOP
+    PERFORM public.refresh_user_skill_profile(u.id);
+    processed := processed + 1;
+  END LOOP;
+  RETURN processed;
+END;
+$$;
+
+-- 9.4 light analytics warehouse table
+CREATE TABLE IF NOT EXISTS public.analytics_daily (
+  day date PRIMARY KEY,
+  dau integer NOT NULL DEFAULT 0,
+  new_signups integer NOT NULL DEFAULT 0,
+  conversion_rate numeric NOT NULL DEFAULT 0,
+  churn_rate numeric NOT NULL DEFAULT 0,
+  mrr numeric NOT NULL DEFAULT 0,
+  total_ai_requests integer NOT NULL DEFAULT 0,
+  avg_test_score numeric NOT NULL DEFAULT 0,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+ALTER TABLE public.analytics_daily ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Admins read analytics daily" ON public.analytics_daily;
+CREATE POLICY "Admins read analytics daily" ON public.analytics_daily
+  FOR SELECT USING (auth.jwt()->>'role' IN ('admin','teacher'));
+
+-- 9.5 feedback ratings loop
+CREATE TABLE IF NOT EXISTS public.feedback_ratings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  submission_type text NOT NULL CHECK (submission_type IN ('writing','speaking')),
+  submission_id uuid NOT NULL,
+  feedback_id text,
+  rating smallint NOT NULL CHECK (rating BETWEEN 1 AND 5),
+  comment text,
+  admin_status text NOT NULL DEFAULT 'new' CHECK (admin_status IN ('new','reviewed','escalated')),
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS feedback_ratings_submission_idx ON public.feedback_ratings (submission_type, submission_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS feedback_ratings_admin_status_idx ON public.feedback_ratings (admin_status, created_at DESC);
+
+ALTER TABLE public.feedback_ratings ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users manage own feedback ratings" ON public.feedback_ratings;
+CREATE POLICY "Users manage own feedback ratings" ON public.feedback_ratings
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "Admins read feedback ratings" ON public.feedback_ratings;
+CREATE POLICY "Admins read feedback ratings" ON public.feedback_ratings
+  FOR SELECT USING (auth.jwt()->>'role' IN ('admin','teacher'));
+
+DROP POLICY IF EXISTS "Admins update feedback ratings" ON public.feedback_ratings;
+CREATE POLICY "Admins update feedback ratings" ON public.feedback_ratings
+  FOR UPDATE USING (auth.jwt()->>'role' IN ('admin','teacher')) WITH CHECK (auth.jwt()->>'role' IN ('admin','teacher'));
+
+-- 9.6 public API authentication and webhooks
+CREATE TABLE IF NOT EXISTS public.api_keys (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  key_hash text NOT NULL,
+  key_prefix text NOT NULL,
+  permissions jsonb NOT NULL DEFAULT '{}'::jsonb,
+  last_used timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_hash_uq ON public.api_keys (key_hash);
+CREATE INDEX IF NOT EXISTS api_keys_user_idx ON public.api_keys (user_id, created_at DESC);
+
+ALTER TABLE public.api_keys ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users manage own api keys" ON public.api_keys;
+CREATE POLICY "Users manage own api keys" ON public.api_keys
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE IF NOT EXISTS public.webhooks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  url text NOT NULL,
+  events text[] NOT NULL DEFAULT '{}',
+  secret text NOT NULL,
+  active boolean NOT NULL DEFAULT true,
+  last_delivery_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT timezone('utc', now()),
+  updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS webhooks_user_idx ON public.webhooks (user_id, created_at DESC);
+
+ALTER TABLE public.webhooks ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users manage own webhooks" ON public.webhooks;
+CREATE POLICY "Users manage own webhooks" ON public.webhooks
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation
- Deliver Phase 9 foundations to enable hyper‑personalized study plans, heuristic band predictions, user/admin analytics, and a public API surface for integrations.
- Persist user skill profiles, feedback signals and light analytics so nightly jobs and services can compute personalized recommendations and KPIs.
- Expose stable endpoints and auth primitives so partners and third‑party tools can integrate safely and at scale.

### Description
- Added a database migration `supabase/migrations/20260415000001_phase9_ai_personalization.sql` which creates `user_skill_profiles`, nightly refresh functions (`refresh_user_skill_profile`, `refresh_all_user_skill_profiles`), `analytics_daily`, `feedback_ratings`, `api_keys`, and `webhooks` with appropriate indexes and RLS policies.
- Implemented recommendation service in `lib/recommendations.ts` with `getNextExercises`, `getWeaknessFocusedContent`, and `getPersonalizedStudyPlan`, including a simple in‑memory cache and adaptive difficulty heuristics.
- Implemented prediction service in `lib/prediction.ts` with `predictBandScore` and `predictBandWhatIf` to return a predicted band, confidence interval, trend, and uplift for what‑if scenarios.
- Added authenticated product APIs `GET /api/recommendations`, `GET /api/prediction`, and `POST /api/prediction/what-if`, plus a public API key helper `lib/apiKeyAuth.ts` and v1 endpoints (`/api/v1/*`) for basic user/progress/tests/writing submission and speaking feedback retrieval.
- Updated UI: enhanced `/dashboard` to show Predicted Band (confidence + trend), a “Recommended for You” panel, and a What‑if simulator; added `/admin/analytics` page and `/developers` developer portal scaffold.

### Testing
- Ran `npm run lint` in this environment which failed because the `next` binary and project dependencies are not installed here, so linting could not complete.
- Attempted a Playwright navigation and screenshot of `http://127.0.0.1:3000/dashboard` which failed with `ERR_EMPTY_RESPONSE` because no local app server was running in this environment.
- No other automated unit or integration tests were executed in this environment; further CI runs should validate TypeScript, linting, and endpoint behavior once dependencies and a dev server are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a65f72f298833383d731816d15dde3)