### PR TITLE
Add admin RLS policy for usage_tracking

### DIFF
--- a/supabase/migrations/20260601000000_usage_tracking_admin_policy.sql
+++ b/supabase/migrations/20260601000000_usage_tracking_admin_policy.sql
@@ -1,0 +1,11 @@
+-- EPIC 3.1 hardening follow-up: grant admin visibility into usage tracking.
+BEGIN;
+
+DO $$ BEGIN
+  CREATE POLICY "usage_tracking_admin_all" ON public.usage_tracking
+    FOR ALL
+    USING (auth.jwt()->>'role' = 'admin')
+    WITH CHECK (auth.jwt()->>'role' = 'admin');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Close EPIC 3.1 gap by granting `admin` users full visibility over `public.usage_tracking`, matching the roadmap acceptance criteria that admins (and service role) must be able to see all usage records.

### Description
- Add new idempotent Supabase migration `supabase/migrations/20260601000000_usage_tracking_admin_policy.sql` that creates a `FOR ALL` RLS policy `usage_tracking_admin_all` with `USING (auth.jwt()->>'role' = 'admin')` and `WITH CHECK (auth.jwt()->>'role' = 'admin')`.

### Testing
- Ran `git diff --check` to ensure no patch hygiene issues and the check passed.
- Verified repository state with `git status --short` to confirm the migration file is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b868da888333bf06e72fd4cd49be)