### PR TITLE
Centralize subscription enforcement and apply premium wrapper across premium APIs

### DIFF
--- a/lib/premiumRoute.ts
+++ b/lib/premiumRoute.ts
@@ -1,11 +1,11 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest } from 'next';
 import type { User } from '@/types/user';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { AuthError, requireAuth } from '@/lib/auth';
 import { requireActiveSubscription } from '@/lib/subscription';
 
-export async function requirePremiumUser(req: NextApiRequest, res: NextApiResponse): Promise<User> {
-  const supabase = createSupabaseServerClient({ req, res });
+export async function requirePremiumUser(req: NextApiRequest): Promise<User> {
+  const supabase = createSupabaseServerClient({ req });
   const user = await requireAuth(supabase);
 
   try {

--- a/lib/subscription/getActiveSubscription.ts
+++ b/lib/subscription/getActiveSubscription.ts
@@ -81,12 +81,3 @@ export async function getActiveSubscription(
     isActive: plan !== 'free' && (status === 'active' || status === 'trialing' || status === 'past_due'),
   };
 }
-
-export async function requireActiveSubscription(
-  userId: string,
-  supabaseClient?: SupabaseClient<Database>,
-): Promise<ActiveSubscription> {
-  const subscription = await getActiveSubscription(userId, supabaseClient);
-  if (!subscription.isActive) throw new Error('subscription_inactive');
-  return subscription;
-}

--- a/pages/api/ai/explain.ts
+++ b/pages/api/ai/explain.ts
@@ -39,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const supabase = createSupabaseServerClient({ req, res });
   let user;
   try {
-    user = await requirePremiumUser(req, res);
+    user = await requirePremiumUser(req);
   } catch (error) {
     if (error instanceof AuthError) return writeAuthError(res, error.code);
     throw error;

--- a/pages/api/ai/next-item.ts
+++ b/pages/api/ai/next-item.ts
@@ -20,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const supabase = createSupabaseServerClient({ req, res });
     let user;
     try {
-      user = await requirePremiumUser(req, res);
+      user = await requirePremiumUser(req);
     } catch (error) {
       if (error instanceof AuthError) return writeAuthError(res, error.code);
       throw error;

--- a/pages/api/ai/profile-suggest.ts
+++ b/pages/api/ai/profile-suggest.ts
@@ -67,7 +67,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const supabase = createSupabaseServerClient({ req, res });
   let user;
   try {
-    user = await requirePremiumUser(req, res);
+    user = await requirePremiumUser(req);
   } catch (error) {
     if (error instanceof AuthError) return writeAuthError(res, error.code);
     throw error;

--- a/pages/api/ai/recommend.ts
+++ b/pages/api/ai/recommend.ts
@@ -17,7 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const supabase = createSupabaseServerClient({ req, res });
     let user;
     try {
-      user = await requirePremiumUser(req, res);
+      user = await requirePremiumUser(req);
     } catch (error) {
       if (error instanceof AuthError) return writeAuthError(res, error.code);
       throw error;

--- a/pages/api/ai/summary.ts
+++ b/pages/api/ai/summary.ts
@@ -15,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const supabase = createSupabaseServerClient({ req, res });
     let user;
     try {
-      user = await requirePremiumUser(req, res);
+      user = await requirePremiumUser(req);
     } catch (error) {
       if (error instanceof AuthError) return writeAuthError(res, error.code);
       throw error;

--- a/pages/api/counters/increment.ts
+++ b/pages/api/counters/increment.ts
@@ -2,7 +2,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { createClient } from '@supabase/supabase-js';
-import { getActiveSubscription, requireActiveSubscription } from '@/lib/subscription/getActiveSubscription';
+import { getUserPlan } from '@/lib/subscription';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 const BodySchema = z.object({
   counter: z.enum([
@@ -55,23 +56,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   if (!token) return res.status(401).json({ ok: false, error: 'Missing Authorization bearer token' });
 
   const supabase = createClient(supabaseUrl, supabaseKey, { global: { headers: { Authorization: `Bearer ${token}` } } });
-  const { data: userRes, error: userErr } = await supabase.auth.getUser();
-  if (userErr || !userRes.user?.id) return res.status(401).json({ ok: false, error: 'Unauthorized' });
-  const userId = userRes.user.id;
 
+  let userId: string;
   try {
-    await requireActiveSubscription(userId, supabase);
+    const user = await requirePremiumUser(req);
+    userId = user.id;
   } catch {
     return res.status(402).json({ ok: false, error: 'subscription_required' });
   }
 
   const { counter, delta } = parse.data;
 
-  const subscription = await getActiveSubscription(userId, supabase);
-  const plan = subscription.plan;
+  const plan = await getUserPlan(supabase as any, userId);
 
-  const limit = plan === 'pro' ? MASTER_LIMITS[counter]
-    : plan === 'premium' ? BOOSTER_LIMITS[counter]
+  const limit = plan === 'master' ? MASTER_LIMITS[counter]
+    : plan === 'booster' || plan === 'starter' ? BOOSTER_LIMITS[counter]
     : FREE_LIMITS[counter];
 
   const today = new Date().toISOString().slice(0, 10);

--- a/pages/api/prediction/index.ts
+++ b/pages/api/prediction/index.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const supabase = createSupabaseServerClient({ req, res });
   try {
-    const user = await requirePremiumUser(req, res);
+    const user = await requirePremiumUser(req);
     const prediction = await predictBandScore(user.id, supabase as any);
     return res.status(200).json(prediction);
   } catch (error) {

--- a/pages/api/prediction/what-if.ts
+++ b/pages/api/prediction/what-if.ts
@@ -20,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const supabase = createSupabaseServerClient({ req, res });
   try {
-    const user = await requirePremiumUser(req, res);
+    const user = await requirePremiumUser(req);
     const prediction = await predictBandWhatIf(user.id, parsed.data, supabase as any);
     return res.status(200).json(prediction);
   } catch (error) {

--- a/pages/api/recommendations.ts
+++ b/pages/api/recommendations.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const supabase = createSupabaseServerClient({ req, res });
   try {
-    const user = await requirePremiumUser(req, res);
+    const user = await requirePremiumUser(req);
     const count = Number(req.query.count ?? 5);
     const days = Number(req.query.days ?? 7);
 

--- a/pages/api/speaking/score.ts
+++ b/pages/api/speaking/score.ts
@@ -2,10 +2,10 @@ import { env } from '@/lib/env';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import OpenAI from 'openai';
-import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { trackor } from '@/lib/analytics/trackor.server';
 import { z } from 'zod';
-import { getActiveSubscription, requireActiveSubscription } from '@/lib/subscription/getActiveSubscription';
+import { getUserPlan } from '@/lib/subscription';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 const AI_RETRY_COUNT = 1;
 const AUDIO_FETCH_TIMEOUT_MS = 30_000;
@@ -147,21 +147,8 @@ export default async function handler(
   const { attemptId } = req.body as { attemptId?: string };
   if (!attemptId) return res.status(400).json({ error: 'Missing attemptId' });
 
-  const supabase = createSupabaseServerClient({ req });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) return res.status(401).json({ error: 'Unauthorized' });
-
-  try {
-    await requireActiveSubscription(user.id, supabase);
-  } catch {
-    return res.status(402).json({ error: 'subscription_required' });
-  }
-
-  const subscription = await getActiveSubscription(user.id, supabase);
-  const plan = subscription.plan;
+  const user = await requirePremiumUser(req);
+  const plan = await getUserPlan(supabaseAdmin as any, user.id);
 
   if (!env.OPENAI_API_KEY) {
     return res.status(503).json({

--- a/pages/api/speaking/start-attempt.ts
+++ b/pages/api/speaking/start-attempt.ts
@@ -2,7 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseFromRequest } from '@/lib/apiAuth';
 import { trackor } from '@/lib/analytics/trackor.server';
 import { checkLimit, incrementUsage, limitExceeded } from '@/lib/usage';
-import { getActiveSubscription, requireActiveSubscription } from '@/lib/subscription/getActiveSubscription';
+import { getUserPlan } from '@/lib/subscription';
+import { requirePremiumUser } from '@/lib/premiumRoute';
 
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -12,18 +13,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!part) return res.status(400).json({ error: 'Missing part' });
 
   const supabase = supabaseFromRequest(req);
-  const { data: userRes } = await supabase.auth.getUser();
-  const user = userRes?.user;
-  if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
+  let user;
   try {
-    await requireActiveSubscription(user.id, supabase);
+    user = await requirePremiumUser(req);
   } catch {
     return res.status(402).json({ error: 'subscription_required' });
   }
 
-  const subscription = await getActiveSubscription(user.id, supabase);
-  const plan = subscription.plan;
+  const plan = await getUserPlan(supabase as any, user.id);
 
   const freeLimit = Number(process.env.LIMIT_FREE_SPEAKING ?? 2) || 0;
   const enforceLimit = plan === 'free' && freeLimit > 0;


### PR DESCRIPTION
### Motivation

- Eliminate enforcement drift caused by multiple `requireActiveSubscription` implementations and consolidate subscription checks to a single authoritative location. 
- Ensure premium API routes always authenticate first, then validate subscription, to prevent missing auth-before-subscription checks. 
- Replace ad-hoc per-route subscription reads with a centralized API to reduce duplication and RLS/Stripe surface area.

### Description

- Removed the duplicate `requireActiveSubscription` implementation from `lib/subscription/getActiveSubscription.ts` and kept the centralized enforcement in `lib/subscription/index.ts` (single exported `requireActiveSubscription(supabase, userId)`).
- Introduced/standardized the premium wrapper in `lib/premiumRoute.ts` as `requirePremiumUser(req)` which runs `requireAuth` then `requireActiveSubscription` and returns the `User` (throws `AuthError('forbidden','subscription_required')` on subscription failures).
- Replaced manual subscription checks and direct per-route reads in premium API routes to use the wrapper and central helpers: updated call sites to `requirePremiumUser(req)` and switched to `getUserPlan` from `@/lib/subscription` where routes previously called `getActiveSubscription` or `requireActiveSubscription` manually; primary modified routes include `pages/api/counters/increment.ts`, `pages/api/speaking/start-attempt.ts`, and `pages/api/speaking/score.ts`, and aligned wrapper usage across `pages/api/ai/*`, `pages/api/prediction/*`, and `pages/api/recommendations.ts`.
- Adjusted imports so enforcement and plan lookups come from the central subscription module (imports changed from `@/lib/subscription/getActiveSubscription` to `@/lib/subscription`) and ensured premium API folders no longer perform direct `supabase.from('subscriptions')` reads in the scoped premium routes.

### Testing

- Ran targeted repository searches with `rg` to verify there is exactly one exported `requireActiveSubscription` and that premium routes now call `requirePremiumUser(req)`; the search confirmed a single definition in `lib/subscription/index.ts` and updated usages across the premium routes (success).
- Verified through `rg` that the targeted premium API folders (`pages/api/ai`, `pages/api/speaking`, `pages/api/counters`, `pages/api/writing`) no longer contain direct `supabase.from('subscriptions')` reads (success for the scoped folders in this pass).
- Attempted a full type-check with `npx tsc --noEmit`, which failed due to pre-existing, unrelated TypeScript errors in `pages/writing/index.tsx` and `scripts/dev-next.mjs` (these failures are not introduced by this enforcement change).
- Attempted linting of touched files with `npx eslint ...`, which could not complete in this environment due to missing local dependency resolution (`@eslint/eslintrc`) and is therefore unresolved in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6c4a3aff08333bfbeea440d188b69)