### PR TITLE
Enforce premium subscription checks on protected APIs

### DIFF
--- a/lib/premiumRoute.ts
+++ b/lib/premiumRoute.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { User } from '@/types/user';
+import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { AuthError, requireAuth } from '@/lib/auth';
+import { requireActiveSubscription } from '@/lib/subscription';
+
+export async function requirePremiumUser(req: NextApiRequest, res: NextApiResponse): Promise<User> {
+  const supabase = createSupabaseServerClient({ req, res });
+  const user = await requireAuth(supabase);
+
+  try {
+    await requireActiveSubscription(supabase, user.id);
+  } catch (error) {
+    if ((error as Error).message === 'subscription_required' || (error as Error).message === 'subscription_inactive') {
+      throw new AuthError('forbidden', 'subscription_required');
+    }
+    throw error;
+  }
+
+  return user;
+}

--- a/pages/api/ai/explain.ts
+++ b/pages/api/ai/explain.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { guardAIRequest } from '@/lib/usage';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 import { z } from 'zod';
 
 const ItemSchema = z.object({
@@ -38,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const supabase = createSupabaseServerClient({ req, res });
   let user;
   try {
-    user = await requireAuth(supabase);
+    user = await requirePremiumUser(req, res);
   } catch (error) {
     if (error instanceof AuthError) return writeAuthError(res, error.code);
     throw error;

--- a/pages/api/ai/next-item.ts
+++ b/pages/api/ai/next-item.ts
@@ -1,8 +1,9 @@
 // pages/api/ai/next-item.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { guardAIRequest } from '@/lib/usage';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 type Out = {
   difficulty: 'Easy' | 'Medium' | 'Hard';
@@ -19,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const supabase = createSupabaseServerClient({ req, res });
     let user;
     try {
-      user = await requireAuth(supabase);
+      user = await requirePremiumUser(req, res);
     } catch (error) {
       if (error instanceof AuthError) return writeAuthError(res, error.code);
       throw error;

--- a/pages/api/ai/profile-suggest.ts
+++ b/pages/api/ai/profile-suggest.ts
@@ -2,8 +2,9 @@ import { env } from "@/lib/env";
 // pages/api/ai/profile-suggest.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { guardAIRequest } from '@/lib/usage';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 import { LEVELS, PREFS, TIME } from '@/lib/profile-options';
 
 type EnglishLevel = typeof LEVELS[number];
@@ -66,7 +67,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const supabase = createSupabaseServerClient({ req, res });
   let user;
   try {
-    user = await requireAuth(supabase);
+    user = await requirePremiumUser(req, res);
   } catch (error) {
     if (error instanceof AuthError) return writeAuthError(res, error.code);
     throw error;

--- a/pages/api/ai/recommend.ts
+++ b/pages/api/ai/recommend.ts
@@ -1,8 +1,9 @@
 // pages/api/ai/recommend.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { guardAIRequest } from '@/lib/usage';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 import { getAIRecommendations, type RecommendInput } from '@/lib/ai/provider';
 import { requireFeature } from '@/lib/features';
 
@@ -16,7 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const supabase = createSupabaseServerClient({ req, res });
     let user;
     try {
-      user = await requireAuth(supabase);
+      user = await requirePremiumUser(req, res);
     } catch (error) {
       if (error instanceof AuthError) return writeAuthError(res, error.code);
       throw error;

--- a/pages/api/ai/summary.ts
+++ b/pages/api/ai/summary.ts
@@ -1,8 +1,9 @@
 // pages/api/ai/summary.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { guardAIRequest } from '@/lib/usage';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 const API_KEY = process.env.OPENAI_API_KEY || '';
 const MODEL = process.env.GX_AI_MODEL || 'gpt-4o-mini';
@@ -14,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const supabase = createSupabaseServerClient({ req, res });
     let user;
     try {
-      user = await requireAuth(supabase);
+      user = await requirePremiumUser(req, res);
     } catch (error) {
       if (error instanceof AuthError) return writeAuthError(res, error.code);
       throw error;

--- a/pages/api/prediction/index.ts
+++ b/pages/api/prediction/index.ts
@@ -1,14 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { predictBandScore } from '@/lib/prediction';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
 
   const supabase = createSupabaseServerClient({ req, res });
   try {
-    const user = await requireAuth(supabase);
+    const user = await requirePremiumUser(req, res);
     const prediction = await predictBandScore(user.id, supabase as any);
     return res.status(200).json(prediction);
   } catch (error) {

--- a/pages/api/prediction/what-if.ts
+++ b/pages/api/prediction/what-if.ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { predictBandWhatIf } from '@/lib/prediction';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 const schema = z.object({
   reading: z.number().min(0).max(9).optional(),
@@ -19,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const supabase = createSupabaseServerClient({ req, res });
   try {
-    const user = await requireAuth(supabase);
+    const user = await requirePremiumUser(req, res);
     const prediction = await predictBandWhatIf(user.id, parsed.data, supabase as any);
     return res.status(200).json(prediction);
   } catch (error) {

--- a/pages/api/recommendations.ts
+++ b/pages/api/recommendations.ts
@@ -1,14 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { requireAuth, AuthError, writeAuthError } from '@/lib/auth';
+import { AuthError, writeAuthError } from '@/lib/auth';
 import { getNextExercises, getPersonalizedStudyPlan, getWeaknessFocusedContent } from '@/lib/recommendations';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).json({ error: 'method_not_allowed' });
 
   const supabase = createSupabaseServerClient({ req, res });
   try {
-    const user = await requireAuth(supabase);
+    const user = await requirePremiumUser(req, res);
     const count = Number(req.query.count ?? 5);
     const days = Number(req.query.days ?? 7);
 

--- a/supabase/migrations/20251027_profiles_rls_hardening.sql
+++ b/supabase/migrations/20251027_profiles_rls_hardening.sql
@@ -4,7 +4,6 @@ create table if not exists public.profiles (
   email text,
   full_name text,
   avatar_url text,
-  plan text default 'free'::text,
   settings jsonb default '{}'::jsonb,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()

--- a/supabase/migrations/20251109_quota.sql
+++ b/supabase/migrations/20251109_quota.sql
@@ -51,14 +51,18 @@ LANGUAGE sql IMMUTABLE AS $$
   SELECT date_trunc('month', ts)::date;
 $$;
 
--- 6) Get current plan for user. Replace this logic if you store plan elsewhere.
--- Expect a profiles table or subscriptions table; here is a safe placeholder:
+-- 6) Get current plan for user from subscriptions table.
 CREATE OR REPLACE FUNCTION get_user_plan(p_user_id uuid)
 RETURNS text
 LANGUAGE sql STABLE AS $$
-  -- Try from profiles.plan; fallback to 'free'
   SELECT COALESCE(
-    (SELECT lower(btrim(p.plan)) FROM public.profiles p WHERE p.id = p_user_id),
+    (
+      SELECT lower(btrim(COALESCE(to_jsonb(s)->>'plan_id', s.plan, 'free')))
+      FROM public.subscriptions s
+      WHERE s.user_id = p_user_id
+      ORDER BY s.updated_at DESC NULLS LAST, s.created_at DESC NULLS LAST
+      LIMIT 1
+    ),
     'free'
   );
 $$;


### PR DESCRIPTION
### Motivation
- Ensure premium/AI endpoints enforce both authentication and an active subscription at the API layer to close a revenue-protection gap.
- Eliminate ambiguity between `profiles.plan` and `subscriptions` as the source-of-truth for entitlement decisions.
- Prevent client-side or tooling bypasses by making subscription checks mandatory at server entrance for premium routes.

### Description
- Add `lib/premiumRoute.ts` with `requirePremiumUser(req, res)` which calls `requireAuth` then `requireActiveSubscription` and maps inactive/missing subscriptions to an `AuthError('forbidden', 'subscription_required')` response.
- Refactor premium-facing APIs to use `requirePremiumUser(req, res)` instead of `requireAuth(...)` for these routes: `pages/api/ai/explain`, `pages/api/ai/recommend`, `pages/api/ai/next-item`, `pages/api/ai/profile-suggest`, `pages/api/ai/summary`, `pages/api/prediction`, `pages/api/prediction/what-if`, and `pages/api/recommendations`.
- Remove the `plan` default from `public.profiles` creation in `supabase/migrations/20251027_profiles_rls_hardening.sql` to avoid dual plan fields.
- Update `get_user_plan()` in `supabase/migrations/20251109_quota.sql` to read the effective plan from `public.subscriptions` (with a `free` fallback) and to prefer `plan_id` when present.

### Testing
- Attempted static validation via `npm run lint`, but it could not complete in this environment because the `next` binary is not available (`next: not found`).
- Verified call-site refactor and migration updates via repository search and direct file inspection, confirming the new `requirePremiumUser` usage and migration edits succeeded.
- No other automated tests were executed in this runtime; unit/integration tests should be run in CI with `next` present to fully validate changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6bcfeddc8833389524ac1d7041269)