### PR TITLE
Add layout-grouped page inventory generator and generated report

### DIFF
--- a/docs/page-layout-status.md
+++ b/docs/page-layout-status.md
@@ -1,0 +1,426 @@
+# Page Inventory by Layout
+
+Auto-generated from `pages/**` and grouped using route layout rules from `lib/routes/routeLayoutMap.ts`.
+
+> Status is inferred automatically from file content markers (e.g., TODO/WIP/coming soon).
+
+## Admin Layout
+
+- Total pages: **31**
+- ✅ Done: **12** · 🟡 In Progress: **19** · ⚪ Not Started: **0**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/admin` | 🟡 In Progress | `pages/admin/index.tsx` |
+| `/admin/alerts` | ✅ Done | `pages/admin/alerts.tsx` |
+| `/admin/analytics` | ✅ Done | `pages/admin/analytics.tsx` |
+| `/admin/audit` | 🟡 In Progress | `pages/admin/audit.tsx` |
+| `/admin/content/reading` | 🟡 In Progress | `pages/admin/content/reading.tsx` |
+| `/admin/contracts` | 🟡 In Progress | `pages/admin/contracts.tsx` |
+| `/admin/features` | ✅ Done | `pages/admin/features.tsx` |
+| `/admin/imp-as` | ✅ Done | `pages/admin/imp-as.tsx` |
+| `/admin/investor-metrics` | ✅ Done | `pages/admin/investor-metrics.tsx` |
+| `/admin/listening` | 🟡 In Progress | `pages/admin/listening.tsx` |
+| `/admin/listening/articles` | ✅ Done | `pages/admin/listening/articles.tsx` |
+| `/admin/listening/media` | ✅ Done | `pages/admin/listening/media.tsx` |
+| `/admin/partners` | ✅ Done | `pages/admin/partners/index.tsx` |
+| `/admin/plans` | 🟡 In Progress | `pages/admin/plans.tsx` |
+| `/admin/premium/pin` | 🟡 In Progress | `pages/admin/premium/pin.tsx` |
+| `/admin/premium/promo-codes` | 🟡 In Progress | `pages/admin/premium/promo-codes.tsx` |
+| `/admin/premium/promo-usage` | 🟡 In Progress | `pages/admin/premium/promo-usage.tsx` |
+| `/admin/reading` | 🟡 In Progress | `pages/admin/reading.tsx` |
+| `/admin/reports/writing-activity` | ✅ Done | `pages/admin/reports/writing-activity.tsx` |
+| `/admin/reviews` | 🟡 In Progress | `pages/admin/reviews/index.tsx` |
+| `/admin/reviews/[attemptId]` | 🟡 In Progress | `pages/admin/reviews/[attemptId].tsx` |
+| `/admin/speaking` | 🟡 In Progress | `pages/admin/speaking/index.tsx` |
+| `/admin/speaking/attempts` | 🟡 In Progress | `pages/admin/speaking/attempts.tsx` |
+| `/admin/stop-impersonation` | ✅ Done | `pages/admin/stop-impersonation.tsx` |
+| `/admin/students` | 🟡 In Progress | `pages/admin/students/index.tsx` |
+| `/admin/teacher` | ✅ Done | `pages/admin/teacher/index.tsx` |
+| `/admin/teachers` | ✅ Done | `pages/admin/teachers/index.tsx` |
+| `/admin/users` | 🟡 In Progress | `pages/admin/users.tsx` |
+| `/admin/vocabulary/new-sense` | 🟡 In Progress | `pages/admin/vocabulary/new-sense.tsx` |
+| `/admin/writing` | 🟡 In Progress | `pages/admin/writing/index.tsx` |
+| `/admin/writing/topics` | 🟡 In Progress | `pages/admin/writing/topics.tsx` |
+
+## Auth Layout
+
+- Total pages: **17**
+- ✅ Done: **6** · 🟡 In Progress: **11** · ⚪ Not Started: **0**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/auth/callback` | ✅ Done | `pages/auth/callback.tsx` |
+| `/auth/forgot` | 🟡 In Progress | `pages/auth/forgot.tsx` |
+| `/auth/login` | ✅ Done | `pages/auth/login.tsx` |
+| `/auth/mfa` | 🟡 In Progress | `pages/auth/mfa.tsx` |
+| `/auth/reset` | 🟡 In Progress | `pages/auth/reset.tsx` |
+| `/auth/signup` | ✅ Done | `pages/auth/signup.tsx` |
+| `/forgot-password` | 🟡 In Progress | `pages/forgot-password.tsx` |
+| `/login` | ✅ Done | `pages/login/index.tsx` |
+| `/login/email` | 🟡 In Progress | `pages/login/email.tsx` |
+| `/login/password` | 🟡 In Progress | `pages/login/password.tsx` |
+| `/login/phone` | 🟡 In Progress | `pages/login/phone.tsx` |
+| `/signup` | ✅ Done | `pages/signup/index.tsx` |
+| `/signup/email` | 🟡 In Progress | `pages/signup/email.tsx` |
+| `/signup/password` | 🟡 In Progress | `pages/signup/password.tsx` |
+| `/signup/phone` | 🟡 In Progress | `pages/signup/phone.tsx` |
+| `/signup/verify` | ✅ Done | `pages/signup/verify.tsx` |
+| `/update-password` | 🟡 In Progress | `pages/update-password.tsx` |
+
+## Community Layout
+
+- Total pages: **4**
+- ✅ Done: **0** · 🟡 In Progress: **4** · ⚪ Not Started: **0**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/community` | 🟡 In Progress | `pages/community/index.tsx` |
+| `/community/chat` | 🟡 In Progress | `pages/community/chat.tsx` |
+| `/community/questions` | 🟡 In Progress | `pages/community/questions.tsx` |
+| `/community/review` | 🟡 In Progress | `pages/community/review/index.tsx` |
+
+## Dashboard Layout
+
+- Total pages: **105**
+- ✅ Done: **84** · 🟡 In Progress: **16** · ⚪ Not Started: **5**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/challenge` | ✅ Done | `pages/challenge/index.tsx` |
+| `/challenge/[cohort]` | ✅ Done | `pages/challenge/[cohort].tsx` |
+| `/coach` | ⚪ Not Started | `pages/coach/index.tsx` |
+| `/coach/[id]` | ✅ Done | `pages/coach/[id].tsx` |
+| `/dashboard` | ✅ Done | `pages/dashboard/index.tsx` |
+| `/dashboard/activity` | ⚪ Not Started | `pages/dashboard/activity/index.tsx` |
+| `/dashboard/ai-reports` | ✅ Done | `pages/dashboard/ai-reports.tsx` |
+| `/dashboard/billing` | ✅ Done | `pages/dashboard/billing.tsx` |
+| `/dashboard/progress` | ✅ Done | `pages/dashboard/progress.tsx` |
+| `/dashboard/reading` | ✅ Done | `pages/dashboard/reading.tsx` |
+| `/dashboard/speaking` | ✅ Done | `pages/dashboard/speaking.tsx` |
+| `/dashboard/writing` | ✅ Done | `pages/dashboard/writing.tsx` |
+| `/exam-day` | ✅ Done | `pages/exam-day.tsx` |
+| `/exam/rehearsal` | ✅ Done | `pages/exam/rehearsal.tsx` |
+| `/leaderboard` | ⚪ Not Started | `pages/leaderboard/index.tsx` |
+| `/mock` | ⚪ Not Started | `pages/mock/index.tsx` |
+| `/mock/[section]` | ✅ Done | `pages/mock/[section].tsx` |
+| `/mock/analytics` | ✅ Done | `pages/mock/analytics.tsx` |
+| `/mock/dashboard` | 🟡 In Progress | `pages/mock/dashboard.tsx` |
+| `/mock/full` | ⚪ Not Started | `pages/mock/full/index.tsx` |
+| `/mock/listening` | ✅ Done | `pages/mock/listening/index.tsx` |
+| `/mock/listening/[slug]` | 🟡 In Progress | `pages/mock/listening/[slug].tsx` |
+| `/mock/listening/exam/[slug]` | ✅ Done | `pages/mock/listening/exam/[slug].tsx` |
+| `/mock/listening/history` | ✅ Done | `pages/mock/listening/history/index.tsx` |
+| `/mock/listening/result` | 🟡 In Progress | `pages/mock/listening/result.tsx` |
+| `/mock/listening/result/[attemptId]` | ✅ Done | `pages/mock/listening/result/[attemptId].tsx` |
+| `/mock/listening/review` | ✅ Done | `pages/mock/listening/review.tsx` |
+| `/mock/listening/review/[attemptId]` | ✅ Done | `pages/mock/listening/review/[attemptId].tsx` |
+| `/mock/reading` | ✅ Done | `pages/mock/reading/index.tsx` |
+| `/mock/reading/[slug]` | ✅ Done | `pages/mock/reading/[slug].tsx` |
+| `/mock/reading/[slug]/result` | ✅ Done | `pages/mock/reading/[slug]/result.tsx` |
+| `/mock/reading/analytics` | ✅ Done | `pages/mock/reading/analytics.tsx` |
+| `/mock/reading/challenges` | ✅ Done | `pages/mock/reading/challenges/index.tsx` |
+| `/mock/reading/challenges/accuracy` | ✅ Done | `pages/mock/reading/challenges/accuracy.tsx` |
+| `/mock/reading/challenges/mastery` | ✅ Done | `pages/mock/reading/challenges/mastery.tsx` |
+| `/mock/reading/challenges/speed` | 🟡 In Progress | `pages/mock/reading/challenges/speed.tsx` |
+| `/mock/reading/challenges/weekly` | ✅ Done | `pages/mock/reading/challenges/weekly.tsx` |
+| `/mock/reading/daily` | ✅ Done | `pages/mock/reading/daily.tsx` |
+| `/mock/reading/drill/passage` | ✅ Done | `pages/mock/reading/drill/passage.tsx` |
+| `/mock/reading/drill/question-type` | ✅ Done | `pages/mock/reading/drill/question-type.tsx` |
+| `/mock/reading/drill/speed` | ✅ Done | `pages/mock/reading/drill/speed.tsx` |
+| `/mock/reading/feedback/[attemptId]` | 🟡 In Progress | `pages/mock/reading/feedback/[attemptId].tsx` |
+| `/mock/reading/history` | ✅ Done | `pages/mock/reading/history/index.tsx` |
+| `/mock/reading/result/[attemptId]` | ✅ Done | `pages/mock/reading/result/[attemptId].tsx` |
+| `/mock/reading/review/[attemptId]` | ✅ Done | `pages/mock/reading/review/[attemptId].tsx` |
+| `/mock/reading/techniques` | ✅ Done | `pages/mock/reading/techniques.tsx` |
+| `/mock/reading/weekly` | ✅ Done | `pages/mock/reading/weekly/index.tsx` |
+| `/mock/resume` | ✅ Done | `pages/mock/resume.tsx` |
+| `/mock/speaking` | ✅ Done | `pages/mock/speaking/index.tsx` |
+| `/mock/speaking/[id]` | ✅ Done | `pages/mock/speaking/[id].tsx` |
+| `/mock/writing` | ✅ Done | `pages/mock/writing/index.tsx` |
+| `/mock/writing/[testId]` | ✅ Done | `pages/mock/writing/[testId].tsx` |
+| `/mock/writing/result/[attemptId]` | ✅ Done | `pages/mock/writing/result/[attemptId].tsx` |
+| `/mock/writing/run` | ✅ Done | `pages/mock/writing/run.tsx` |
+| `/notifications` | 🟡 In Progress | `pages/notifications/index.tsx` |
+| `/onboarding` | 🟡 In Progress | `pages/onboarding/index.tsx` |
+| `/onboarding/baseline` | ✅ Done | `pages/onboarding/baseline.tsx` |
+| `/onboarding/diagnostic` | ✅ Done | `pages/onboarding/diagnostic.tsx` |
+| `/onboarding/exam-date` | 🟡 In Progress | `pages/onboarding/exam-date.tsx` |
+| `/onboarding/goal` | ✅ Done | `pages/onboarding/goal.tsx` |
+| `/onboarding/notifications` | ✅ Done | `pages/onboarding/notifications.tsx` |
+| `/onboarding/review` | ✅ Done | `pages/onboarding/review.tsx` |
+| `/onboarding/skills` | ✅ Done | `pages/onboarding/skills.tsx` |
+| `/onboarding/study-rhythm` | 🟡 In Progress | `pages/onboarding/study-rhythm.tsx` |
+| `/onboarding/target-band` | 🟡 In Progress | `pages/onboarding/target-band.tsx` |
+| `/onboarding/teacher` | ✅ Done | `pages/onboarding/teacher/index.tsx` |
+| `/onboarding/teacher/status` | ✅ Done | `pages/onboarding/teacher/status.tsx` |
+| `/onboarding/thinking` | ✅ Done | `pages/onboarding/thinking.tsx` |
+| `/onboarding/timeline` | 🟡 In Progress | `pages/onboarding/timeline.tsx` |
+| `/onboarding/vibe` | ✅ Done | `pages/onboarding/vibe.tsx` |
+| `/onboarding/welcome` | ✅ Done | `pages/onboarding/welcome/index.tsx` |
+| `/onboarding/welcome` | ✅ Done | `pages/onboarding/welcome.tsx` |
+| `/placement` | ✅ Done | `pages/placement/index.tsx` |
+| `/placement/result` | ✅ Done | `pages/placement/result.tsx` |
+| `/placement/run` | 🟡 In Progress | `pages/placement/run.tsx` |
+| `/placement/start` | ✅ Done | `pages/placement/start.tsx` |
+| `/practice` | ✅ Done | `pages/practice/index.tsx` |
+| `/practice/listening` | ✅ Done | `pages/practice/listening.tsx` |
+| `/practice/listening/daily` | 🟡 In Progress | `pages/practice/listening/daily.tsx` |
+| `/practice/reading` | ✅ Done | `pages/practice/reading.tsx` |
+| `/practice/speaking` | ✅ Done | `pages/practice/speaking.tsx` |
+| `/practice/writing` | ✅ Done | `pages/practice/writing.tsx` |
+| `/predictor` | ✅ Done | `pages/predictor/index.tsx` |
+| `/predictor/result` | ✅ Done | `pages/predictor/result.tsx` |
+| `/progress` | ✅ Done | `pages/progress/index.tsx` |
+| `/progress/[token]` | ✅ Done | `pages/progress/[token].tsx` |
+| `/quick` | ✅ Done | `pages/quick/index.tsx` |
+| `/quick/[skill]` | 🟡 In Progress | `pages/quick/[skill].tsx` |
+| `/restricted` | ✅ Done | `pages/restricted.tsx` |
+| `/score` | ✅ Done | `pages/score/index.tsx` |
+| `/study-plan` | ✅ Done | `pages/study-plan/index.tsx` |
+| `/study-plan/[weekId]` | ✅ Done | `pages/study-plan/[weekId].tsx` |
+| `/teacher` | ✅ Done | `pages/teacher/index.tsx` |
+| `/teacher/Welcome` | 🟡 In Progress | `pages/teacher/Welcome.tsx` |
+| `/teacher/cohorts/[id]` | ✅ Done | `pages/teacher/cohorts/[id].tsx` |
+| `/teacher/onboarding` | 🟡 In Progress | `pages/teacher/onboarding.tsx` |
+| `/teacher/pending` | ✅ Done | `pages/teacher/pending.tsx` |
+| `/teacher/register` | ✅ Done | `pages/teacher/register.tsx` |
+| `/tokens-test` | ✅ Done | `pages/tokens-test.tsx` |
+| `/whatsapp-tasks` | ✅ Done | `pages/whatsapp-tasks.tsx` |
+| `/writing/mock/[mockId]/evaluating` | ✅ Done | `pages/writing/mock/[mockId]/evaluating.tsx` |
+| `/writing/mock/[mockId]/results` | ✅ Done | `pages/writing/mock/[mockId]/results.tsx` |
+| `/writing/mock/[mockId]/review` | ✅ Done | `pages/writing/mock/[mockId]/review.tsx` |
+| `/writing/mock/[mockId]/start` | ✅ Done | `pages/writing/mock/[mockId]/start.tsx` |
+| `/writing/mock/[mockId]/workspace` | ✅ Done | `pages/writing/mock/[mockId]/workspace.tsx` |
+
+## Institutions Layout
+
+- Total pages: **5**
+- ✅ Done: **2** · 🟡 In Progress: **3** · ⚪ Not Started: **0**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/institutions` | 🟡 In Progress | `pages/institutions/index.tsx` |
+| `/institutions/[orgId]` | ✅ Done | `pages/institutions/[orgId]/index.tsx` |
+| `/institutions/[orgId]/reports` | ✅ Done | `pages/institutions/[orgId]/reports.tsx` |
+| `/institutions/[orgId]/students` | 🟡 In Progress | `pages/institutions/[orgId]/students.tsx` |
+| `/orgs` | 🟡 In Progress | `pages/orgs/index.tsx` |
+
+## Learning Layout
+
+- Total pages: **107**
+- ✅ Done: **74** · 🟡 In Progress: **28** · ⚪ Not Started: **5**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/ai` | 🟡 In Progress | `pages/ai/index.tsx` |
+| `/ai/coach` | 🟡 In Progress | `pages/ai/coach/index.tsx` |
+| `/ai/mistakes-book` | ✅ Done | `pages/ai/mistakes-book/index.tsx` |
+| `/ai/study-buddy` | 🟡 In Progress | `pages/ai/study-buddy/index.tsx` |
+| `/ai/study-buddy/session/[id]/practice` | ✅ Done | `pages/ai/study-buddy/session/[id]/practice.tsx` |
+| `/ai/study-buddy/session/[id]/summary` | 🟡 In Progress | `pages/ai/study-buddy/session/[id]/summary.tsx` |
+| `/ai/writing/[id]` | ✅ Done | `pages/ai/writing/[id].tsx` |
+| `/bookings` | ✅ Done | `pages/bookings/index.tsx` |
+| `/bookings/[id]` | ✅ Done | `pages/bookings/[id].tsx` |
+| `/cert/[id]` | ✅ Done | `pages/cert/[id].tsx` |
+| `/cert/writing/[attemptId]` | ✅ Done | `pages/cert/writing/[attemptId].tsx` |
+| `/classes` | 🟡 In Progress | `pages/classes/index.tsx` |
+| `/classes/[id]` | ✅ Done | `pages/classes/[id].tsx` |
+| `/content/studio` | 🟡 In Progress | `pages/content/studio/index.tsx` |
+| `/content/studio/[id]` | ✅ Done | `pages/content/studio/[id].tsx` |
+| `/internal/content/playground` | 🟡 In Progress | `pages/internal/content/playground.tsx` |
+| `/labs/ai-tutor` | 🟡 In Progress | `pages/labs/ai-tutor.tsx` |
+| `/learn/listening` | ✅ Done | `pages/learn/listening/index.tsx` |
+| `/learn/listening/coach` | 🟡 In Progress | `pages/learn/listening/coach.tsx` |
+| `/learn/listening/mistakes` | 🟡 In Progress | `pages/learn/listening/mistakes.tsx` |
+| `/learn/listening/tips` | 🟡 In Progress | `pages/learn/listening/tips.tsx` |
+| `/learning` | ✅ Done | `pages/learning/index.tsx` |
+| `/learning/[slug]` | ✅ Done | `pages/learning/[slug].tsx` |
+| `/learning/drills` | ✅ Done | `pages/learning/drills.tsx` |
+| `/learning/skills` | ✅ Done | `pages/learning/skills/index.tsx` |
+| `/learning/skills/[skill]` | ✅ Done | `pages/learning/skills/[skill].tsx` |
+| `/learning/skills/lessons` | ✅ Done | `pages/learning/skills/lessons/index.tsx` |
+| `/learning/skills/lessons/[slug]` | ✅ Done | `pages/learning/skills/lessons/[slug].tsx` |
+| `/learning/strategies` | 🟡 In Progress | `pages/learning/strategies/index.tsx` |
+| `/learning/strategies/[tipSlug]` | ✅ Done | `pages/learning/strategies/[tipSlug].tsx` |
+| `/listening` | ✅ Done | `pages/listening/index.tsx` |
+| `/listening/[slug]` | 🟡 In Progress | `pages/listening/[slug].tsx` |
+| `/listening/[slug]/review` | ✅ Done | `pages/listening/[slug]/review.tsx` |
+| `/reading` | ⚪ Not Started | `pages/reading/index.tsx` |
+| `/reading/[slug]` | ✅ Done | `pages/reading/[slug].tsx` |
+| `/reading/[slug]/review` | 🟡 In Progress | `pages/reading/[slug]/review.tsx` |
+| `/reading/passage/[slug]` | ✅ Done | `pages/reading/passage/[slug].tsx` |
+| `/reading/stats` | ✅ Done | `pages/reading/stats.tsx` |
+| `/review/listening/[id]` | ✅ Done | `pages/review/listening/[id].tsx` |
+| `/review/reading/[id]` | ✅ Done | `pages/review/reading/[id].tsx` |
+| `/review/share/[token]` | ✅ Done | `pages/review/share/[token].tsx` |
+| `/review/speaking/[id]` | ✅ Done | `pages/review/speaking/[id].tsx` |
+| `/review/writing/[id]` | ✅ Done | `pages/review/writing/[id].tsx` |
+| `/speaking` | ✅ Done | `pages/speaking/index.tsx` |
+| `/speaking/[promptId]` | ✅ Done | `pages/speaking/[promptId].tsx` |
+| `/speaking/attempts` | ✅ Done | `pages/speaking/attempts/index.tsx` |
+| `/speaking/attempts/[attemptId]/result` | ✅ Done | `pages/speaking/attempts/[attemptId]/result.tsx` |
+| `/speaking/buddy` | ✅ Done | `pages/speaking/buddy.tsx` |
+| `/speaking/coach` | ✅ Done | `pages/speaking/coach/index.tsx` |
+| `/speaking/coach/[slug]` | ✅ Done | `pages/speaking/coach/[slug].tsx` |
+| `/speaking/coach/free` | 🟡 In Progress | `pages/speaking/coach/free.tsx` |
+| `/speaking/library` | ✅ Done | `pages/speaking/library.tsx` |
+| `/speaking/live` | ✅ Done | `pages/speaking/live/index.tsx` |
+| `/speaking/live/[id]` | ✅ Done | `pages/speaking/live/[id].tsx` |
+| `/speaking/packs/[slug]` | ✅ Done | `pages/speaking/packs/[slug].tsx` |
+| `/speaking/partner` | 🟡 In Progress | `pages/speaking/partner.tsx` |
+| `/speaking/partner/history` | 🟡 In Progress | `pages/speaking/partner/history.tsx` |
+| `/speaking/partner/review/[attemptId]` | ✅ Done | `pages/speaking/partner/review/[attemptId].tsx` |
+| `/speaking/practice` | ✅ Done | `pages/speaking/practice.tsx` |
+| `/speaking/report` | ✅ Done | `pages/speaking/report.tsx` |
+| `/speaking/review/[id]` | 🟡 In Progress | `pages/speaking/review/[id].tsx` |
+| `/speaking/roleplay` | ✅ Done | `pages/speaking/roleplay/index.tsx` |
+| `/speaking/roleplay/[scenario]` | 🟡 In Progress | `pages/speaking/roleplay/[scenario].tsx` |
+| `/speaking/settings` | ✅ Done | `pages/speaking/settings.tsx` |
+| `/speaking/simulator` | ✅ Done | `pages/speaking/simulator/index.tsx` |
+| `/speaking/simulator/part1` | ✅ Done | `pages/speaking/simulator/part1.tsx` |
+| `/speaking/simulator/part2` | ✅ Done | `pages/speaking/simulator/part2.tsx` |
+| `/speaking/simulator/part3` | ✅ Done | `pages/speaking/simulator/part3.tsx` |
+| `/tools/listening/accent-trainer` | 🟡 In Progress | `pages/tools/listening/accent-trainer.tsx` |
+| `/tools/listening/dictation` | 🟡 In Progress | `pages/tools/listening/dictation.tsx` |
+| `/tools/mark-sections/[slug]` | 🟡 In Progress | `pages/tools/mark-sections/[slug].tsx` |
+| `/vocab` | ✅ Done | `pages/vocab/index.tsx` |
+| `/vocabulary` | ✅ Done | `pages/vocabulary/index.tsx` |
+| `/vocabulary/[word]` | ✅ Done | `pages/vocabulary/[word].tsx` |
+| `/vocabulary/ai-lab` | 🟡 In Progress | `pages/vocabulary/ai-lab.tsx` |
+| `/vocabulary/infiniteapplications` | ✅ Done | `pages/vocabulary/infiniteapplications.tsx` |
+| `/vocabulary/learned` | ✅ Done | `pages/vocabulary/learned.tsx` |
+| `/vocabulary/linking-words` | ✅ Done | `pages/vocabulary/linking-words.tsx` |
+| `/vocabulary/lists` | ✅ Done | `pages/vocabulary/lists.tsx` |
+| `/vocabulary/my-words` | 🟡 In Progress | `pages/vocabulary/my-words.tsx` |
+| `/vocabulary/quizzes` | ✅ Done | `pages/vocabulary/quizzes/index.tsx` |
+| `/vocabulary/quizzes/today` | ✅ Done | `pages/vocabulary/quizzes/today.tsx` |
+| `/vocabulary/review` | ✅ Done | `pages/vocabulary/review.tsx` |
+| `/vocabulary/saved` | ⚪ Not Started | `pages/vocabulary/saved.tsx` |
+| `/vocabulary/speaking` | ✅ Done | `pages/vocabulary/speaking/index.tsx` |
+| `/vocabulary/speaking/[topic]` | ✅ Done | `pages/vocabulary/speaking/[topic].tsx` |
+| `/vocabulary/synonyms` | ✅ Done | `pages/vocabulary/synonyms.tsx` |
+| `/vocabulary/topics` | ✅ Done | `pages/vocabulary/topics/index.tsx` |
+| `/vocabulary/topics/[topic]` | ⚪ Not Started | `pages/vocabulary/topics/[topic].tsx` |
+| `/word-of-the-day` | ✅ Done | `pages/word-of-the-day.tsx` |
+| `/writing` | ⚪ Not Started | `pages/writing/index.tsx` |
+| `/writing/[slug]` | ✅ Done | `pages/writing/[slug].tsx` |
+| `/writing/drills` | ✅ Done | `pages/writing/drills/index.tsx` |
+| `/writing/drills/[slug]` | 🟡 In Progress | `pages/writing/drills/[slug].tsx` |
+| `/writing/learn` | 🟡 In Progress | `pages/writing/learn/index.tsx` |
+| `/writing/learn/coherence` | ✅ Done | `pages/writing/learn/coherence.tsx` |
+| `/writing/learn/grammar` | ✅ Done | `pages/writing/learn/grammar.tsx` |
+| `/writing/learn/lexical` | ✅ Done | `pages/writing/learn/lexical.tsx` |
+| `/writing/learn/task1-overview` | ✅ Done | `pages/writing/learn/task1-overview.tsx` |
+| `/writing/learn/task2-structure` | ✅ Done | `pages/writing/learn/task2-structure.tsx` |
+| `/writing/library` | 🟡 In Progress | `pages/writing/library.tsx` |
+| `/writing/mock` | ✅ Done | `pages/writing/mock/index.tsx` |
+| `/writing/overview` | 🟡 In Progress | `pages/writing/overview.tsx` |
+| `/writing/progress` | ✅ Done | `pages/writing/progress.tsx` |
+| `/writing/resources` | ⚪ Not Started | `pages/writing/resources.tsx` |
+| `/writing/review/[attemptId]` | ✅ Done | `pages/writing/review/[attemptId].tsx` |
+| `/writing/review/calibrate` | ✅ Done | `pages/writing/review/calibrate.tsx` |
+
+## Marketing Layout
+
+- Total pages: **18**
+- ✅ Done: **14** · 🟡 In Progress: **3** · ⚪ Not Started: **1**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/` | ⚪ Not Started | `pages/index.tsx` |
+| `/.well-known/assetlinks.json` | ✅ Done | `pages/.well-known/assetlinks.json.ts` |
+| `/403` | ✅ Done | `pages/403.tsx` |
+| `/404` | ✅ Done | `pages/404.tsx` |
+| `/500` | ✅ Done | `pages/500.tsx` |
+| `/accessibility` | 🟡 In Progress | `pages/accessibility.tsx` |
+| `/blog` | 🟡 In Progress | `pages/blog/index.tsx` |
+| `/blog/[slug]` | ✅ Done | `pages/blog/[slug].tsx` |
+| `/data-deletion` | ✅ Done | `pages/data-deletion.tsx` |
+| `/developers` | ✅ Done | `pages/developers/index.tsx` |
+| `/faq` | 🟡 In Progress | `pages/faq.tsx` |
+| `/legal/privacy` | ✅ Done | `pages/legal/privacy.tsx` |
+| `/legal/terms` | ✅ Done | `pages/legal/terms.tsx` |
+| `/partners` | ✅ Done | `pages/partners/index.tsx` |
+| `/pwa/app` | ✅ Done | `pages/pwa/app.tsx` |
+| `/r/[code]` | ✅ Done | `pages/r/[code].tsx` |
+| `/visa` | ✅ Done | `pages/visa/index.tsx` |
+| `/welcome` | ✅ Done | `pages/welcome/index.tsx` |
+
+## Marketplace Layout
+
+- Total pages: **16**
+- ✅ Done: **10** · 🟡 In Progress: **6** · ⚪ Not Started: **0**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/checkout` | 🟡 In Progress | `pages/checkout/index.tsx` |
+| `/checkout/cancel` | ✅ Done | `pages/checkout/cancel.tsx` |
+| `/checkout/confirm` | ✅ Done | `pages/checkout/confirm.tsx` |
+| `/checkout/crypto` | ✅ Done | `pages/checkout/crypto.tsx` |
+| `/checkout/save-card` | 🟡 In Progress | `pages/checkout/save-card.tsx` |
+| `/checkout/success` | ✅ Done | `pages/checkout/success.tsx` |
+| `/marketplace` | 🟡 In Progress | `pages/marketplace/index.tsx` |
+| `/premium` | ✅ Done | `pages/premium/index.tsx` |
+| `/premium/PremiumExamPage` | ✅ Done | `pages/premium/PremiumExamPage.tsx` |
+| `/premium/listening/[slug]` | ✅ Done | `pages/premium/listening/[slug].tsx` |
+| `/premium/pin` | ✅ Done | `pages/premium/pin.tsx` |
+| `/premium/reading/[slug]` | 🟡 In Progress | `pages/premium/reading/[slug].tsx` |
+| `/pricing` | 🟡 In Progress | `pages/pricing/index.tsx` |
+| `/pricing/overview` | 🟡 In Progress | `pages/pricing/overview.tsx` |
+| `/promotions` | ✅ Done | `pages/promotions/index.tsx` |
+| `/waitlist` | ✅ Done | `pages/waitlist.tsx` |
+
+## Proctoring Layout
+
+- Total pages: **2**
+- ✅ Done: **1** · 🟡 In Progress: **1** · ⚪ Not Started: **0**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/proctoring/check` | 🟡 In Progress | `pages/proctoring/check.tsx` |
+| `/proctoring/exam/[id]` | ✅ Done | `pages/proctoring/exam/[id].tsx` |
+
+## Profile Layout
+
+- Total pages: **23**
+- ✅ Done: **19** · 🟡 In Progress: **3** · ⚪ Not Started: **1**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/me/listening/saved` | 🟡 In Progress | `pages/me/listening/saved.tsx` |
+| `/mistakes` | ✅ Done | `pages/mistakes/index.tsx` |
+| `/profile` | 🟡 In Progress | `pages/profile/index.tsx` |
+| `/profile/account` | ✅ Done | `pages/profile/account/index.tsx` |
+| `/profile/account/activity` | ⚪ Not Started | `pages/profile/account/activity.tsx` |
+| `/profile/account/billing` | ✅ Done | `pages/profile/account/billing.tsx` |
+| `/profile/account/redeem` | 🟡 In Progress | `pages/profile/account/redeem.tsx` |
+| `/profile/account/referrals` | ✅ Done | `pages/profile/account/referrals.tsx` |
+| `/profile/billing` | ✅ Done | `pages/profile/billing.tsx` |
+| `/profile/setup` | ✅ Done | `pages/profile/setup/index.tsx` |
+| `/profile/streak` | ✅ Done | `pages/profile/streak.tsx` |
+| `/profile/subscription` | ✅ Done | `pages/profile/subscription.tsx` |
+| `/roadmap` | ✅ Done | `pages/roadmap.tsx` |
+| `/saved` | ✅ Done | `pages/saved/index.tsx` |
+| `/settings` | ✅ Done | `pages/settings/index.tsx` |
+| `/settings/accessibility` | ✅ Done | `pages/settings/accessibility.tsx` |
+| `/settings/account` | ✅ Done | `pages/settings/account.tsx` |
+| `/settings/billing` | ✅ Done | `pages/settings/billing.tsx` |
+| `/settings/language` | ✅ Done | `pages/settings/language.tsx` |
+| `/settings/notifications` | ✅ Done | `pages/settings/notifications.tsx` |
+| `/settings/privacy` | ✅ Done | `pages/settings/privacy.tsx` |
+| `/settings/profile` | ✅ Done | `pages/settings/profile.tsx` |
+| `/settings/security` | ✅ Done | `pages/settings/security.tsx` |
+
+## Reports Layout
+
+- Total pages: **4**
+- ✅ Done: **1** · 🟡 In Progress: **3** · ⚪ Not Started: **0**
+
+| Route | Status | Source File |
+|---|---|---|
+| `/analytics/listening` | 🟡 In Progress | `pages/analytics/listening.tsx` |
+| `/analytics/listening/trajectory` | 🟡 In Progress | `pages/analytics/listening/trajectory.tsx` |
+| `/analytics/writing` | ✅ Done | `pages/analytics/writing.tsx` |
+| `/reports/band-analytics` | 🟡 In Progress | `pages/reports/band-analytics.tsx` |
+

