### PR TITLE
Fix Phase 7 migration to handle preexisting audit_logs and alerts tables

### DIFF
--- a/supabase/migrations/20260420000000_phase7_audit_logging.sql
+++ b/supabase/migrations/20260420000000_phase7_audit_logging.sql
@@ -14,6 +14,34 @@ create table if not exists public.audit_logs (
   created_at timestamptz not null default now()
 );
 
+
+-- Backfill columns when table already existed before this migration
+alter table public.audit_logs
+  add column if not exists user_id uuid,
+  add column if not exists action text,
+  add column if not exists resource text,
+  add column if not exists resource_id text,
+  add column if not exists old_data jsonb,
+  add column if not exists new_data jsonb,
+  add column if not exists ip_address inet,
+  add column if not exists user_agent text,
+  add column if not exists metadata jsonb not null default '{}'::jsonb,
+  add column if not exists created_at timestamptz not null default now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'audit_logs_user_id_fkey'
+      AND conrelid = 'public.audit_logs'::regclass
+  ) THEN
+    ALTER TABLE public.audit_logs
+      ADD CONSTRAINT audit_logs_user_id_fkey
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
 create index if not exists idx_audit_logs_user_id on public.audit_logs (user_id);
 create index if not exists idx_audit_logs_action on public.audit_logs (action);
 create index if not exists idx_audit_logs_resource on public.audit_logs (resource);
@@ -72,6 +100,31 @@ create table if not exists public.alerts (
   created_at timestamptz not null default now(),
   resolved_at timestamptz
 );
+
+
+-- Backfill columns when table already existed before this migration
+alter table public.alerts
+  add column if not exists user_id uuid,
+  add column if not exists type text,
+  add column if not exists severity text,
+  add column if not exists details jsonb not null default '{}'::jsonb,
+  add column if not exists resolved boolean not null default false,
+  add column if not exists created_at timestamptz not null default now(),
+  add column if not exists resolved_at timestamptz;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'alerts_user_id_fkey'
+      AND conrelid = 'public.alerts'::regclass
+  ) THEN
+    ALTER TABLE public.alerts
+      ADD CONSTRAINT alerts_user_id_fkey
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
 
 create index if not exists idx_alerts_resolved_created on public.alerts (resolved, created_at desc);
 create index if not exists idx_alerts_type on public.alerts (type);


### PR DESCRIPTION
### Motivation
- Prevent runtime failure `ERROR: 42703: column "user_id" does not exist` when the migration runs against databases where `public.audit_logs` or `public.alerts` already exist without the new columns. 
- Ensure the migration can be applied idempotently across environments with schema drift so indexes and FK constraints can be created safely.

### Description
- Added `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` backfill blocks for `public.audit_logs` to ensure `user_id`, `action`, `resource`, `resource_id`, `old_data`, `new_data`, `ip_address`, `user_agent`, `metadata`, and `created_at` exist before creating indexes. 
- Added a guarded `DO $$ ... END $$;` block that conditionally creates the `audit_logs_user_id_fkey` foreign-key only if it does not already exist. 
- Applied the same backfill and guarded FK creation pattern to `public.alerts` to ensure `user_id`, `type`, `severity`, `details`, `resolved`, `created_at`, and `resolved_at` exist and the `alerts_user_id_fkey` is added only when missing. 
- Kept original `CREATE TABLE IF NOT EXISTS`, index creation, RLS enabling, and policy creation intact while inserting the backfill steps before index creation. 

### Testing
- Ran `rg` searches to locate the migration file and confirm target lines, which returned the expected migration path (`supabase/migrations/20260420000000_phase7_audit_logging.sql`). (succeeded)
- Inspected the updated migration with `sed -n` and `nl -ba` to verify the backfill and guarded FK blocks were inserted before index creation. (succeeded)
- Executed `git diff --check` to validate patch formatting and found no issues. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a66221e82483208f65fd66eac59676)