### PR TITLE
Fix header auth fallback and improve language selector & cookie banner UI

### DIFF
--- a/components/CookieConsentBanner.tsx
+++ b/components/CookieConsentBanner.tsx
@@ -30,17 +30,33 @@ export default function CookieConsentBanner() {
   if (consent) return null;
 
   return (
-    <aside className="fixed inset-x-4 bottom-4 z-[100] rounded-xl border border-border bg-card p-4 shadow-lg">
-      <p className="text-sm text-foreground">
-        We use essential cookies to keep GramorX secure and functional. Optional analytics cookies help us improve the platform.
-      </p>
-      <div className="mt-3 flex gap-2">
-        <button onClick={() => save('rejected')} className="rounded border border-border px-3 py-1 text-sm">
-          Reject optional
-        </button>
-        <button onClick={() => save('accepted')} className="rounded bg-primary px-3 py-1 text-sm text-primary-foreground">
-          Accept all
-        </button>
+    <aside className="fixed inset-x-3 bottom-3 z-[100] sm:inset-x-6 sm:bottom-6">
+      <div className="mx-auto max-w-3xl rounded-2xl border border-border/70 bg-card/95 p-4 shadow-2xl backdrop-blur md:p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-foreground">Cookie preferences</p>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+              We use essential cookies for sign-in and security. Optional analytics cookies help us improve the experience.
+            </p>
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={() => save('rejected')}
+              className="rounded-xl border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Reject optional
+            </button>
+            <button
+              type="button"
+              onClick={() => save('accepted')}
+              className="rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              Accept all cookies
+            </button>
+          </div>
+        </div>
       </div>
     </aside>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -28,7 +28,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
 
-  const { loading, user: contextUser } = useUserContext();
+  const { loading, user: contextUser, role: contextRole } = useUserContext();
   const {
     user: headerUser,
     role,
@@ -57,7 +57,8 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
     [contextUser, headerUser]
   );
 
-  const isHeaderReady = ready || !!contextUser?.id;
+  const effectiveRole = (role ?? contextRole ?? 'guest') as string;
+  const isHeaderReady = ready || !!contextUser?.id || Boolean(contextRole);
 
   const [hasPremiumAccess, setHasPremiumAccess] = useState(false);
   const [premiumRooms, setPremiumRooms] = useState<string[]>([]);
@@ -412,7 +413,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
               {/* Desktop nav */}
               <DesktopNav
                 user={user}
-                role={role ?? 'guest'}
+                role={effectiveRole}
                 ready={isHeaderReady}
                 streak={streakState}
                 openModules={openDesktopModules}
@@ -430,7 +431,7 @@ export const Header: React.FC<{ streak?: number }> = ({ streak }) => {
               {/* Mobile nav */}
               <MobileNav
                 user={user}
-                role={role ?? 'guest'}
+                role={effectiveRole}
                 ready={isHeaderReady}
                 streak={streakState ?? 0}
                 mobileOpen={mobileOpen}

--- a/components/navigation/DesktopNav.tsx
+++ b/components/navigation/DesktopNav.tsx
@@ -17,6 +17,7 @@ import ModuleMenu from './ModuleMenu';
 import { navigationSchema } from '@/config/navigation';
 import { filterNavItems } from '@/lib/navigation/utils';
 import type { SubscriptionTier } from '@/lib/navigation/types';
+import { useLocale } from '@/lib/locale';
 import { cn } from '@/lib/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 
@@ -63,6 +64,7 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
   onClearPremiumAccess,
   subscriptionTier,
 }) => {
+  const { locale, setLocale } = useLocale();
   const uid = user?.id ?? null;
   const isTeacher = role === 'teacher';
   const canSeePartners = role === 'partner' || role === 'admin';
@@ -331,6 +333,20 @@ export const DesktopNav: React.FC<DesktopNavProps> = ({
 
       {/* RIGHT CLUSTER: streak, notifications, theme, user */}
       <div className="flex items-center gap-3">
+        <label className="hidden xl:inline-flex items-center gap-2 rounded-full border border-border dark:border-border-dark bg-card dark:bg-card-dark px-3 py-1.5 text-xs text-muted-foreground dark:text-muted-foreground-dark">
+          <span>Lang</span>
+          <select
+            value={locale}
+            onChange={(event) => setLocale(event.target.value)}
+            className="bg-transparent text-xs font-medium text-foreground dark:text-foreground-dark outline-none"
+            aria-label="Language selector"
+          >
+            <option value="en">English</option>
+            <option value="ur">اردو</option>
+            <option value="es">Español</option>
+          </select>
+        </label>
+
         {/* Streak chip: show for authenticated users */}
         {uid && (
           <StreakChip

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -43,7 +43,6 @@ import { getRouteConfig, isAttemptPath } from '@/lib/routes/routeLayoutMap';
 
 import LoadingProvider from '@/components/loading/LoadingProvider';
 import CookieConsentBanner from '@/components/CookieConsentBanner';
-import LanguageSwitcher from '@/components/LanguageSwitcher';
 
 const PricingReasonBanner = dynamic(() => import('@/components/paywall/PricingReasonBanner'), {
   ssr: false,
@@ -335,9 +334,6 @@ export default function App(props: AppProps) {
           </SWRConfig>
         </NotificationProvider>
       </ToastProvider>
-      <div className="fixed right-4 top-4 z-[90]">
-        <LanguageSwitcher />
-      </div>
       <CookieConsentBanner />
       <SpeedInsights />
     </LocaleProvider>


### PR DESCRIPTION
### Motivation
- The header could render without knowing the authenticated role during session hydration which caused incorrect nav/sign-in behavior and layout decisions.  
- The floating top-right language switcher overlapped header actions on some viewports and needed relocating into the header.  
- The cookie consent UI required a more compliant, responsive layout and clearer copy for accept/reject actions.

### Description
- Make header role/ready resolution more robust by combining `useHeaderState` with `UserContext` role as a fallback and pass the computed `effectiveRole` into both desktop and mobile nav components (`components/Header.tsx`).
- Remove the global fixed `LanguageSwitcher` from `_app` and embed a compact language selector into the desktop header right cluster (`pages/_app.tsx`, `components/navigation/DesktopNav.tsx`).
- Replace the simple cookie banner with a redesigned responsive bottom banner with improved copy and larger, clearer action buttons (`components/CookieConsentBanner.tsx`).
- Minor UI/accessibility adjustments to classes and aria labels for the new selector and banner to reduce overlap and improve clarity (`components/navigation/DesktopNav.tsx`, `components/CookieConsentBanner.tsx`).

### Testing
- Ran `npx eslint` on the touched files which failed due to a missing local ESLint runtime dependency (`@eslint/eslintrc`), so lint pass could not be completed in this environment.  
- Attempted to run the Next dev server (`npm run dev:3001`) for visual verification but the `next` binary is not available in the environment, so runtime/manual visual checks were not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ebedee2c8320beee0405787082b5)