--- a/scripts/page_layout_status_report.py
+++ b/scripts/page_layout_status_report.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGES_DIR = ROOT / 'pages'
+OUT_FILE = ROOT / 'docs' / 'page-layout-status.md'
+
+ROUTE_LAYOUT_MAP: dict[str, tuple[str, bool]] = {
+    '/': ('marketing', True),
+    '/auth/callback': ('auth', False),
+    '/auth/forgot': ('auth', False),
+    '/auth/login': ('auth', False),
+    '/auth/mfa': ('auth', False),
+    '/auth/reset': ('auth', False),
+    '/auth/signup': ('auth', False),
+    '/forgot-password': ('auth', False),
+    '/update-password': ('auth', False),
+    '/login': ('auth', False),
+    '/login/email': ('auth', False),
+    '/login/password': ('auth', False),
+    '/login/phone': ('auth', False),
+    '/signup': ('auth', False),
+    '/signup/email': ('auth', False),
+    '/signup/password': ('auth', False),
+    '/signup/phone': ('auth', False),
+    '/signup/verify': ('auth', False),
+    '/proctoring/check': ('proctoring', False),
+    '/proctoring/exam/[id]': ('proctoring', False),
+    '/premium': ('marketplace', False),
+    '/premium/PremiumExamPage': ('marketplace', False),
+    '/premium/pin': ('marketplace', False),
+    '/premium/listening/[slug]': ('marketplace', False),
+    '/premium/reading/[slug]': ('marketplace', False),
+    '/403': ('marketing', True),
+    '/404': ('marketing', True),
+    '/500': ('marketing', True),
+    '/pwa/app': ('marketing', False),
+}
+
+ROUTE_MATCHERS: list[tuple[re.Pattern[str], tuple[str, bool]]] = [
+    (re.compile(r'^/admin(/|$)'), ('admin', True)),
+    (re.compile(r'^(?:/institutions(/|$)|/orgs$)'), ('institutions', True)),
+    (re.compile(r'^/teacher(/|$)'), ('dashboard', True)),
+    (re.compile(r'^(?:/reports(/|$)|/analytics(/|$))'), ('reports', True)),
+    (re.compile(r'^(?:/marketplace(/|$)|/checkout(/|$)|/pricing(/|$)|/promotions$|/waitlist$)'), ('marketplace', True)),
+    (re.compile(r'^/community(/|$)'), ('community', True)),
+    (re.compile(r'^(?:/profile(/|$)|/settings(/|$)|/saved$|/mistakes$|/roadmap$|/me/listening/saved$)'), ('profile', True)),
+    (re.compile(r'^/mock/reading/\[slug\](/|$)'), ('dashboard', False)),
+    (re.compile(r'^/mock/reading/(result|review|feedback)(/|$)'), ('dashboard', False)),
+    (re.compile(r'^/mock/listening/(\[slug\]|exam|result|review)(/|$)'), ('dashboard', False)),
+    (re.compile(r'^/mock/writing/(run|result)(/|$)'), ('dashboard', False)),
+    (re.compile(r'^/mock/\[section\]$'), ('dashboard', False)),
+    (re.compile(r'^/writing/mock/\[mockId\]/(start|workspace|review|results|evaluating)$'), ('dashboard', False)),
+    (re.compile(r'^/exam/\[id\]$'), ('dashboard', False)),
+    (re.compile(r'^/placement/run$'), ('dashboard', False)),
+    (re.compile(r'^(?:/dashboard(/|$)|/mock(/|$)|/practice(/|$)|/study-plan(/|$)|/progress(/|$)|/quick(/|$)|/challenge(/|$)|/coach(/|$)|/onboarding(/|$)|/placement(/|$)|/predictor(/|$)|/notifications$|/leaderboard$|/score$|/exam-day$|/whatsapp-tasks$|/tokens-test$|/restricted$|/exam/rehearsal$)'), ('dashboard', True)),
+    (re.compile(r'^(?:/learn(/|$)|/learning(/|$)|/reading(/|$)|/listening(/|$)|/writing(/|$)|/speaking(/|$)|/vocabulary(/|$)|/review(/|$)|/tools(/|$)|/cert(/|$)|/classes(/|$)|/bookings(/|$)|/content/studio(/|$)|/internal/content(/|$)|/vocab$|/word-of-the-day$|/ai(/|$)|/labs/ai-tutor$)'), ('learning', True)),
+    (re.compile(r'^(?:/accessibility$|/blog(/|$)|/data-deletion$|/developers$|/faq$|/legal(/|$)|/partners$|/r/\[code\]$|/visa$|/welcome$)'), ('marketing', True)),
+]
+
+IN_PROGRESS_RE = re.compile(r'(TODO|TBD|WIP|placeholder|stub|not implemented|mock data|dummy)', re.IGNORECASE)
+NOT_STARTED_RE = re.compile(r'(coming soon|under construction|not started|start here)', re.IGNORECASE)
+
+
+def page_route_from_file(path: Path) -> str:
+    rel = path.relative_to(PAGES_DIR)
+    route = '/' + str(rel).replace('\\', '/')
+    route = re.sub(r'/index\.(tsx|ts|jsx|js)$', '/', route)
+    route = re.sub(r'\.(tsx|ts|jsx|js)$', '', route)
+    if route != '/' and route.endswith('/'):
+        route = route[:-1]
+    return route
+
+
+def get_route_config(route: str) -> tuple[str, bool]:
+    if route in ROUTE_LAYOUT_MAP:
+        return ROUTE_LAYOUT_MAP[route]
+
+    for pattern, config in ROUTE_LAYOUT_MAP.items():
+        if '[' not in pattern:
+            continue
+        regex_pattern = '^' + re.sub(r'\[([^\]]+)\]', r'([^/]+)', pattern).replace('/', '\\/') + '$'
+        if re.match(regex_pattern, route):
+            return config
+
+    for pattern, config in ROUTE_MATCHERS:
+        if pattern.search(route):
+            return config
+
+    return ('marketing', True)
+
+
+def infer_status(file_contents: str) -> str:
+    if NOT_STARTED_RE.search(file_contents):
+        return 'Not Started'
+    if IN_PROGRESS_RE.search(file_contents):
+        return 'In Progress'
+    return 'Done'
+
+
+def status_badge(status: str) -> str:
+    return {
+        'Done': '✅ Done',
+        'In Progress': '🟡 In Progress',
+        'Not Started': '⚪ Not Started',
+    }[status]
+
+
+def main() -> None:
+    candidate_files = sorted(
+        p
+        for p in PAGES_DIR.rglob('*')
+        if p.is_file()
+        and p.suffix in {'.tsx', '.ts', '.jsx', '.js'}
+        and p.name not in {'_app.tsx', '_document.tsx', '_error.tsx'}
+        and 'api' not in p.relative_to(PAGES_DIR).parts
+        and not any(part in {'components', 'hooks', '__tests__', '__mocks__'} for part in p.relative_to(PAGES_DIR).parts)
+    )
+
+    page_files: list[Path] = []
+    default_export_re = re.compile(r'export\s+default\s+', re.MULTILINE)
+    for candidate in candidate_files:
+        content = candidate.read_text(encoding='utf-8', errors='ignore')
+        if default_export_re.search(content):
+            page_files.append(candidate)
+
+    groups: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+
+    for page_file in page_files:
+        route = page_route_from_file(page_file)
+        layout, _ = get_route_config(route)
+        status = infer_status(page_file.read_text(encoding='utf-8', errors='ignore'))
+        groups[layout].append((route, status, str(page_file.relative_to(ROOT))))
+
+    lines: list[str] = []
+    lines.append('# Page Inventory by Layout')
+    lines.append('')
+    lines.append('Auto-generated from `pages/**` and grouped using route layout rules from `lib/routes/routeLayoutMap.ts`.')
+    lines.append('')
+    lines.append('> Status is inferred automatically from file content markers (e.g., TODO/WIP/coming soon).')
+    lines.append('')
+
+    for layout in sorted(groups.keys()):
+        pages = sorted(groups[layout], key=lambda x: x[0])
+        done = sum(1 for _, s, _ in pages if s == 'Done')
+        progress = sum(1 for _, s, _ in pages if s == 'In Progress')
+        not_started = sum(1 for _, s, _ in pages if s == 'Not Started')
+
+        lines.append(f'## {layout.title()} Layout')
+        lines.append('')
+        lines.append(f'- Total pages: **{len(pages)}**')
+        lines.append(f'- ✅ Done: **{done}** · 🟡 In Progress: **{progress}** · ⚪ Not Started: **{not_started}**')
+        lines.append('')
+        lines.append('| Route | Status | Source File |')
+        lines.append('|---|---|---|')
+        for route, status, src in pages:
+            lines.append(f'| `{route}` | {status_badge(status)} | `{src}` |')
+        lines.append('')
+
+    OUT_FILE.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+    print(f'Wrote {OUT_FILE.relative_to(ROOT)} with {len(page_files)} pages.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Motivation

- Provide a readable inventory of all Next.js `pages/**` grouped by the app layout used so teams can quickly see per-layout coverage and development status.

### Description

- Add `scripts/page_layout_status_report.py`, a generator that scans `pages/**`, resolves layout using the same explicit routes and regex matchers as `lib/routes/routeLayoutMap.ts`, and groups pages by layout.
- Infer page status (`Done`, `In Progress`, `Not Started`) from content markers using regexes for common tokens like `TODO`, `WIP`, and `coming soon` and format the results with simple status badges.
- Filter candidate files to exclude non-page helpers and directories (e.g., `components`, `hooks`, `__tests__`, `__mocks__`) and require a `export default` to better detect real page files.
- Emit a human-friendly Markdown report at `docs/page-layout-status.md` with per-layout totals and a table of `Route`, `Status`, and `Source File` for each page.

### Testing

- Ran `python scripts/page_layout_status_report.py` and verified it produced `docs/page-layout-status.md` successfully, writing an inventory of pages (332 pages in the final run). 
- Opened and inspected `docs/page-layout-status.md` to confirm grouping, counts, and status badges rendered as expected. 
- Executed quick repository listings and file inspections (e.g., `sed`/`nl`) to validate the generated content structure and sample rows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ecfde50483338a9c81fc4af9c12c)