### PR TITLE
Refactor route pages to use centralized app shell layouts

### DIFF
--- a/components/layouts/AppLayoutManager.tsx
+++ b/components/layouts/AppLayoutManager.tsx
@@ -34,10 +34,11 @@ import BillingLayout from '@/components/layouts/BillingLayout';
 import ResourcesLayout from '@/components/layouts/ResourcesLayout';
 import AnalyticsLayout from '@/components/layouts/AnalyticsLayout';
 import SupportLayout from '@/components/layouts/SupportLayout';
+import WritingLayout from '@/components/layouts/WritingLayout';
+import ExamResourceLayout from '@/components/layouts/ExamResourceLayout';
 
 // ⭐ NEW — Breadcrumb Bar V2
 import { BreadcrumbBar } from '@/components/navigation/BreadcrumbBar';
-
 
 // -----------------------
 // Error Boundary
@@ -59,9 +60,7 @@ const LayoutErrorBoundary: React.FC<{ children: ReactNode }> = ({ children }) =>
           <p className="text-sm text-muted-foreground mb-4">
             There was a problem loading this page layout.
           </p>
-          <Button onClick={() => window.location.reload()}>
-            Reload Page
-          </Button>
+          <Button onClick={() => window.location.reload()}>Reload Page</Button>
         </div>
       </Card>
     );
@@ -69,7 +68,6 @@ const LayoutErrorBoundary: React.FC<{ children: ReactNode }> = ({ children }) =>
 
   return <>{children}</>;
 };
-
 
 // -----------------------
 // Props
@@ -98,7 +96,6 @@ type AppLayoutManagerProps = {
   showBreadcrumbs?: boolean;
 };
 
-
 // -----------------------
 // Teacher Onboarding Gate
 // -----------------------
@@ -110,7 +107,7 @@ function TeacherOnboardingGate() {
       event.preventDefault();
       void router.push('/teacher/register');
     },
-    [router]
+    [router],
   );
 
   return (
@@ -122,7 +119,8 @@ function TeacherOnboardingGate() {
           </p>
           <h2 className="text-h3 font-semibold text-foreground">Complete your profile</h2>
           <p className="text-small text-muted-foreground">
-            Your account is created but not approved yet. Share a quick profile so our team can unlock the teacher workspace for you.
+            Your account is created but not approved yet. Share a quick profile so our team can
+            unlock the teacher workspace for you.
           </p>
         </div>
 
@@ -151,7 +149,6 @@ function TeacherOnboardingGate() {
   );
 }
 
-
 // -----------------------
 // Teacher Access Helper
 // -----------------------
@@ -167,7 +164,7 @@ const useTeacherAccess = (role?: string | null, isTeacherApproved?: boolean | nu
       canAccessTeacher,
       isApproved,
       shouldRedirect: isTeacherRoute && role && !canAccessTeacher,
-      showOnboarding: role === 'teacher' && !isApproved
+      showOnboarding: role === 'teacher' && !isApproved,
     };
   }, [role, isTeacherApproved, isTeacherRoute]);
 
@@ -180,7 +177,6 @@ const useTeacherAccess = (role?: string | null, isTeacherApproved?: boolean | nu
   return teacherAccess;
 };
 
-
 // -----------------------
 // Layout Config Type
 // -----------------------
@@ -192,10 +188,9 @@ type LayoutConfig = {
     role?: string | null,
     isTeacherApproved?: boolean | null,
     children?: ReactNode,
-    guardFallback?: () => ReactNode
+    guardFallback?: () => ReactNode,
   ) => ReactNode;
 };
-
 
 // -----------------------
 // MAIN COMPONENT
