### PR TITLE
Fix Phase 8 migration when `plans` table already exists without new columns

### DIFF
--- a/supabase/migrations/20260421000000_phase8_global_saas_readiness.sql
+++ b/supabase/migrations/20260421000000_phase8_global_saas_readiness.sql
@@ -17,6 +17,19 @@ create table if not exists public.plans (
   updated_at timestamptz not null default now()
 );
 
+alter table public.plans add column if not exists description text;
+alter table public.plans add column if not exists price_monthly numeric(10,2);
+alter table public.plans add column if not exists price_yearly numeric(10,2);
+alter table public.plans add column if not exists lifetime_price numeric(10,2);
+alter table public.plans add column if not exists features jsonb not null default '[]'::jsonb;
+alter table public.plans add column if not exists stripe_price_monthly_id text;
+alter table public.plans add column if not exists stripe_price_yearly_id text;
+alter table public.plans add column if not exists stripe_price_lifetime_id text;
+alter table public.plans add column if not exists sort_order integer not null default 0;
+alter table public.plans add column if not exists is_active boolean not null default true;
+alter table public.plans add column if not exists created_at timestamptz not null default now();
+alter table public.plans add column if not exists updated_at timestamptz not null default now();
+
 insert into public.plans (
   id,name,description,price_monthly,price_yearly,lifetime_price,features,sort_order,is_active
 )


### PR DESCRIPTION
### Motivation
- The Phase 8 migration failed in environments where `public.plans` already existed with an older schema because `CREATE TABLE IF NOT EXISTS` does not add missing columns and the subsequent upsert referenced columns like `description` that weren't present.
- The change makes the migration idempotent so it can run safely against both fresh and existing databases.

### Description
- Added `ALTER TABLE public.plans ADD COLUMN IF NOT EXISTS` statements for `description`, `price_monthly`, `price_yearly`, `lifetime_price`, `features`, `stripe_price_monthly_id`, `stripe_price_yearly_id`, `stripe_price_lifetime_id`, `sort_order`, `is_active`, `created_at`, and `updated_at` in `supabase/migrations/20260421000000_phase8_global_saas_readiness.sql` before the seed/upsert block.
- Left the existing `INSERT ... ON CONFLICT DO UPDATE` seed logic unchanged so behavior on fresh schemas is preserved.
- Ensures the migration is safe to run multiple times and across environments with older `plans` schemas.

### Testing
- Inspected the migration file with `sed -n` and `nl -ba` to verify the new `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` lines were inserted and positioned before the insert/upsert, and those inspections succeeded.
- Searched the repo with `rg -n` to confirm the migration location and references, and the search succeeded.
- Verified the diff with `git diff` and committed the change with `git commit`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6624d9b708320b7d580ea5ef1bdad)