@@ -221,13 +216,13 @@ export function AppLayoutManager({
   guardFallback,
   showBreadcrumbs,
 }: AppLayoutManagerProps) {
+  // Architecture note: Pages must not self-wrap with app shell layouts.
 
   const router = useRouter();
   const pathname = router.pathname;
   const teacherAccess = useTeacherAccess(role, isTeacherApproved);
   const isTeacherRoute = pathname.startsWith('/teacher');
   const teacherAccessRole = role ?? 'guest';
-
 
   // -----------------------
   // Teacher Content Switch
@@ -252,14 +247,18 @@ export function AppLayoutManager({
     return guardFallback();
   }, [role, teacherAccessRole, teacherAccess.isApproved, children, guardFallback]);
 
-
   // -----------------------
   // Layout Mapping
   // -----------------------
   const layoutConfigs: LayoutConfig[] = useMemo(
     () => [
       { type: 'admin', component: AdminLayout, guard: () => isAdminRoute },
-      { type: 'teacher', component: TeacherLayout, guard: () => isTeacherRoute, getContent: () => getTeacherContent() },
+      {
+        type: 'teacher',
+        component: TeacherLayout,
+        guard: () => isTeacherRoute,
+        getContent: () => getTeacherContent(),
+      },
       { type: 'institutions', component: InstitutionsLayout, guard: () => isInstitutionsRoute },
       { type: 'dashboard', component: DashboardLayout, guard: () => isDashboardRoute },
       { type: 'marketplace', component: MarketplaceLayout, guard: () => isMarketplaceRoute },
@@ -267,12 +266,55 @@ export function AppLayoutManager({
       { type: 'community', component: CommunityLayout, guard: () => isCommunityRoute },
       { type: 'reports', component: ReportsLayout, guard: () => isReportsRoute },
       { type: 'marketing', component: PublicMarketingLayout, guard: () => isMarketingRoute },
-      { type: 'profile', component: ProfileLayout, guard: () => pathname.startsWith('/profile') || pathname.startsWith('/user') },
-      { type: 'communication', component: CommunicationLayout, guard: () => pathname.startsWith('/messages') || pathname.startsWith('/chat') || pathname.startsWith('/inbox') },
-      { type: 'billing', component: BillingLayout, guard: () => pathname.startsWith('/billing') || pathname.startsWith('/payment') || pathname.startsWith('/subscription') },
-      { type: 'resources', component: ResourcesLayout, guard: () => pathname.startsWith('/resources') || pathname.startsWith('/library') },
-      { type: 'analytics', component: AnalyticsLayout, guard: () => pathname.startsWith('/analytics') || pathname.startsWith('/stats') },
-      { type: 'support', component: SupportLayout, guard: () => pathname.startsWith('/support') || pathname.startsWith('/help') },
+      {
+        type: 'profile',
+        component: ProfileLayout,
+        guard: () => pathname.startsWith('/profile') || pathname.startsWith('/user'),
+      },
+      {
+        type: 'communication',
+        component: CommunicationLayout,
+        guard: () =>
+          pathname.startsWith('/messages') ||
+          pathname.startsWith('/chat') ||
+          pathname.startsWith('/inbox'),
+      },
+      {
+        type: 'billing',
+        component: BillingLayout,
+        guard: () =>
+          pathname.startsWith('/billing') ||
+          pathname.startsWith('/payment') ||
+          pathname.startsWith('/subscription'),
+      },
+      {
+        type: 'resources',
+        component: ResourcesLayout,
+        guard: () => pathname.startsWith('/resources') || pathname.startsWith('/library'),
+      },
+      {
+        type: 'analytics',
+        component: AnalyticsLayout,
+        guard: () => pathname.startsWith('/analytics') || pathname.startsWith('/stats'),
+      },
+      {
+        type: 'support',
+        component: SupportLayout,
+        guard: () => pathname.startsWith('/support') || pathname.startsWith('/help'),
+      },
+      {
+        type: 'exam-resources',
+        component: ExamResourceLayout,
+        guard: () => pathname.startsWith('/exam-day') || pathname.startsWith('/exam/rehearsal'),
+      },
+      {
+        type: 'writing',
+        component: WritingLayout,
+        guard: () =>
+          pathname.startsWith('/writing/overview') ||
+          pathname.startsWith('/writing/library') ||
+          pathname.startsWith('/writing/progress'),
+      },
     ],
     [
       isAdminRoute,
@@ -286,27 +328,21 @@ export function AppLayoutManager({
       isMarketingRoute,
       pathname,
       getTeacherContent,
-    ]
+    ],
   );
-
 
   // -----------------------
   // Which Layout Active?
   // -----------------------
   const activeLayout = useMemo(
     () => layoutConfigs.find((config) => config.guard?.(role, isTeacherApproved)) || null,
-    [layoutConfigs, role, isTeacherApproved]
+    [layoutConfigs, role, isTeacherApproved],
   );
-
 
   // -----------------------
   // Apply Wrappers
   // -----------------------
-  const getNakedContent = (
-    auth: boolean,
-    proctoring: boolean,
-    content: ReactNode
-  ) => {
+  const getNakedContent = (auth: boolean, proctoring: boolean, content: ReactNode) => {
     // For specific auth pages that should be truly naked (no AuthLayout)
     const nakedAuthRoutes = ['/forgot-password', '/update-password'];
     if (nakedAuthRoutes.includes(router.pathname)) {
@@ -314,24 +350,78 @@ export function AppLayoutManager({
     }
     if (auth) {
       const authCopy: Record<string, { title: string; subtitle: string }> = {
-        '/login': { title: 'Welcome back', subtitle: 'Sign in to continue your IELTS prep journey.' },
-        '/login/index': { title: 'Welcome back', subtitle: 'Sign in to continue your IELTS prep journey.' },
-        '/login/email': { title: 'Sign in with email', subtitle: 'Use your email and password to access your account.' },
-        '/login/phone': { title: 'Sign in with phone', subtitle: 'Get a one-time code on your phone and continue securely.' },
-        '/login/password': { title: 'Set new password', subtitle: 'Create a secure password to protect your account.' },
-        '/signup': { title: 'Create your account', subtitle: 'Choose a sign-up method and start improving your band score.' },
-        '/signup/index': { title: 'Create your account', subtitle: 'Choose a sign-up method and start improving your band score.' },
-        '/signup/email': { title: 'Sign up with email', subtitle: 'Create your account using email verification.' },
-        '/signup/phone': { title: 'Sign up with phone', subtitle: 'Create your account with a secure SMS verification code.' },
-        '/signup/password': { title: 'Create password', subtitle: 'Set a strong password to finish your account setup.' },
-        '/signup/verify': { title: 'Verify your email', subtitle: 'Check your inbox and confirm your email to continue.' },
-        '/auth/forgot': { title: 'Forgot password', subtitle: 'We will send a reset link to your email address.' },
-        '/auth/reset': { title: 'Reset password', subtitle: 'Choose a new password and sign in again.' },
-        '/auth/verify': { title: 'Email verification', subtitle: 'Finalizing your verification and secure sign-in.' },
-        '/auth/confirm': { title: 'Confirm your email', subtitle: 'We are validating your email confirmation link.' },
-        '/auth/mfa': { title: 'Two-factor authentication', subtitle: 'Enter the 6-digit code from your authenticator app.' },
-        '/forgot-password': { title: 'Forgot password', subtitle: 'We will send a reset link to your email address.' },
-        '/update-password': { title: 'Update password', subtitle: 'Set a new password and get back into your account.' },
+        '/login': {
+          title: 'Welcome back',
+          subtitle: 'Sign in to continue your IELTS prep journey.',
+        },
+        '/login/index': {
+          title: 'Welcome back',
+          subtitle: 'Sign in to continue your IELTS prep journey.',
+        },
+        '/login/email': {
+          title: 'Sign in with email',
+          subtitle: 'Use your email and password to access your account.',
+        },
+        '/login/phone': {
+          title: 'Sign in with phone',
+          subtitle: 'Get a one-time code on your phone and continue securely.',
+        },
+        '/login/password': {
+          title: 'Set new password',
+          subtitle: 'Create a secure password to protect your account.',
+        },
+        '/signup': {
+          title: 'Create your account',
+          subtitle: 'Choose a sign-up method and start improving your band score.',
+        },
+        '/signup/index': {
+          title: 'Create your account',
+          subtitle: 'Choose a sign-up method and start improving your band score.',
+        },
+        '/signup/email': {
+          title: 'Sign up with email',
+          subtitle: 'Create your account using email verification.',
+        },
+        '/signup/phone': {
+          title: 'Sign up with phone',
+          subtitle: 'Create your account with a secure SMS verification code.',
+        },
+        '/signup/password': {
+          title: 'Create password',
+          subtitle: 'Set a strong password to finish your account setup.',
+        },
+        '/signup/verify': {
+          title: 'Verify your email',
+          subtitle: 'Check your inbox and confirm your email to continue.',
+        },
+        '/auth/forgot': {
+          title: 'Forgot password',
+          subtitle: 'We will send a reset link to your email address.',
+        },
+        '/auth/reset': {
+          title: 'Reset password',
+          subtitle: 'Choose a new password and sign in again.',
+        },
+        '/auth/verify': {
+          title: 'Email verification',
+          subtitle: 'Finalizing your verification and secure sign-in.',
+        },
+        '/auth/confirm': {
+          title: 'Confirm your email',
+          subtitle: 'We are validating your email confirmation link.',
+        },
+        '/auth/mfa': {
+          title: 'Two-factor authentication',
+          subtitle: 'Enter the 6-digit code from your authenticator app.',
+        },
+        '/forgot-password': {
+          title: 'Forgot password',
+          subtitle: 'We will send a reset link to your email address.',
+        },
+        '/update-password': {
+          title: 'Update password',
+          subtitle: 'Set a new password and get back into your account.',
+        },
       };
 
       const copy = authCopy[router.pathname] ?? {
@@ -339,7 +429,11 @@ export function AppLayoutManager({
         subtitle: 'Secure sign in and sign up experience across all devices.',
       };
 
-      return <AuthLayout title={copy.title} subtitle={copy.subtitle}>{content}</AuthLayout>;
+      return (
+        <AuthLayout title={copy.title} subtitle={copy.subtitle}>
+          {content}
+        </AuthLayout>
+      );
     }
     if (proctoring) return <ProctoringLayout>{content}</ProctoringLayout>;
     return content;
@@ -370,7 +464,6 @@ export function AppLayoutManager({
     children,
     guardFallback,
   ]);
-
 
   // -----------------------
   // Final Layout Wrap

--- a/components/layouts/ExamResourceLayout.tsx
+++ b/components/layouts/ExamResourceLayout.tsx
@@ -1,6 +1,7 @@
 // components/layouts/ExamResourceLayout.tsx
 import * as React from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { Header } from '@/components/Header';
 import Footer from '@/components/Footer';
 import { Container } from '@/components/design-system/Container';
@@ -11,7 +12,15 @@ type Props = {
   children: React.ReactNode;
 };
 
+const titleByPath: Record<string, string> = {
+  '/exam-day': 'Exam day playbook',
+  '/exam/rehearsal': 'Exam rehearsal',
+};
+
 export default function ExamResourceLayout({ title, children }: Props) {
+  const router = useRouter();
+  const resolvedTitle = title ?? titleByPath[router.pathname] ?? 'Exam resources';
+
   return (
     <>
       <Header />
@@ -22,7 +31,7 @@ export default function ExamResourceLayout({ title, children }: Props) {
               <p className="text-caption uppercase tracking-[0.12em] text-muted-foreground">
                 IELTS exam resources
               </p>
-              <h1 className="text-h3 font-semibold">{title ?? 'Exam resources'}</h1>
+              <h1 className="text-h3 font-semibold">{resolvedTitle}</h1>
             </div>
             <div className="flex flex-wrap gap-2">
               <Button asChild size="sm" variant="outline">

--- a/components/layouts/WritingLayout.tsx
+++ b/components/layouts/WritingLayout.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import clsx from 'clsx';
+
+import { Badge } from '@/components/design-system/Badge';
+import { Container } from '@/components/design-system/Container';
+import { PLANS } from '@/types/pricing';
+import { hasPlan } from '@/lib/planAccess';
+import { usePlan } from '@/hooks/usePlan';
+
+const NAV_ITEMS: Array<{
+  id: 'overview' | 'library' | 'progress';
+  label: string;
+  description: string;
+  href: string;
+}> = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    description: 'Study window, readiness, and focus',
+    href: '/writing/overview',
+  },
+  {
+    id: 'library',
+    label: 'Prompt library',
+    description: 'Filters, curated sets, and AI tools',
+    href: '/writing/library',
+  },
+  {
+    id: 'progress',
+    label: 'Progress',
+    description: 'Drafts, submissions, and feedback',
+    href: '/writing/progress',
+  },
+];
+
+const planBadgeCopy = {
+  free: 'Explorer access',
+  starter: 'Seedling access',
+  booster: 'Rocket access',
+  master: 'Owl access',
+} as const;
+
+export default function WritingLayout({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const { plan } = usePlan();
+  const planInfo = PLANS[plan] ?? PLANS.free;
+  const aiUnlocked = hasPlan(plan, 'master');
+
+  const current: 'overview' | 'library' | 'progress' = router.pathname.includes('/library')
+    ? 'library'
+    : router.pathname.includes('/progress')
+      ? 'progress'
+      : 'overview';
+
+  return (
+    <Container className="relative py-10 sm:py-14">
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.08),_transparent_55%)]"
+        aria-hidden
+      />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 sm:px-6 lg:px-0">
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <Badge variant="soft" tone="default" size="sm">
+              {planBadgeCopy[plan] ?? 'Explorer access'}
+            </Badge>
+            <h1 className="text-3xl font-semibold text-foreground sm:text-4xl">Writing studio</h1>
+            <p className="max-w-2xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              Draft confidently, unlock targeted drills, and review detailed scoring for IELTS Task
+              1 and Task 2.
+              {aiUnlocked
+                ? ' Your Owl plan includes instant AI prompt generation and deeper analytics.'
+                : ' Upgrade to Owl to unlock instant AI prompt generation and deeper analytics.'}
+            </p>
+          </div>
+          <Badge variant="outline" tone="info" size="sm" className="self-start sm:self-auto">
+            {planInfo.name}
+          </Badge>
+        </header>
+
+        <nav aria-label="Writing studio sections" className="overflow-x-auto">
+          <ul className="flex min-w-full gap-3 rounded-2xl border border-border/60 bg-card/70 p-2 shadow-inner">
+            {NAV_ITEMS.map((item) => {
+              const isActive = item.id === current;
+              return (
+                <li key={item.id} className="min-w-[12rem] flex-1">
+                  <Link
+                    href={item.href}
+                    className={clsx(
+                      'group flex h-full flex-col gap-1 rounded-xl border px-4 py-3 text-left transition-colors',
+                      isActive
+                        ? 'border-primary/60 bg-primary/10 text-foreground shadow-sm'
+                        : 'border-transparent bg-transparent text-muted-foreground hover:border-border/70 hover:bg-card/60',
+                    )}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    <span
+                      className={clsx(
+                        'text-sm font-semibold',
+                        isActive ? 'text-foreground' : 'text-foreground/80',
+                      )}
+                    >
+                      {item.label}
+                    </span>
+                    <span className="text-xs text-muted-foreground">{item.description}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+
+        <div className="space-y-8 pb-8 sm:space-y-10">{children}</div>
+      </div>
+    </Container>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -164,6 +164,7 @@ function useRouteAccessCheck(pathname: string, role?: string | null) {
 
 // ---------- Inner app ----------
 function InnerApp({ Component, pageProps }: AppProps) {
+  // Architecture note: Pages must not self-wrap with app shell layouts.
   const router = useRouter();
   const pathname = router.pathname;
   const { locale: activeLocale } = useLocale();
@@ -332,15 +333,21 @@ export default function App(props: AppProps) {
           </SWRConfig>
         </NotificationProvider>
       </ToastProvider>
-      <div className="fixed right-4 top-4 z-[90]"><LanguageSwitcher /></div>
+      <div className="fixed right-4 top-4 z-[90]">
+        <LanguageSwitcher />
+      </div>
       <CookieConsentBanner />
       <SpeedInsights />
     </LocaleProvider>
   );
 }
 
-
-export function reportWebVitals(metric: { id: string; name: string; value: number; label: string }) {
+export function reportWebVitals(metric: {
+  id: string;
+  name: string;
+  value: number;
+  label: string;
+}) {
   if (typeof window === 'undefined') return;
 
   const payload = JSON.stringify({

--- a/pages/admin/analytics.tsx
+++ b/pages/admin/analytics.tsx
@@ -1,6 +1,5 @@
 import type { NextPage } from 'next';
 import useSWR from 'swr';
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 
 const fetcher = async (url: string) => {
   const res = await fetch(url, { credentials: 'include' });
@@ -13,46 +12,46 @@ const AdminAnalyticsPage: NextPage = () => {
   const metrics = (data?.metrics ?? []) as Array<any>;
 
   return (
-    <DashboardLayout>
-      <section className="space-y-4">
-        <h1 className="text-2xl font-semibold">Admin Analytics</h1>
-        <p className="text-sm text-muted-foreground">Daily KPIs for growth, revenue, engagement, and AI usage.</p>
+    <section className="space-y-4">
+      <h1 className="text-2xl font-semibold">Admin Analytics</h1>
+      <p className="text-sm text-muted-foreground">
+        Daily KPIs for growth, revenue, engagement, and AI usage.
+      </p>
 
-        {error ? <p className="text-sm text-red-500">Failed to load analytics.</p> : null}
-        {isLoading ? <p className="text-sm text-muted-foreground">Loading…</p> : null}
+      {error ? <p className="text-sm text-red-500">Failed to load analytics.</p> : null}
+      {isLoading ? <p className="text-sm text-muted-foreground">Loading…</p> : null}
 
-        <div className="overflow-x-auto rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
-          <table className="min-w-full text-sm">
-            <thead>
-              <tr className="text-left text-muted-foreground">
-                <th className="px-2 py-2">Day</th>
-                <th className="px-2 py-2">DAU</th>
-                <th className="px-2 py-2">Signups</th>
-                <th className="px-2 py-2">Conversion</th>
-                <th className="px-2 py-2">Churn</th>
-                <th className="px-2 py-2">MRR</th>
-                <th className="px-2 py-2">AI Requests</th>
-                <th className="px-2 py-2">Avg Score</th>
+      <div className="overflow-x-auto rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="px-2 py-2">Day</th>
+              <th className="px-2 py-2">DAU</th>
+              <th className="px-2 py-2">Signups</th>
+              <th className="px-2 py-2">Conversion</th>
+              <th className="px-2 py-2">Churn</th>
+              <th className="px-2 py-2">MRR</th>
+              <th className="px-2 py-2">AI Requests</th>
+              <th className="px-2 py-2">Avg Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {metrics.map((row) => (
+              <tr key={row.day} className="border-t border-border/50">
+                <td className="px-2 py-2">{row.day}</td>
+                <td className="px-2 py-2">{row.dau}</td>
+                <td className="px-2 py-2">{row.new_signups}</td>
+                <td className="px-2 py-2">{Number(row.conversion_rate ?? 0).toFixed(2)}%</td>
+                <td className="px-2 py-2">{Number(row.churn_rate ?? 0).toFixed(2)}%</td>
+                <td className="px-2 py-2">${Number(row.mrr ?? 0).toFixed(2)}</td>
+                <td className="px-2 py-2">{row.total_ai_requests}</td>
+                <td className="px-2 py-2">{Number(row.avg_test_score ?? 0).toFixed(2)}</td>
               </tr>
-            </thead>
-            <tbody>
-              {metrics.map((row) => (
-                <tr key={row.day} className="border-t border-border/50">
-                  <td className="px-2 py-2">{row.day}</td>
-                  <td className="px-2 py-2">{row.dau}</td>
-                  <td className="px-2 py-2">{row.new_signups}</td>
-                  <td className="px-2 py-2">{Number(row.conversion_rate ?? 0).toFixed(2)}%</td>
-                  <td className="px-2 py-2">{Number(row.churn_rate ?? 0).toFixed(2)}%</td>
-                  <td className="px-2 py-2">${Number(row.mrr ?? 0).toFixed(2)}</td>
-                  <td className="px-2 py-2">{row.total_ai_requests}</td>
-                  <td className="px-2 py-2">{Number(row.avg_test_score ?? 0).toFixed(2)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-    </DashboardLayout>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   );
 };
 

--- a/pages/dashboard/ai-reports.tsx
+++ b/pages/dashboard/ai-reports.tsx
@@ -1,15 +1,14 @@
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 
 export default function ai_reportsPage() {
   return (
-    <DashboardLayout>
+    <>
       <h1 className="text-2xl font-semibold">Ai reports</h1>
       <Card>
         <p className="text-sm text-slate-500 dark:text-slate-400">
           This module is now aligned with the enterprise dashboard architecture.
         </p>
       </Card>
-    </DashboardLayout>
+    </>
   );
 }

--- a/pages/dashboard/billing.tsx
+++ b/pages/dashboard/billing.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useSubscription } from '@/hooks/useSubscription';
@@ -9,27 +8,31 @@ export default function BillingPage() {
   const subscription = useSubscription();
 
   return (
-    <DashboardLayout>
-      <div className="space-y-4">
-        <h1 className="text-2xl font-semibold">Billing</h1>
-        <Card>
-          <div className="space-y-3 p-4">
-            <p className="text-sm text-slate-500 dark:text-slate-400">Current plan: {subscription.displayPlan.name}</p>
-            <p className="text-sm text-slate-500 dark:text-slate-400">Status: {subscription.statusLabel}</p>
-            {subscription.renewsAtLabel ? (
-              <p className="text-sm text-slate-500 dark:text-slate-400">Renews: {subscription.renewsAtLabel}</p>
-            ) : null}
-            <div className="space-y-2">
-              <UsageMeter feature="ai.explain" label="AI Explain" />
-              <UsageMeter feature="ai.summary" label="AI Summary" />
-              <UsageMeter feature="ai.writing.score" label="AI Writing Score" />
-            </div>
-            <Link href="/profile/account/billing">
-              <Button>Manage in billing portal</Button>
-            </Link>
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Billing</h1>
+      <Card>
+        <div className="space-y-3 p-4">
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Current plan: {subscription.displayPlan.name}
+          </p>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Status: {subscription.statusLabel}
+          </p>
+          {subscription.renewsAtLabel ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Renews: {subscription.renewsAtLabel}
+            </p>
+          ) : null}
+          <div className="space-y-2">
+            <UsageMeter feature="ai.explain" label="AI Explain" />
+            <UsageMeter feature="ai.summary" label="AI Summary" />
+            <UsageMeter feature="ai.writing.score" label="AI Writing Score" />
           </div>
-        </Card>
-      </div>
-    </DashboardLayout>
+          <Link href="/profile/account/billing">
+            <Button>Manage in billing portal</Button>
+          </Link>
+        </div>
+      </Card>
+    </div>
   );
 }

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { useMemo, useState } from 'react';
 import useSWR from 'swr';
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import useDashboard, {
   useEstimatedBandScore,
   useImprovementGraph,
@@ -43,19 +42,22 @@ const DashboardPage: NextPage = () => {
   const { data: prediction } = useSWR('/api/prediction', fetcher);
   const [whatIfWriting, setWhatIfWriting] = useState(7);
   const whatIfPayload = useMemo(() => ({ writing: whatIfWriting }), [whatIfWriting]);
-  const { data: whatIf } = useSWR(['/api/prediction/what-if', whatIfPayload], async ([url, payload]) => {
-    const res = await fetch(url, {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (!res.ok) throw new Error('what_if_failed');
-    return res.json();
-  });
+  const { data: whatIf } = useSWR(
+    ['/api/prediction/what-if', whatIfPayload],
+    async ([url, payload]) => {
+      const res = await fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('what_if_failed');
+      return res.json();
+    },
+  );
 
   return (
-    <DashboardLayout>
+    <>
       <section className="space-y-6">
         <header className="space-y-2">
           <h1 className="text-2xl font-semibold">AI Learning Dashboard</h1>
@@ -72,23 +74,42 @@ const DashboardPage: NextPage = () => {
 
         <div className="grid gap-4 md:grid-cols-3">
           <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Predicted Band Score</p>
-            <p className="mt-2 text-3xl font-semibold">{typeof prediction?.predictedBand === 'number' ? prediction.predictedBand.toFixed(1) : typeof score === 'number' ? score.toFixed(1) : '—'}</p>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Predicted Band Score
+            </p>
+            <p className="mt-2 text-3xl font-semibold">
+              {typeof prediction?.predictedBand === 'number'
+                ? prediction.predictedBand.toFixed(1)
+                : typeof score === 'number'
+                  ? score.toFixed(1)
+                  : '—'}
+            </p>
             <p className="mt-1 text-xs text-muted-foreground">
-              Confidence ±{typeof prediction?.confidenceInterval === 'number' ? prediction.confidenceInterval : 0.5} · Trend: {prediction?.trend ?? 'stable'}
+              Confidence ±
+              {typeof prediction?.confidenceInterval === 'number'
+                ? prediction.confidenceInterval
+                : 0.5}{' '}
+              · Trend: {prediction?.trend ?? 'stable'}
             </p>
           </article>
 
           <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Study Streak</p>
             <p className="mt-2 text-3xl font-semibold">🔥 {streak} days</p>
-            <p className="mt-1 text-xs text-muted-foreground">Consistency is the fastest path to target band gains.</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Consistency is the fastest path to target band gains.
+            </p>
           </article>
 
           <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Billing & Usage</p>
-            <p className="mt-2 text-sm text-muted-foreground">Track plan usage meters and invoices in one place.</p>
-            <Link href="/settings/billing" className="mt-3 inline-flex text-sm font-medium text-indigo-600 hover:underline">
+            <p className="mt-2 text-sm text-muted-foreground">
+              Track plan usage meters and invoices in one place.
+            </p>
+            <Link
+              href="/settings/billing"
+              className="mt-3 inline-flex text-sm font-medium text-indigo-600 hover:underline"
+            >
               Open billing transparency panel
             </Link>
           </article>
@@ -105,7 +126,10 @@ const DashboardPage: NextPage = () => {
                     <span>{item.score.toFixed(1)}/10</span>
                   </div>
                   <div className="h-2 rounded bg-slate-200 dark:bg-slate-700">
-                    <div className="h-2 rounded bg-indigo-500" style={{ width: `${Math.max(0, Math.min(100, item.score * 10))}%` }} />
+                    <div
+                      className="h-2 rounded bg-indigo-500"
+                      style={{ width: `${Math.max(0, Math.min(100, item.score * 10))}%` }}
+                    />
                   </div>
                 </div>
               ))}
@@ -119,7 +143,9 @@ const DashboardPage: NextPage = () => {
                 <p className="font-medium text-emerald-600">Strengths</p>
                 <ul className="mt-1 space-y-1 text-muted-foreground">
                   {strengths.map((s) => (
-                    <li key={s.skill}>{s.skill} ({s.score.toFixed(1)})</li>
+                    <li key={s.skill}>
+                      {s.skill} ({s.score.toFixed(1)})
+                    </li>
                   ))}
                 </ul>
               </div>
@@ -127,7 +153,9 @@ const DashboardPage: NextPage = () => {
                 <p className="font-medium text-amber-600">Weaknesses</p>
                 <ul className="mt-1 space-y-1 text-muted-foreground">
                   {weaknesses.map((s) => (
-                    <li key={s.skill}>{s.skill} ({s.score.toFixed(1)})</li>
+                    <li key={s.skill}>
+                      {s.skill} ({s.score.toFixed(1)})
+                    </li>
                   ))}
                 </ul>
               </div>
@@ -138,22 +166,31 @@ const DashboardPage: NextPage = () => {
         <section className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm">
           <TrendChart
             title="Improvement Graph"
-            points={(points.length ? points : [{ label: 'No data', band: 0 }]).map((p) => ({ label: p.label, value: p.band }))}
+            points={(points.length ? points : [{ label: 'No data', band: 0 }]).map((p) => ({
+              label: p.label,
+              value: p.band,
+            }))}
           />
         </section>
 
         <section className="grid gap-4 lg:grid-cols-3">
           <article className="rounded-2xl border border-border/70 bg-card/80 p-4 shadow-sm lg:col-span-2">
             <h2 className="text-base font-semibold">Recommended for You</h2>
-            <p className="mt-1 text-xs text-muted-foreground">Today&apos;s recommendations based on your latest skill profile.</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Today&apos;s recommendations based on your latest skill profile.
+            </p>
             <div className="mt-3 space-y-2">
               {(recommendations?.nextExercises ?? []).slice(0, 5).map((item: any) => (
                 <div key={item.taskId} className="rounded-lg border border-border/60 p-2 text-sm">
                   <p className="font-medium">{item.title}</p>
-                  <p className="text-xs text-muted-foreground">{item.module} · {item.type} · {item.reason}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {item.module} · {item.type} · {item.reason}
+                  </p>
                 </div>
               ))}
-              {!(recommendations?.nextExercises ?? []).length ? <p className="text-xs text-muted-foreground">No personalized exercises yet.</p> : null}
+              {!(recommendations?.nextExercises ?? []).length ? (
+                <p className="text-xs text-muted-foreground">No personalized exercises yet.</p>
+              ) : null}
             </div>
           </article>
 
@@ -169,16 +206,30 @@ const DashboardPage: NextPage = () => {
               onChange={(event) => setWhatIfWriting(Number(event.target.value))}
               className="mt-3 w-full"
             />
-            <p className="mt-2 text-sm">Writing target: <span className="font-semibold">{whatIfWriting.toFixed(1)}</span></p>
-            <p className="mt-1 text-sm">Predicted: <span className="font-semibold">{typeof whatIf?.predictedBand === 'number' ? whatIf.predictedBand.toFixed(1) : '—'}</span></p>
-            <p className="mt-1 text-xs text-emerald-600">Potential uplift: {typeof whatIf?.uplift === 'number' ? `${whatIf.uplift >= 0 ? '+' : ''}${whatIf.uplift.toFixed(2)}` : '—'}</p>
+            <p className="mt-2 text-sm">
+              Writing target: <span className="font-semibold">{whatIfWriting.toFixed(1)}</span>
+            </p>
+            <p className="mt-1 text-sm">
+              Predicted:{' '}
+              <span className="font-semibold">
+                {typeof whatIf?.predictedBand === 'number' ? whatIf.predictedBand.toFixed(1) : '—'}
+              </span>
+            </p>
+            <p className="mt-1 text-xs text-emerald-600">
+              Potential uplift:{' '}
+              {typeof whatIf?.uplift === 'number'
+                ? `${whatIf.uplift >= 0 ? '+' : ''}${whatIf.uplift.toFixed(2)}`
+                : '—'}
+            </p>
           </article>
         </section>
 
-        {isLoading ? <p className="text-xs text-muted-foreground">Loading dashboard analytics…</p> : null}
+        {isLoading ? (
+          <p className="text-xs text-muted-foreground">Loading dashboard analytics…</p>
+        ) : null}
       </section>
       <AICommandCenter />
-    </DashboardLayout>
+    </>
   );
 };
 

--- a/pages/dashboard/progress.tsx
+++ b/pages/dashboard/progress.tsx
@@ -1,10 +1,9 @@
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 import { VocabInsightsCards } from '@/components/quiz/VocabInsightsCards';
 
 export default function progressPage() {
   return (
-    <DashboardLayout>
+    <div className="space-y-4">
       <h1 className="text-2xl font-semibold">Progress</h1>
       <Card>
         <p className="text-sm text-slate-500 dark:text-slate-400">
@@ -12,6 +11,6 @@ export default function progressPage() {
         </p>
       </Card>
       <VocabInsightsCards />
-    </DashboardLayout>
+    </div>
   );
 }

--- a/pages/dashboard/reading.tsx
+++ b/pages/dashboard/reading.tsx
@@ -1,15 +1,14 @@
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 
 export default function readingPage() {
   return (
-    <DashboardLayout>
+    <>
       <h1 className="text-2xl font-semibold">Reading</h1>
       <Card>
         <p className="text-sm text-slate-500 dark:text-slate-400">
           This module is now aligned with the enterprise dashboard architecture.
         </p>
       </Card>
-    </DashboardLayout>
+    </>
   );
 }

--- a/pages/dashboard/speaking.tsx
+++ b/pages/dashboard/speaking.tsx
@@ -1,15 +1,14 @@
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 
 export default function speakingPage() {
   return (
-    <DashboardLayout>
+    <>
       <h1 className="text-2xl font-semibold">Speaking</h1>
       <Card>
         <p className="text-sm text-slate-500 dark:text-slate-400">
           This module is now aligned with the enterprise dashboard architecture.
         </p>
       </Card>
-    </DashboardLayout>
+    </>
   );
 }

--- a/pages/dashboard/writing.tsx
+++ b/pages/dashboard/writing.tsx
@@ -1,15 +1,14 @@
-import { DashboardLayout } from '@/components/layouts/DashboardLayout';
 import { Card } from '@/components/ui/Card';
 
 export default function writingPage() {
   return (
-    <DashboardLayout>
+    <>
       <h1 className="text-2xl font-semibold">Writing</h1>
       <Card>
         <p className="text-sm text-slate-500 dark:text-slate-400">
           This module is now aligned with the enterprise dashboard architecture.
         </p>
       </Card>
-    </DashboardLayout>
+    </>
   );
 }

--- a/pages/exam-day.tsx
+++ b/pages/exam-day.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import Link from 'next/link';
-import ExamResourceLayout from '@/components/layouts/ExamResourceLayout';
 
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
@@ -45,10 +44,9 @@ export default function ExamDayPage() {
         />
       </Head>
 
-      <ExamResourceLayout title="Exam day playbook">
-        <section className="bg-lightBg py-0 dark:bg-transparent">
-          <Container>
-            <div className="mx-auto grid max-w-5xl gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+      <section className="bg-lightBg py-0 dark:bg-transparent">
+        <Container>
+          <div className="mx-auto grid max-w-5xl gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
             <article className="space-y-6 rounded-ds-2xl bg-card/70 p-6 shadow-lg shadow-black/5 backdrop-blur">
               <header className="space-y-3">
                 <span className="inline-flex items-center rounded-full bg-primary/10 px-4 py-1 text-small font-medium text-primary">
@@ -56,8 +54,9 @@ export default function ExamDayPage() {
                 </span>
                 <h1 className="font-slab text-h2">Exam day playbook</h1>
                 <p className="text-body text-mutedText">
-                  Use this focused checklist to keep exam morning calm, intentional, and aligned with how you practised.
-                  You&apos;ve already put in the work—today is about execution.
+                  Use this focused checklist to keep exam morning calm, intentional, and aligned
+                  with how you practised. You&apos;ve already put in the work—today is about
+                  execution.
                 </p>
               </header>
 
@@ -70,7 +69,8 @@ export default function ExamDayPage() {
               <Card className="space-y-4 rounded-ds-2xl p-6">
                 <h2 className="font-slab text-h4">Launch a final mock</h2>
                 <p className="text-small text-mutedText">
-                  A quick mock keeps pacing sharp and reminds you of the timing rhythm before the real thing.
+                  A quick mock keeps pacing sharp and reminds you of the timing rhythm before the
+                  real thing.
                 </p>
                 <Button asChild size="lg" fullWidth>
                   <Link href="/mock">Start a mock exam</Link>
@@ -89,10 +89,9 @@ export default function ExamDayPage() {
                 </ul>
               </Card>
             </aside>
-            </div>
-          </Container>
-        </section>
-      </ExamResourceLayout>
+          </div>
+        </Container>
+      </section>
     </>
   );
 }

--- a/pages/exam/rehearsal.tsx
+++ b/pages/exam/rehearsal.tsx
@@ -2,17 +2,14 @@ import DeviceCheck from '@/components/exam/DeviceCheck';
 import TimingRehearsal from '@/components/exam/TimingRehearsal';
 import AnxietyScripts from '@/components/exam/AnxietyScripts';
 import ExamChecklist from '@/components/exam/ExamChecklist';
-import ExamResourceLayout from '@/components/layouts/ExamResourceLayout';
 
 export default function ExamRehearsalPage() {
   return (
-    <ExamResourceLayout title="Exam rehearsal">
-      <div className="space-y-8">
-        <DeviceCheck />
-        <TimingRehearsal />
-        <AnxietyScripts />
-        <ExamChecklist />
-      </div>
-    </ExamResourceLayout>
+    <div className="space-y-8">
+      <DeviceCheck />
+      <TimingRehearsal />
+      <AnxietyScripts />
+      <ExamChecklist />
+    </div>
   );
 }

--- a/pages/writing/library.tsx
+++ b/pages/writing/library.tsx
@@ -9,7 +9,6 @@ import { Icon } from '@/components/design-system/Icon';
 import { Input } from '@/components/design-system/Input';
 import { Select } from '@/components/design-system/Select';
 import { Separator } from '@/components/design-system/Separator';
-import { WritingLayout } from '@/layouts/WritingLayout';
 import { withPlan } from '@/lib/plan/withPlan';
 import { getServerClient } from '@/lib/supabaseServer';
 import type { PlanId } from '@/types/pricing';
@@ -68,7 +67,9 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
     sortPromptCards(prompts.map((prompt) => ({ ...prompt, source: prompt.source ?? 'library' }))),
   );
   useEffect(() => {
-    setPromptLibrary(sortPromptCards(prompts.map((prompt) => ({ ...prompt, source: prompt.source ?? 'library' }))));
+    setPromptLibrary(
+      sortPromptCards(prompts.map((prompt) => ({ ...prompt, source: prompt.source ?? 'library' }))),
+    );
   }, [prompts]);
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -103,7 +104,8 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
         return false;
       }
       if (query) {
-        const haystack = `${prompt.topic} ${prompt.outlineSummary ?? ''} ${(prompt.outlineItems ?? []).join(' ')}`.toLowerCase();
+        const haystack =
+          `${prompt.topic} ${prompt.outlineSummary ?? ''} ${(prompt.outlineItems ?? []).join(' ')}`.toLowerCase();
         if (!haystack.includes(query)) {
           return false;
         }
@@ -112,7 +114,8 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
     });
   }, [difficultyFilter, promptLibrary, searchTerm, taskFilter]);
 
-  const hasFiltersActive = searchTerm.trim().length > 0 || taskFilter !== 'all' || difficultyFilter !== 'all';
+  const hasFiltersActive =
+    searchTerm.trim().length > 0 || taskFilter !== 'all' || difficultyFilter !== 'all';
 
   const resetFilters = useCallback(() => {
     setSearchTerm('');
@@ -140,7 +143,9 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
         source: prompt.source ?? 'library',
       }));
       setPromptLibrary(sortPromptCards(mapped));
-      setAnnouncement(`Prompt library refreshed. Showing ${mapped.length} prompt${mapped.length === 1 ? '' : 's'}.`);
+      setAnnouncement(
+        `Prompt library refreshed. Showing ${mapped.length} prompt${mapped.length === 1 ? '' : 's'}.`,
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unable to refresh prompts';
       setLibraryError(message);
@@ -194,8 +199,12 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
         });
 
         const addedCount = generated.length;
-        setGeneratorMessage(`Added ${addedCount} new prompt${addedCount === 1 ? '' : 's'} to your library.`);
-        setAnnouncement(`Added ${addedCount} new prompt${addedCount === 1 ? '' : 's'} to your library.`);
+        setGeneratorMessage(
+          `Added ${addedCount} new prompt${addedCount === 1 ? '' : 's'} to your library.`,
+        );
+        setAnnouncement(
+          `Added ${addedCount} new prompt${addedCount === 1 ? '' : 's'} to your library.`,
+        );
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unable to generate prompts';
         setGeneratorError(message);
@@ -208,7 +217,7 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
   );
 
   return (
-    <WritingLayout plan={__plan} current="library">
+    <>
       <div aria-live="polite" role="status" className="sr-only">
         {announcement}
       </div>
@@ -266,7 +275,13 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
             </Select>
           </div>
           <div className="flex flex-wrap gap-2">
-            <Button type="button" variant="ghost" size="sm" onClick={resetFilters} disabled={!hasFiltersActive}>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={resetFilters}
+              disabled={!hasFiltersActive}
+            >
               Clear
             </Button>
             <Button
@@ -310,11 +325,18 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
                 </div>
                 <div className="space-y-2">
                   <h3 className="text-lg font-semibold text-foreground">{prompt.topic}</h3>
-                  {prompt.outlineSummary && <p className="line-clamp-4 text-sm text-muted-foreground">{prompt.outlineSummary}</p>}
+                  {prompt.outlineSummary && (
+                    <p className="line-clamp-4 text-sm text-muted-foreground">
+                      {prompt.outlineSummary}
+                    </p>
+                  )}
                   {rocketUnlocked && prompt.outlineItems && prompt.outlineItems.length > 0 && (
                     <ul className="space-y-1 text-xs text-muted-foreground">
                       {prompt.outlineItems.slice(0, 3).map((item, index) => (
-                        <li key={`${prompt.id}-outline-${index}`} className="flex items-start gap-2">
+                        <li
+                          key={`${prompt.id}-outline-${index}`}
+                          className="flex items-start gap-2"
+                        >
                           <Icon name="check" size={12} className="mt-0.5 text-primary" />
                           <span>{item}</span>
                         </li>
@@ -323,7 +345,10 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
                   )}
                   {rocketUnlocked && prompt.createdAt && (
                     <p className="text-xs text-muted-foreground">
-                      Updated {new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(prompt.createdAt))}
+                      Updated{' '}
+                      {new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(
+                        new Date(prompt.createdAt),
+                      )}
                     </p>
                   )}
                 </div>
@@ -351,7 +376,8 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold text-foreground">AI prompt generator</h2>
             <p className="text-sm text-muted-foreground">
-              Craft fresh prompts tailored to your focus area. New prompts appear at the top of your library instantly.
+              Craft fresh prompts tailored to your focus area. New prompts appear at the top of your
+              library instantly.
             </p>
           </div>
           <Badge variant="soft" tone={aiUnlocked ? 'success' : 'default'} size="sm">
@@ -360,14 +386,20 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
         </div>
         {!aiUnlocked && (
           <div className="rounded-2xl border border-dashed border-border/60 bg-muted/40 p-4 text-sm text-muted-foreground">
-            Upgrade to Owl for unlimited prompt generation with Groq/OpenAI models and curated fallbacks.
+            Upgrade to Owl for unlimited prompt generation with Groq/OpenAI models and curated
+            fallbacks.
           </div>
         )}
         <form className="grid gap-4 md:grid-cols-2" onSubmit={handleGeneratePrompts}>
           <Select
             label="How many prompts?"
             value={generatorOptions.count}
-            onChange={(event) => setGeneratorOptions((prev) => ({ ...prev, count: Number(event.target.value) as 1 | 3 | 5 }))}
+            onChange={(event) =>
+              setGeneratorOptions((prev) => ({
+                ...prev,
+                count: Number(event.target.value) as 1 | 3 | 5,
+              }))
+            }
             disabled={!aiUnlocked}
           >
             {countOptions.map((option) => (
@@ -379,7 +411,12 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
           <Select
             label="Task"
             value={generatorOptions.task}
-            onChange={(event) => setGeneratorOptions((prev) => ({ ...prev, task: event.target.value as WritingTaskType }))}
+            onChange={(event) =>
+              setGeneratorOptions((prev) => ({
+                ...prev,
+                task: event.target.value as WritingTaskType,
+              }))
+            }
             disabled={!aiUnlocked}
           >
             <option value="task1">Task 1</option>
@@ -389,7 +426,10 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
             label="Difficulty"
             value={String(generatorOptions.difficulty)}
             onChange={(event) =>
-              setGeneratorOptions((prev) => ({ ...prev, difficulty: Number(event.target.value) as typeof prev.difficulty }))
+              setGeneratorOptions((prev) => ({
+                ...prev,
+                difficulty: Number(event.target.value) as typeof prev.difficulty,
+              }))
             }
             disabled={!aiUnlocked}
           >
@@ -403,19 +443,28 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
             label="Theme (optional)"
             placeholder="Sustainability, public health, …"
             value={generatorOptions.theme}
-            onChange={(event) => setGeneratorOptions((prev) => ({ ...prev, theme: event.target.value }))}
+            onChange={(event) =>
+              setGeneratorOptions((prev) => ({ ...prev, theme: event.target.value }))
+            }
             disabled={!aiUnlocked}
           />
           <Input
             label="Style hints (optional)"
             placeholder="Formal tone, emphasise comparisons, …"
             value={generatorOptions.style}
-            onChange={(event) => setGeneratorOptions((prev) => ({ ...prev, style: event.target.value }))}
+            onChange={(event) =>
+              setGeneratorOptions((prev) => ({ ...prev, style: event.target.value }))
+            }
             className="md:col-span-2"
             disabled={!aiUnlocked}
           />
           <div className="md:col-span-2 flex flex-wrap gap-3">
-            <Button type="submit" variant="primary" disabled={!aiUnlocked} loading={generatorLoading}>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={!aiUnlocked}
+              loading={generatorLoading}
+            >
               Generate prompts
             </Button>
             <Button
@@ -440,14 +489,17 @@ const WritingPromptLibrary = ({ prompts, total, __plan }: LibraryPageProps) => {
         {generatorMessage && <p className="text-sm text-success">{generatorMessage}</p>}
         <Separator />
         <p className="text-xs text-muted-foreground">
-          Generated prompts are stored in your personal library. Refresh above to ensure filters include the latest additions.
+          Generated prompts are stored in your personal library. Refresh above to ensure filters
+          include the latest additions.
         </p>
       </Card>
-    </WritingLayout>
+    </>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<LibraryPageProps> = withPlan('starter')(async (ctx) => {
+export const getServerSideProps: GetServerSideProps<LibraryPageProps> = withPlan('starter')(async (
+  ctx,
+) => {
   const supabase = getServerClient(ctx.req as any, ctx.res as any);
   const {
     data: { user },

--- a/pages/writing/overview.tsx
+++ b/pages/writing/overview.tsx
@@ -8,7 +8,6 @@ import { Card } from '@/components/design-system/Card';
 import { EmptyState } from '@/components/design-system/EmptyState';
 import { ProgressBar } from '@/components/design-system/ProgressBar';
 import { Separator } from '@/components/design-system/Separator';
-import { WritingLayout } from '@/layouts/WritingLayout';
 import { withPlan } from '@/lib/plan/withPlan';
 import { getServerClient } from '@/lib/supabaseServer';
 import type { Database } from '@/types/supabase';
@@ -51,9 +50,10 @@ export const ActionButton = ({ to, children, ...rest }: ActionButtonProps) =>
   );
 
 // OverviewCard provides a single place to change card surface for overview pages.
-export const OverviewCard: React.FC<React.PropsWithChildren<{ className?: string }>> = ({ children, className = '' }) => (
-  <Card className={`card-surface p-6 sm:p-8 ${className}`}>{children}</Card>
-);
+export const OverviewCard: React.FC<React.PropsWithChildren<{ className?: string }>> = ({
+  children,
+  className = '',
+}) => <Card className={`card-surface p-6 sm:p-8 ${className}`}>{children}</Card>;
 
 export const StatItem: React.FC<{
   label: string;
@@ -67,27 +67,49 @@ export const StatItem: React.FC<{
         <span>{label}</span>
         <span className="font-semibold text-foreground">{value}</span>
       </div>
-      {typeof progress === 'number' && <ProgressBar value={progress} tone="info" ariaLabel={`${label} progress`} />}
+      {typeof progress === 'number' && (
+        <ProgressBar value={progress} tone="info" ariaLabel={`${label} progress`} />
+      )}
       {meta && <div className="text-xs text-muted-foreground">{meta}</div>}
     </div>
   );
 };
 
-export const AttemptCard: React.FC<{ attempt: AttemptSummary; compact?: boolean }> = ({ attempt, compact = false }) => {
+export const AttemptCard: React.FC<{ attempt: AttemptSummary; compact?: boolean }> = ({
+  attempt,
+  compact = false,
+}) => {
   return (
-    <li className={`flex flex-col gap-3 rounded-2xl border border-border/60 bg-card/70 p-5 shadow-sm transition-transform ${compact ? 'sm:flex-row sm:items-center' : ''}`}>
+    <li
+      className={`flex flex-col gap-3 rounded-2xl border border-border/60 bg-card/70 p-5 shadow-sm transition-transform ${compact ? 'sm:flex-row sm:items-center' : ''}`}
+    >
       <div className="flex-1">
         <p className="text-sm font-medium text-foreground">{attempt.promptTopic}</p>
-        <p className="text-xs text-muted-foreground">Updated {new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(attempt.updatedAt))}</p>
+        <p className="text-xs text-muted-foreground">
+          Updated{' '}
+          {new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(
+            new Date(attempt.updatedAt),
+          )}
+        </p>
       </div>
 
       <div className="mt-3 flex items-center gap-3 text-sm text-muted-foreground sm:mt-0 sm:flex-col sm:items-end">
         <span>{attempt.wordCount} words</span>
-        {attempt.overallBand ? <span className="font-semibold text-foreground">Band {attempt.overallBand.toFixed(1)}</span> : <span>Awaiting score</span>}
+        {attempt.overallBand ? (
+          <span className="font-semibold text-foreground">
+            Band {attempt.overallBand.toFixed(1)}
+          </span>
+        ) : (
+          <span>Awaiting score</span>
+        )}
       </div>
 
       <div className="mt-3 flex gap-2 sm:mt-0">
-        <ActionButton size="sm" variant="outline" to={`/writing/${attempt.promptSlug}?attemptId=${attempt.id}`}>
+        <ActionButton
+          size="sm"
+          variant="outline"
+          to={`/writing/${attempt.promptSlug}?attemptId=${attempt.id}`}
+        >
           View
         </ActionButton>
         {attempt.hasFeedback && (
@@ -109,9 +131,12 @@ const progressPercentage = (value: number, target: number) => {
   return Math.max(0, Math.min(100, Math.round((value / target) * 100)));
 };
 
-const formatDate = (value: string) => new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value));
+const formatDate = (value: string) =>
+  new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value));
 const formatDateTime = (value: string) =>
-  new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+  new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(
+    new Date(value),
+  );
 
 const statusLabel: Record<AttemptSummary['status'], string> = {
   draft: 'Draft in progress',
@@ -122,11 +147,13 @@ const statusLabel: Record<AttemptSummary['status'], string> = {
 const planLimitCopy: Record<PlanId, { label: string; description: string }> = {
   free: {
     label: 'Explorer preview',
-    description: 'Upgrade to Seedling to unlock the full library with filters and drill recommendations.',
+    description:
+      'Upgrade to Seedling to unlock the full library with filters and drill recommendations.',
   },
   starter: {
     label: '100 prompts unlocked',
-    description: 'Browse the 100 most recent prompts curated for Seedling plans with smart filters.',
+    description:
+      'Browse the 100 most recent prompts curated for Seedling plans with smart filters.',
   },
   booster: {
     label: '500 detailed prompts',
@@ -166,7 +193,13 @@ interface OverviewPageProps {
   __plan: PlanId;
 }
 
-const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }: OverviewPageProps) => {
+const WritingOverview = ({
+  readiness,
+  planSummary,
+  microPrompt,
+  stats,
+  __plan,
+}: OverviewPageProps) => {
   const [microPromptState, setMicroPromptState] = useState(microPrompt);
   const [microPromptLoading, setMicroPromptLoading] = useState(false);
   const [microPromptError, setMicroPromptError] = useState<string | null>(null);
@@ -178,23 +211,55 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
   const planTargets = RETAKE_PLAN_TARGETS;
 
   const planProgressItems = useMemo(
-    () => [
-      { key: 'redrafts', label: 'Redrafts completed', value: planSummary.redraftsCompleted, target: planTargets.redrafts },
-      { key: 'drills', label: 'Micro-drills logged', value: planSummary.drillsCompleted, target: planTargets.drills },
-      { key: 'mocks', label: 'Mock attempts reviewed', value: planSummary.mocksCompleted, target: planTargets.mocks },
-    ] as const,
-    [planSummary.drillsCompleted, planSummary.mocksCompleted, planSummary.redraftsCompleted, planTargets.drills, planTargets.mocks, planTargets.redrafts],
+    () =>
+      [
+        {
+          key: 'redrafts',
+          label: 'Redrafts completed',
+          value: planSummary.redraftsCompleted,
+          target: planTargets.redrafts,
+        },
+        {
+          key: 'drills',
+          label: 'Micro-drills logged',
+          value: planSummary.drillsCompleted,
+          target: planTargets.drills,
+        },
+        {
+          key: 'mocks',
+          label: 'Mock attempts reviewed',
+          value: planSummary.mocksCompleted,
+          target: planTargets.mocks,
+        },
+      ] as const,
+    [
+      planSummary.drillsCompleted,
+      planSummary.mocksCompleted,
+      planSummary.redraftsCompleted,
+      planTargets.drills,
+      planTargets.mocks,
+      planTargets.redrafts,
+    ],
   );
 
   const refreshMicroPrompt = useCallback(async () => {
     try {
       const response = await fetch('/api/writing/notifications/micro-prompt');
       const payload = (await response.json()) as
-        | ({ ok: true; message: string; lastSentAt: string | null; channels: string[]; canSendWhatsApp: boolean; alreadySentToday: boolean; retakeReminder: OverviewPageProps['microPrompt']['retakeReminder'] })
-        | ({ ok: false; error: string });
+        | {
+            ok: true;
+            message: string;
+            lastSentAt: string | null;
+            channels: string[];
+            canSendWhatsApp: boolean;
+            alreadySentToday: boolean;
+            retakeReminder: OverviewPageProps['microPrompt']['retakeReminder'];
+          }
+        | { ok: false; error: string };
 
       if (!response.ok || !payload || !('ok' in payload) || !payload.ok) {
-        const reason = !payload || !('error' in payload) ? 'Unable to refresh micro prompt' : payload.error;
+        const reason =
+          !payload || !('error' in payload) ? 'Unable to refresh micro prompt' : payload.error;
         throw new Error(reason);
       }
 
@@ -241,7 +306,7 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
   const currentPlanCopy = planLimitCopy[__plan];
 
   return (
-    <WritingLayout plan={__plan} current="overview">
+    <>
       <div aria-live="polite" role="status" className="sr-only">
         {announcement}
       </div>
@@ -255,9 +320,12 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
             </Badge>
 
             <div className="space-y-3">
-              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">Your writing overview</h2>
+              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+                Your writing overview
+              </h2>
               <p className="text-base leading-relaxed text-muted-foreground sm:text-lg">
-                Track readiness, review reminders, and hop into focused drills. Use the navigation above to explore the full prompt library and analyze your history.
+                Track readiness, review reminders, and hop into focused drills. Use the navigation
+                above to explore the full prompt library and analyze your history.
               </p>
             </div>
 
@@ -274,7 +342,9 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
             </div>
 
             {!passReadiness && missingSummary.length > 0 && (
-              <p className="text-sm text-muted-foreground">Unlock redrafts by completing: {missingSummary.join(', ')}</p>
+              <p className="text-sm text-muted-foreground">
+                Unlock redrafts by completing: {missingSummary.join(', ')}
+              </p>
             )}
           </div>
 
@@ -282,7 +352,8 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
             <div className="flex items-center justify-between">
               <span className="font-medium text-foreground">Study window</span>
               <Badge variant="default" tone="info" size="sm">
-                {formatDate(planSummary.windowStart)} &ndash; {planSummary.windowEnd ? formatDate(planSummary.windowEnd) : 'TBD'}
+                {formatDate(planSummary.windowStart)} &ndash;{' '}
+                {planSummary.windowEnd ? formatDate(planSummary.windowEnd) : 'TBD'}
               </Badge>
             </div>
 
@@ -291,7 +362,11 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
             <ul className="space-y-3">
               {planProgressItems.map((item) => (
                 <li key={item.key} className="space-y-2">
-                  <StatItem label={item.label} value={`${item.value}/${item.target}`} progress={progressPercentage(item.value, item.target)} />
+                  <StatItem
+                    label={item.label}
+                    value={`${item.value}/${item.target}`}
+                    progress={progressPercentage(item.value, item.target)}
+                  />
                 </li>
               ))}
             </ul>
@@ -317,8 +392,12 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
           </div>
 
           <div className="mt-4 flex flex-wrap gap-3">
-            <ActionButton variant="primary" to="/writing/library">Open prompt library</ActionButton>
-            <ActionButton variant="ghost" to="/pricing?need=starter">Upgrade plans</ActionButton>
+            <ActionButton variant="primary" to="/writing/library">
+              Open prompt library
+            </ActionButton>
+            <ActionButton variant="ghost" to="/pricing?need=starter">
+              Upgrade plans
+            </ActionButton>
           </div>
         </OverviewCard>
 
@@ -326,21 +405,33 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
           <div className="flex items-start justify-between gap-3">
             <div>
               <h3 className="text-xl font-semibold text-foreground">Daily micro prompt</h3>
-              <p className="text-sm text-muted-foreground">A quick nudge to sharpen today&apos;s session.</p>
+              <p className="text-sm text-muted-foreground">
+                A quick nudge to sharpen today&apos;s session.
+              </p>
             </div>
-            <Badge variant="default" tone="info" size="sm">Updated daily</Badge>
+            <Badge variant="default" tone="info" size="sm">
+              Updated daily
+            </Badge>
           </div>
 
-          <div className="mt-3 rounded-2xl border border-dashed border-border/50 bg-muted/50 p-3 text-sm text-foreground">{microPromptState.message}</div>
+          <div className="mt-3 rounded-2xl border border-dashed border-border/50 bg-muted/50 p-3 text-sm text-foreground">
+            {microPromptState.message}
+          </div>
 
           {microPromptState.retakeReminder && (
-            <div className="mt-3 rounded-2xl border border-dashed border-border/40 bg-card/60 p-3 text-xs text-muted-foreground">{microPromptState.retakeReminder.message}</div>
+            <div className="mt-3 rounded-2xl border border-dashed border-border/40 bg-card/60 p-3 text-xs text-muted-foreground">
+              {microPromptState.retakeReminder.message}
+            </div>
           )}
 
           {microPromptError && <p className="mt-2 text-sm text-danger">{microPromptError}</p>}
 
           <div className="mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-            <span>{microPromptState.lastSentAt ? `Last nudged ${formatDateTime(microPromptState.lastSentAt)}` : 'Not delivered yet today'}</span>
+            <span>
+              {microPromptState.lastSentAt
+                ? `Last nudged ${formatDateTime(microPromptState.lastSentAt)}`
+                : 'Not delivered yet today'}
+            </span>
             {!microPromptState.canSendWhatsApp && (
               <span>
                 WhatsApp nudges require opt-in &mdash; manage in{' '}
@@ -353,13 +444,25 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
           </div>
 
           <div className="mt-3 flex flex-wrap items-center gap-3">
-            <ActionButton size="sm" variant="primary" onClick={handleSendMicroPrompt} disabled={microPromptState.alreadySentToday && !microPromptLoading} loading={microPromptLoading}>
+            <ActionButton
+              size="sm"
+              variant="primary"
+              onClick={handleSendMicroPrompt}
+              disabled={microPromptState.alreadySentToday && !microPromptLoading}
+              loading={microPromptLoading}
+            >
               {microPromptState.alreadySentToday ? 'Sent for today' : 'Send reminder now'}
             </ActionButton>
-            <ActionButton size="sm" variant="ghost" onClick={refreshMicroPrompt}>Refresh tip</ActionButton>
+            <ActionButton size="sm" variant="ghost" onClick={refreshMicroPrompt}>
+              Refresh tip
+            </ActionButton>
           </div>
 
-          {microPromptState.alreadySentToday && <p className="mt-2 text-xs text-muted-foreground">Tip already delivered today &mdash; check back tomorrow for a fresh cue.</p>}
+          {microPromptState.alreadySentToday && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Tip already delivered today &mdash; check back tomorrow for a fresh cue.
+            </p>
+          )}
         </OverviewCard>
       </section>
 
@@ -369,25 +472,37 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
           <div className="flex items-center justify-between gap-3">
             <div>
               <h3 className="text-xl font-semibold text-foreground">Active drafts</h3>
-              <p className="text-sm text-muted-foreground">Pick up where you left off with autosaved work.</p>
+              <p className="text-sm text-muted-foreground">
+                Pick up where you left off with autosaved work.
+              </p>
             </div>
-            <Badge variant="default" tone="default" size="sm">{stats.activeDrafts} active</Badge>
+            <Badge variant="default" tone="default" size="sm">
+              {stats.activeDrafts} active
+            </Badge>
           </div>
 
           <div className="mt-4">
             {stats.recentAttempts.filter((a) => a.status !== 'scored').length === 0 ? (
-              <EmptyState title="No active drafts" description="Start a new attempt or revisit a scored attempt to launch a redraft." />
+              <EmptyState
+                title="No active drafts"
+                description="Start a new attempt or revisit a scored attempt to launch a redraft."
+              />
             ) : (
               <ul className="space-y-4">
-                {stats.recentAttempts.filter((a) => a.status !== 'scored').slice(0, 3).map((attempt) => (
-                  <AttemptCard key={attempt.id} attempt={attempt} />
-                ))}
+                {stats.recentAttempts
+                  .filter((a) => a.status !== 'scored')
+                  .slice(0, 3)
+                  .map((attempt) => (
+                    <AttemptCard key={attempt.id} attempt={attempt} />
+                  ))}
               </ul>
             )}
           </div>
 
           <div className="mt-4">
-            <ActionButton variant="ghost" to="/writing/progress">View full progress</ActionButton>
+            <ActionButton variant="ghost" to="/writing/progress">
+              View full progress
+            </ActionButton>
           </div>
         </OverviewCard>
 
@@ -395,21 +510,34 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
           <div className="flex items-center justify-between gap-3">
             <div>
               <h3 className="text-xl font-semibold text-foreground">Recent submissions</h3>
-              <p className="text-sm text-muted-foreground">See what you submitted recently and track your scores.</p>
+              <p className="text-sm text-muted-foreground">
+                See what you submitted recently and track your scores.
+              </p>
             </div>
-            <Badge variant="default" tone="default" size="sm">Last {Math.min(stats.recentAttempts.length, 6)}</Badge>
+            <Badge variant="default" tone="default" size="sm">
+              Last {Math.min(stats.recentAttempts.length, 6)}
+            </Badge>
           </div>
 
           <div className="mt-4">
             {stats.recentAttempts.length === 0 ? (
-              <EmptyState title="No attempts yet" description="Submit an essay to unlock AI feedback and trend tracking." />
+              <EmptyState
+                title="No attempts yet"
+                description="Submit an essay to unlock AI feedback and trend tracking."
+              />
             ) : (
-              <ul className="space-y-4">{stats.recentAttempts.slice(0, 6).map((attempt) => <AttemptCard key={attempt.id} attempt={attempt} />)}</ul>
+              <ul className="space-y-4">
+                {stats.recentAttempts.slice(0, 6).map((attempt) => (
+                  <AttemptCard key={attempt.id} attempt={attempt} />
+                ))}
+              </ul>
             )}
           </div>
 
           <div className="mt-4">
-            <ActionButton variant="ghost" to="/writing/progress">View all attempts</ActionButton>
+            <ActionButton variant="ghost" to="/writing/progress">
+              View all attempts
+            </ActionButton>
           </div>
         </OverviewCard>
       </section>
@@ -419,42 +547,69 @@ const WritingOverview = ({ readiness, planSummary, microPrompt, stats, __plan }:
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h3 className="text-xl font-semibold text-foreground">Boost your next attempt</h3>
-            <p className="text-sm text-muted-foreground">Layer drills, reviews, and mock feedback to sharpen your routine.</p>
+            <p className="text-sm text-muted-foreground">
+              Layer drills, reviews, and mock feedback to sharpen your routine.
+            </p>
           </div>
-          <Badge variant="default" tone="info" size="sm">Curated resources</Badge>
+          <Badge variant="default" tone="info" size="sm">
+            Curated resources
+          </Badge>
         </div>
 
         <div className="mt-4 grid gap-4 md:grid-cols-3">
-          <Link href="/writing/drills" className="group block rounded-2xl border border-border/60 bg-card/60 p-4 transition hover:border-primary/60 hover:bg-card">
+          <Link
+            href="/writing/drills"
+            className="group block rounded-2xl border border-border/60 bg-card/60 p-4 transition hover:border-primary/60 hover:bg-card"
+          >
             <div className="flex flex-col h-full">
               <span className="text-sm font-semibold text-foreground">Skill drills</span>
-              <span className="mt-2 text-sm text-muted-foreground">Target coherence, task achievement, and grammar with 10-minute micro drills.</span>
-              <span className="mt-auto text-sm font-medium text-primary group-hover:underline">Visit drills</span>
+              <span className="mt-2 text-sm text-muted-foreground">
+                Target coherence, task achievement, and grammar with 10-minute micro drills.
+              </span>
+              <span className="mt-auto text-sm font-medium text-primary group-hover:underline">
+                Visit drills
+              </span>
             </div>
           </Link>
 
-          <Link href="/writing/reviews" className="group block rounded-2xl border border-border/60 bg-card/60 p-4 transition hover:border-primary/60 hover:bg-card">
+          <Link
+            href="/writing/reviews"
+            className="group block rounded-2xl border border-border/60 bg-card/60 p-4 transition hover:border-primary/60 hover:bg-card"
+          >
             <div className="flex flex-col h-full">
               <span className="text-sm font-semibold text-foreground">AI reviews</span>
-              <span className="mt-2 text-sm text-muted-foreground">Compare attempts, highlight improvements, and plan your next rewrite.</span>
-              <span className="mt-auto text-sm font-medium text-primary group-hover:underline">Open reviews</span>
+              <span className="mt-2 text-sm text-muted-foreground">
+                Compare attempts, highlight improvements, and plan your next rewrite.
+              </span>
+              <span className="mt-auto text-sm font-medium text-primary group-hover:underline">
+                Open reviews
+              </span>
             </div>
           </Link>
 
-          <Link href="/writing/drills?tab=mocks" className="group block rounded-2xl border border-border/60 bg-card/60 p-4 transition hover:border-primary/60 hover:bg-card">
+          <Link
+            href="/writing/drills?tab=mocks"
+            className="group block rounded-2xl border border-border/60 bg-card/60 p-4 transition hover:border-primary/60 hover:bg-card"
+          >
             <div className="flex flex-col h-full">
               <span className="text-sm font-semibold text-foreground">Mock library</span>
-              <span className="mt-2 text-sm text-muted-foreground">Revisit scored mocks, analyse feedback themes, and schedule your next redraft.</span>
-              <span className="mt-auto text-sm font-medium text-primary group-hover:underline">Browse mocks</span>
+              <span className="mt-2 text-sm text-muted-foreground">
+                Revisit scored mocks, analyse feedback themes, and schedule your next redraft.
+              </span>
+              <span className="mt-auto text-sm font-medium text-primary group-hover:underline">
+                Browse mocks
+              </span>
             </div>
           </Link>
         </div>
       </OverviewCard>
-    </WritingLayout>
+    </>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<OverviewPageProps> = withPlan('starter')(async (ctx) => {
+export const getServerSideProps: GetServerSideProps<OverviewPageProps> = withPlan('starter')(async (
+  ctx,
+) => {
   const supabase = getServerClient(ctx.req as any, ctx.res as any);
   const {
     data: { user },
@@ -472,7 +627,9 @@ export const getServerSideProps: GetServerSideProps<OverviewPageProps> = withPla
   const [{ data: attemptRows }, { data: readinessRow }] = await Promise.all([
     supabase
       .from('writing_attempts')
-      .select('id, prompt_id, status, updated_at, word_count, overall_band, task_type, feedback_json, writing_prompts (slug, topic)')
+      .select(
+        'id, prompt_id, status, updated_at, word_count, overall_band, task_type, feedback_json, writing_prompts (slug, topic)',
+      )
       .eq('user_id', user.id)
       .order('updated_at', { ascending: false })
       .limit(12),
@@ -488,7 +645,10 @@ export const getServerSideProps: GetServerSideProps<OverviewPageProps> = withPla
   const attempts = (attemptRows ?? []).map((row) =>
     mapAttemptRow({
       ...row,
-      prompt: row.writing_prompts as Pick<Database['public']['Tables']['writing_prompts']['Row'], 'slug' | 'topic'> | null,
+      prompt: row.writing_prompts as Pick<
+        Database['public']['Tables']['writing_prompts']['Row'],
+        'slug' | 'topic'
+      > | null,
     }),
   );
 
@@ -502,34 +662,36 @@ export const getServerSideProps: GetServerSideProps<OverviewPageProps> = withPla
           readinessRow.status === 'pass'
             ? []
             : Array.isArray(gates?.missing)
-            ? ((gates?.missing as string[]) ?? [])
-            : [],
+              ? ((gates?.missing as string[]) ?? [])
+              : [],
       }
     : null;
 
-  const planWindowStart = readinessRow?.window_start ?? new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  const planWindowStart =
+    readinessRow?.window_start ?? new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
   const planWindowEnd = readinessRow?.window_end ?? null;
 
-  const [{ count: planDrillsCount }, { count: redraftCount }, { count: mockCount }] = await Promise.all([
-    supabase
-      .from('writing_drill_events')
-      .select('*', { count: 'exact', head: true })
-      .eq('user_id', user.id)
-      .gte('completed_at', planWindowStart),
-    supabase
-      .from('writing_attempts')
-      .select('*', { count: 'exact', head: true })
-      .eq('user_id', user.id)
-      .not('version_of', 'is', null)
-      .gte('created_at', planWindowStart),
-    supabase
-      .from('writing_attempts')
-      .select('*', { count: 'exact', head: true })
-      .eq('user_id', user.id)
-      .is('version_of', null)
-      .eq('status', 'scored')
-      .gte('created_at', planWindowStart),
-  ]);
+  const [{ count: planDrillsCount }, { count: redraftCount }, { count: mockCount }] =
+    await Promise.all([
+      supabase
+        .from('writing_drill_events')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .gte('completed_at', planWindowStart),
+      supabase
+        .from('writing_attempts')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .not('version_of', 'is', null)
+        .gte('created_at', planWindowStart),
+      supabase
+        .from('writing_attempts')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .is('version_of', null)
+        .eq('status', 'scored')
+        .gte('created_at', planWindowStart),
+    ]);
 
   const [{ data: profileRow }, { data: lastMicroPrompt }] = await Promise.all([
     supabase

--- a/pages/writing/progress.tsx
+++ b/pages/writing/progress.tsx
@@ -5,8 +5,7 @@ import { Badge } from '@/components/design-system/Badge';
 import { Button } from '@/components/design-system/Button';
 import { Card } from '@/components/design-system/Card';
 import { EmptyState } from '@/components/design-system/EmptyState';
-import { WritingLayout } from '@/layouts/WritingLayout';
-import {   withPlan } from '@/lib/plan/withPlan';
+import { withPlan } from '@/lib/plan/withPlan';
 import { getServerClient } from '@/lib/supabaseServer';
 import type { Database } from '@/types/supabase';
 import type { PlanId } from '@/types/pricing';
@@ -20,7 +19,9 @@ const statusLabel: Record<AttemptSummary['status'], string> = {
 };
 
 const formatDateTime = (value: string) =>
-  new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+  new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(
+    new Date(value),
+  );
 
 interface ProgressPageProps {
   drafts: AttemptSummary[];
@@ -29,23 +30,32 @@ interface ProgressPageProps {
 }
 
 const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
-  const totalWords = useMemo(() => recent.reduce((sum, attempt) => sum + attempt.wordCount, 0), [recent]);
-  const scoredAttempts = useMemo(() => recent.filter((attempt) => attempt.status === 'scored'), [recent]);
+  const totalWords = useMemo(
+    () => recent.reduce((sum, attempt) => sum + attempt.wordCount, 0),
+    [recent],
+  );
+  const scoredAttempts = useMemo(
+    () => recent.filter((attempt) => attempt.status === 'scored'),
+    [recent],
+  );
   const averageBand = useMemo(() => {
-    const scoredBands = scoredAttempts.map((attempt) => attempt.overallBand ?? 0).filter((band) => band > 0);
+    const scoredBands = scoredAttempts
+      .map((attempt) => attempt.overallBand ?? 0)
+      .filter((band) => band > 0);
     if (scoredBands.length === 0) return null;
     const avg = scoredBands.reduce((sum, band) => sum + band, 0) / scoredBands.length;
     return avg;
   }, [scoredAttempts]);
 
   return (
-    <WritingLayout plan={__plan} current="progress">
+    <>
       <Card className="card-surface flex flex-col gap-6 p-6 sm:p-8">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold text-foreground">Attempt insights</h2>
             <p className="text-sm text-muted-foreground">
-              Track drafts in progress, revisit recent submissions, and spot opportunities for the next rewrite.
+              Track drafts in progress, revisit recent submissions, and spot opportunities for the
+              next rewrite.
             </p>
           </div>
           <Badge variant="soft" tone="default" size="sm">
@@ -54,22 +64,34 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
         </div>
         <div className="grid gap-4 sm:grid-cols-3">
           <div className="rounded-2xl border border-border/60 bg-muted/40 p-4">
-            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Words logged</p>
+            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+              Words logged
+            </p>
             <p className="text-2xl font-semibold text-foreground">{totalWords.toLocaleString()}</p>
-            <p className="text-xs text-muted-foreground">Across the last {recent.length} attempts</p>
+            <p className="text-xs text-muted-foreground">
+              Across the last {recent.length} attempts
+            </p>
           </div>
           <div className="rounded-2xl border border-border/60 bg-muted/40 p-4">
-            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Scored attempts</p>
+            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+              Scored attempts
+            </p>
             <p className="text-2xl font-semibold text-foreground">{scoredAttempts.length}</p>
-            <p className="text-xs text-muted-foreground">{scoredAttempts.length > 0 ? 'Ready for deeper review' : 'Submit drafts for scoring'}</p>
+            <p className="text-xs text-muted-foreground">
+              {scoredAttempts.length > 0 ? 'Ready for deeper review' : 'Submit drafts for scoring'}
+            </p>
           </div>
           <div className="rounded-2xl border border-border/60 bg-muted/40 p-4">
-            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Average band</p>
+            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+              Average band
+            </p>
             <p className="text-2xl font-semibold text-foreground">
               {averageBand ? averageBand.toFixed(1) : '—'}
             </p>
             <p className="text-xs text-muted-foreground">
-              {averageBand ? 'Based on scored attempts in the last 90 days' : 'Complete scored attempts to unlock band trends'}
+              {averageBand
+                ? 'Based on scored attempts in the last 90 days'
+                : 'Complete scored attempts to unlock band trends'}
             </p>
           </div>
         </div>
@@ -80,7 +102,9 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
           <div className="flex items-center justify-between gap-3">
             <div>
               <h3 className="text-xl font-semibold text-foreground">Continue drafts</h3>
-              <p className="text-sm text-muted-foreground">Pick up where you left off with autosaved work.</p>
+              <p className="text-sm text-muted-foreground">
+                Pick up where you left off with autosaved work.
+              </p>
             </div>
             <Badge variant="soft" tone="default" size="sm">
               {drafts.length} active
@@ -101,7 +125,9 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
                       <p className="text-sm font-medium text-foreground">{attempt.promptTopic}</p>
-                      <p className="text-xs text-muted-foreground">Updated {formatDateTime(attempt.updatedAt)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        Updated {formatDateTime(attempt.updatedAt)}
+                      </p>
                     </div>
                     <Badge variant="soft" tone="info" size="sm" className="capitalize">
                       {attempt.taskType === 'task1' ? 'Task 1' : 'Task 2'}
@@ -112,7 +138,11 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
                     <span>{statusLabel[attempt.status]}</span>
                   </div>
                   <div className="flex flex-wrap gap-2">
-                    <Button size="sm" variant="primary" href={`/writing/${attempt.promptSlug}?attemptId=${attempt.id}`}>
+                    <Button
+                      size="sm"
+                      variant="primary"
+                      href={`/writing/${attempt.promptSlug}?attemptId=${attempt.id}`}
+                    >
                       Resume draft
                     </Button>
                     <Button size="sm" variant="ghost" href={`/writing/${attempt.promptSlug}`}>
@@ -129,7 +159,9 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
           <div className="flex items-center justify-between gap-3">
             <div>
               <h3 className="text-xl font-semibold text-foreground">Recent attempts</h3>
-              <p className="text-sm text-muted-foreground">See what you submitted recently and track your scores.</p>
+              <p className="text-sm text-muted-foreground">
+                See what you submitted recently and track your scores.
+              </p>
             </div>
             <Badge variant="soft" tone="default" size="sm">
               Last {recent.length}
@@ -150,22 +182,34 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
                   <div className="flex flex-wrap items-center justify-between gap-2">
                     <div>
                       <p className="text-sm font-medium text-foreground">{attempt.promptTopic}</p>
-                      <p className="text-xs text-muted-foreground">{formatDateTime(attempt.updatedAt)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatDateTime(attempt.updatedAt)}
+                      </p>
                     </div>
-                    <Badge variant="soft" tone={attempt.status === 'scored' ? 'success' : 'info'} size="sm">
+                    <Badge
+                      variant="soft"
+                      tone={attempt.status === 'scored' ? 'success' : 'info'}
+                      size="sm"
+                    >
                       {statusLabel[attempt.status]}
                     </Badge>
                   </div>
                   <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
                     <span>{attempt.wordCount} words</span>
                     {attempt.overallBand ? (
-                      <span className="font-semibold text-foreground">Band {attempt.overallBand.toFixed(1)}</span>
+                      <span className="font-semibold text-foreground">
+                        Band {attempt.overallBand.toFixed(1)}
+                      </span>
                     ) : (
                       <span>Awaiting score</span>
                     )}
                   </div>
                   <div className="flex flex-wrap gap-2">
-                    <Button size="sm" variant="outline" href={`/writing/${attempt.promptSlug}?attemptId=${attempt.id}`}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      href={`/writing/${attempt.promptSlug}?attemptId=${attempt.id}`}
+                    >
                       View details
                     </Button>
                     {attempt.hasFeedback && (
@@ -186,7 +230,8 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
           <div>
             <h3 className="text-xl font-semibold text-foreground">Upgrade your analysis</h3>
             <p className="text-sm text-muted-foreground">
-              Export writing history, compare drafts side-by-side, and unlock AI prompt generation with Owl.
+              Export writing history, compare drafts side-by-side, and unlock AI prompt generation
+              with Owl.
             </p>
           </div>
           <Badge variant="soft" tone="info" size="sm">
@@ -205,11 +250,13 @@ const WritingProgress = ({ drafts, recent, __plan }: ProgressPageProps) => {
           </Button>
         </div>
       </Card>
-    </WritingLayout>
+    </>
   );
 };
 
-export const getServerSideProps: GetServerSideProps<ProgressPageProps> = withPlan('starter')(async (ctx) => {
+export const getServerSideProps: GetServerSideProps<ProgressPageProps> = withPlan('starter')(async (
+  ctx,
+) => {
   const supabase = getServerClient(ctx.req as any, ctx.res as any);
   const {
     data: { user },
@@ -226,7 +273,9 @@ export const getServerSideProps: GetServerSideProps<ProgressPageProps> = withPla
 
   const { data: attemptRows } = await supabase
     .from('writing_attempts')
-    .select('id, prompt_id, status, updated_at, word_count, overall_band, task_type, feedback_json, writing_prompts (slug, topic)')
+    .select(
+      'id, prompt_id, status, updated_at, word_count, overall_band, task_type, feedback_json, writing_prompts (slug, topic)',
+    )
     .eq('user_id', user.id)
     .order('updated_at', { ascending: false })
     .limit(30);
@@ -234,7 +283,10 @@ export const getServerSideProps: GetServerSideProps<ProgressPageProps> = withPla
   const attempts = (attemptRows ?? []).map((row) =>
     mapAttemptRow({
       ...row,
-      prompt: row.writing_prompts as Pick<Database['public']['Tables']['writing_prompts']['Row'], 'slug' | 'topic'> | null,
+      prompt: row.writing_prompts as Pick<
+        Database['public']['Tables']['writing_prompts']['Row'],
+        'slug' | 'topic'
+      > | null,
     }),
   );
 


### PR DESCRIPTION
### Motivation
- Reduce per-page layout coupling by centralizing shell/layout concerns in the app layout manager so pages only return their content.
- Preserve page-specific UI while moving shell-level navigation (breadcrumbs, side nav, section tabs) into layout components.
- Keep explicit no-layout exceptions (auth flows, full-screen/mock attempts) intact via existing `showChrome: false` logic.

### Description
- Added a new writing shell component `components/layouts/WritingLayout.tsx` that owns the writing header, plan badge and section tabs and wired it into the layout manager routing.
- Added `components/layouts/ExamResourceLayout.tsx` and moved exam resource header/title logic into it so `pages/exam-day.tsx` and `pages/exam/rehearsal.tsx` now return page content only.
- Updated `components/layouts/AppLayoutManager.tsx` to import and map `WritingLayout` and `ExamResourceLayout` by route and added the comment `// Architecture note: Pages must not self-wrap with app shell layouts.` near the manager entry.
- Removed direct layout wrappers from many route pages (dashboard and writing pages now return content only) and added the same architecture note to `pages/_app.tsx` as `// Architecture note: Pages must not self-wrap with app shell layouts.`

### Testing
- Ran a scoped search with ripgrep (`rg -n "from '@/components/layouts/|from '@/layouts/|<DashboardLayout|<ExamLayout|<WritingLayout|<AuthLayout" pages`) to confirm pages no longer import or self-wrap with the centralized shell layouts, which succeeded.
- Ran Prettier (`npx prettier --write`) on touched files to normalize formatting, which completed successfully for the modified files.
- Ran `git diff --check` to validate whitespace/issues, which reported no problems.
- Attempted lint (`next lint`) but it failed in this environment because the `next` binary is not available, so a full lint pass could not be executed here.
- Attempted a Playwright page snapshot to validate the running app but the local dev server was not running in this environment, producing `ERR_EMPTY_RESPONSE`, so runtime visual validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6db2d8718832fab64d559dfdbfbb6)