### PR TITLE
Add page inventory grouped by layout and implementation status

### DIFF
--- a/docs/page-layout-status.md
+++ b/docs/page-layout-status.md
@@ -1,0 +1,451 @@
+# Page Inventory by Layout
+
+Generated: 2026-03-03T14:17:15Z
+
+> Status heuristic: **Done** (implemented page), **In Progress** (contains WIP/TODO marker), **Not Started** (scaffold-sized or placeholder).
+
+## admin (31)
+
+- ✅ Done: 10
+- 🟡 In Progress: 19
+- ⚪ Not Started: 2
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/admin` | 🟡 In Progress | `pages/admin/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/alerts` | ✅ Done | `pages/admin/alerts.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/analytics` | ✅ Done | `pages/admin/analytics.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/audit` | 🟡 In Progress | `pages/admin/audit.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/content/reading` | 🟡 In Progress | `pages/admin/content/reading.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/contracts` | 🟡 In Progress | `pages/admin/contracts.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/features` | ✅ Done | `pages/admin/features.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/imp-as` | ✅ Done | `pages/admin/imp-as.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/investor-metrics` | ✅ Done | `pages/admin/investor-metrics.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/listening` | 🟡 In Progress | `pages/admin/listening.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/listening/articles` | ✅ Done | `pages/admin/listening/articles.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/listening/media` | ✅ Done | `pages/admin/listening/media.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/partners` | ✅ Done | `pages/admin/partners/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/plans` | 🟡 In Progress | `pages/admin/plans.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/premium/pin` | 🟡 In Progress | `pages/admin/premium/pin.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/premium/promo-codes` | 🟡 In Progress | `pages/admin/premium/promo-codes.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/premium/promo-usage` | 🟡 In Progress | `pages/admin/premium/promo-usage.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/reading` | 🟡 In Progress | `pages/admin/reading.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/reports/writing-activity` | ✅ Done | `pages/admin/reports/writing-activity.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/reviews` | 🟡 In Progress | `pages/admin/reviews/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/reviews/[attemptId]` | 🟡 In Progress | `pages/admin/reviews/[attemptId].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/speaking` | 🟡 In Progress | `pages/admin/speaking/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/speaking/attempts` | 🟡 In Progress | `pages/admin/speaking/attempts.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/stop-impersonation` | ✅ Done | `pages/admin/stop-impersonation.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/admin/students` | 🟡 In Progress | `pages/admin/students/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/teacher` | ⚪ Not Started | `pages/admin/teacher/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/admin/teachers` | ⚪ Not Started | `pages/admin/teachers/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/admin/users` | 🟡 In Progress | `pages/admin/users.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/vocabulary/new-sense` | 🟡 In Progress | `pages/admin/vocabulary/new-sense.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/writing` | 🟡 In Progress | `pages/admin/writing/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/admin/writing/topics` | 🟡 In Progress | `pages/admin/writing/topics.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+
+## auth (17)
+
+- ✅ Done: 1
+- 🟡 In Progress: 11
+- ⚪ Not Started: 5
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/auth/callback` | ⚪ Not Started | `pages/auth/callback.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/auth/forgot` | 🟡 In Progress | `pages/auth/forgot.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/auth/login` | ⚪ Not Started | `pages/auth/login.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/auth/mfa` | 🟡 In Progress | `pages/auth/mfa.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/auth/reset` | 🟡 In Progress | `pages/auth/reset.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/auth/signup` | ⚪ Not Started | `pages/auth/signup.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/forgot-password` | 🟡 In Progress | `pages/forgot-password.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/login` | ⚪ Not Started | `pages/login/index.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/login/email` | 🟡 In Progress | `pages/login/email.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/login/password` | 🟡 In Progress | `pages/login/password.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/login/phone` | 🟡 In Progress | `pages/login/phone.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/signup` | ⚪ Not Started | `pages/signup/index.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/signup/email` | 🟡 In Progress | `pages/signup/email.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/signup/password` | 🟡 In Progress | `pages/signup/password.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/signup/phone` | 🟡 In Progress | `pages/signup/phone.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/signup/verify` | ✅ Done | `pages/signup/verify.tsx` | Implemented page with substantial content; layout source: explicit |
+| `/update-password` | 🟡 In Progress | `pages/update-password.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+
+## community (4)
+
+- ✅ Done: 0
+- 🟡 In Progress: 4
+- ⚪ Not Started: 0
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/community` | 🟡 In Progress | `pages/community/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/community/chat` | 🟡 In Progress | `pages/community/chat.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/community/questions` | 🟡 In Progress | `pages/community/questions.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/community/review` | 🟡 In Progress | `pages/community/review/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+
+## dashboard (121)
+
+- ✅ Done: 69
+- 🟡 In Progress: 21
+- ⚪ Not Started: 31
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/challenge` | ✅ Done | `pages/challenge/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/challenge/[cohort]` | ⚪ Not Started | `pages/challenge/[cohort].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/coach` | 🟡 In Progress | `pages/coach/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/coach/[id]` | ✅ Done | `pages/coach/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard` | ✅ Done | `pages/dashboard/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/activity` | 🟡 In Progress | `pages/dashboard/activity/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/dashboard/ai-reports` | ⚪ Not Started | `pages/dashboard/ai-reports.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/billing` | ✅ Done | `pages/dashboard/billing.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/shared/FeaturePreviewWrapper` | ⚪ Not Started | `pages/dashboard/components/shared/FeaturePreviewWrapper.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/components/shared/NotificationCenter` | ✅ Done | `pages/dashboard/components/shared/NotificationCenter.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/shared/UpgradeModal` | ⚪ Not Started | `pages/dashboard/components/shared/UpgradeModal.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/components/tiers/FreeView` | ⚪ Not Started | `pages/dashboard/components/tiers/FreeView.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/components/tiers/OwlView` | ✅ Done | `pages/dashboard/components/tiers/OwlView.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/tiers/RocketView` | ✅ Done | `pages/dashboard/components/tiers/RocketView.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/tiers/SeedlingView` | ✅ Done | `pages/dashboard/components/tiers/SeedlingView.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/widgets/AIInsights` | ✅ Done | `pages/dashboard/components/widgets/AIInsights.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/widgets/Achievements` | ✅ Done | `pages/dashboard/components/widgets/Achievements.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/widgets/BandProgress` | ✅ Done | `pages/dashboard/components/widgets/BandProgress.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/widgets/DailyLoginFlow` | ⚪ Not Started | `pages/dashboard/components/widgets/DailyLoginFlow.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/components/widgets/ExportReports` | ⚪ Not Started | `pages/dashboard/components/widgets/ExportReports.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/components/widgets/KpiCards` | ✅ Done | `pages/dashboard/components/widgets/KpiCards.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/widgets/Skeletons` | ⚪ Not Started | `pages/dashboard/components/widgets/Skeletons.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/components/widgets/UsageMeters` | ✅ Done | `pages/dashboard/components/widgets/UsageMeters.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/dashboard/components/widgets/WeaknessMap` | ⚪ Not Started | `pages/dashboard/components/widgets/WeaknessMap.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/progress` | ⚪ Not Started | `pages/dashboard/progress.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/reading` | ⚪ Not Started | `pages/dashboard/reading.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/speaking` | ⚪ Not Started | `pages/dashboard/speaking.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/dashboard/writing` | ⚪ Not Started | `pages/dashboard/writing.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/exam-day` | ✅ Done | `pages/exam-day.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/exam/rehearsal` | ⚪ Not Started | `pages/exam/rehearsal.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/leaderboard` | 🟡 In Progress | `pages/leaderboard/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock` | 🟡 In Progress | `pages/mock/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock/[section]` | ✅ Done | `pages/mock/[section].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/analytics` | ⚪ Not Started | `pages/mock/analytics.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/mock/dashboard` | 🟡 In Progress | `pages/mock/dashboard.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock/full` | 🟡 In Progress | `pages/mock/full/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock/listening` | ✅ Done | `pages/mock/listening/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/listening/[slug]` | 🟡 In Progress | `pages/mock/listening/[slug].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock/listening/exam/[slug]` | ✅ Done | `pages/mock/listening/exam/[slug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/listening/history` | ✅ Done | `pages/mock/listening/history/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/listening/result` | 🟡 In Progress | `pages/mock/listening/result.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock/listening/result/[attemptId]` | ✅ Done | `pages/mock/listening/result/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/listening/review` | ⚪ Not Started | `pages/mock/listening/review.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/mock/listening/review/[attemptId]` | ✅ Done | `pages/mock/listening/review/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading` | ✅ Done | `pages/mock/reading/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/[slug]` | ✅ Done | `pages/mock/reading/[slug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/[slug]/result` | ✅ Done | `pages/mock/reading/[slug]/result.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/analytics` | ✅ Done | `pages/mock/reading/analytics.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/challenges` | ✅ Done | `pages/mock/reading/challenges/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/challenges/accuracy` | ✅ Done | `pages/mock/reading/challenges/accuracy.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/challenges/mastery` | ✅ Done | `pages/mock/reading/challenges/mastery.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/challenges/speed` | 🟡 In Progress | `pages/mock/reading/challenges/speed.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock/reading/challenges/weekly` | ✅ Done | `pages/mock/reading/challenges/weekly.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/daily` | ✅ Done | `pages/mock/reading/daily.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/drill/passage` | ✅ Done | `pages/mock/reading/drill/passage.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/drill/question-type` | ✅ Done | `pages/mock/reading/drill/question-type.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/drill/speed` | ✅ Done | `pages/mock/reading/drill/speed.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/feedback/[attemptId]` | 🟡 In Progress | `pages/mock/reading/feedback/[attemptId].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mock/reading/history` | ✅ Done | `pages/mock/reading/history/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/result/[attemptId]` | ✅ Done | `pages/mock/reading/result/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/review/[attemptId]` | ✅ Done | `pages/mock/reading/review/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/techniques` | ✅ Done | `pages/mock/reading/techniques.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/reading/weekly` | ✅ Done | `pages/mock/reading/weekly/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/resume` | ⚪ Not Started | `pages/mock/resume.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/mock/speaking` | ✅ Done | `pages/mock/speaking/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/speaking/[id]` | ✅ Done | `pages/mock/speaking/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/writing` | ✅ Done | `pages/mock/writing/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/writing/[testId]` | ✅ Done | `pages/mock/writing/[testId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/writing/result/[attemptId]` | ✅ Done | `pages/mock/writing/result/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/mock/writing/run` | ⚪ Not Started | `pages/mock/writing/run.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/notifications` | 🟡 In Progress | `pages/notifications/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/onboarding` | 🟡 In Progress | `pages/onboarding/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/onboarding/baseline` | ✅ Done | `pages/onboarding/baseline.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/onboarding/diagnostic` | ✅ Done | `pages/onboarding/diagnostic.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/onboarding/exam-date` | 🟡 In Progress | `pages/onboarding/exam-date.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/onboarding/goal` | ✅ Done | `pages/onboarding/goal.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/onboarding/notifications` | ✅ Done | `pages/onboarding/notifications.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/onboarding/review` | ✅ Done | `pages/onboarding/review.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/onboarding/skills` | ⚪ Not Started | `pages/onboarding/skills.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/onboarding/study-rhythm` | 🟡 In Progress | `pages/onboarding/study-rhythm.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/onboarding/target-band` | 🟡 In Progress | `pages/onboarding/target-band.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/onboarding/teacher` | ⚪ Not Started | `pages/onboarding/teacher/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/onboarding/teacher/status` | ⚪ Not Started | `pages/onboarding/teacher/status.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/onboarding/thinking` | ⚪ Not Started | `pages/onboarding/thinking.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/onboarding/timeline` | 🟡 In Progress | `pages/onboarding/timeline.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/onboarding/vibe` | ✅ Done | `pages/onboarding/vibe.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/onboarding/welcome` | ✅ Done | `pages/onboarding/welcome.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/onboarding/welcome` | ✅ Done | `pages/onboarding/welcome/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/placement` | ✅ Done | `pages/placement/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/placement/result` | ✅ Done | `pages/placement/result.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/placement/run` | 🟡 In Progress | `pages/placement/run.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/placement/start` | ✅ Done | `pages/placement/start.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/practice` | ✅ Done | `pages/practice/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/practice/listening` | ✅ Done | `pages/practice/listening.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/practice/listening/daily` | 🟡 In Progress | `pages/practice/listening/daily.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/practice/reading` | ✅ Done | `pages/practice/reading.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/practice/speaking` | ⚪ Not Started | `pages/practice/speaking.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/practice/writing` | ✅ Done | `pages/practice/writing.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/predictor` | ⚪ Not Started | `pages/predictor/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/predictor/result` | ✅ Done | `pages/predictor/result.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/progress` | ⚪ Not Started | `pages/progress/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/progress/[token]` | ✅ Done | `pages/progress/[token].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/quick` | ✅ Done | `pages/quick/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/quick/[skill]` | 🟡 In Progress | `pages/quick/[skill].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/restricted` | ⚪ Not Started | `pages/restricted.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/score` | ✅ Done | `pages/score/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/study-plan` | ⚪ Not Started | `pages/study-plan/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/study-plan/[weekId]` | ✅ Done | `pages/study-plan/[weekId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/teacher` | ✅ Done | `pages/teacher/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/teacher/Welcome` | 🟡 In Progress | `pages/teacher/Welcome.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/teacher/cohorts/[id]` | ✅ Done | `pages/teacher/cohorts/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/teacher/onboarding` | 🟡 In Progress | `pages/teacher/onboarding.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/teacher/pending` | ✅ Done | `pages/teacher/pending.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/teacher/register` | ✅ Done | `pages/teacher/register.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/tokens-test` | ⚪ Not Started | `pages/tokens-test.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/whatsapp-tasks` | ⚪ Not Started | `pages/whatsapp-tasks.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/writing/mock/[mockId]/evaluating` | ⚪ Not Started | `pages/writing/mock/[mockId]/evaluating.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/writing/mock/[mockId]/results` | ⚪ Not Started | `pages/writing/mock/[mockId]/results.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/writing/mock/[mockId]/review` | ✅ Done | `pages/writing/mock/[mockId]/review.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/mock/[mockId]/start` | ✅ Done | `pages/writing/mock/[mockId]/start.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/mock/[mockId]/workspace` | ✅ Done | `pages/writing/mock/[mockId]/workspace.tsx` | Implemented page with substantial content; layout source: matcher |
+
+## institutions (5)
+
+- ✅ Done: 2
+- 🟡 In Progress: 3
+- ⚪ Not Started: 0
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/institutions` | 🟡 In Progress | `pages/institutions/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/institutions/[orgId]` | ✅ Done | `pages/institutions/[orgId]/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/institutions/[orgId]/reports` | ✅ Done | `pages/institutions/[orgId]/reports.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/institutions/[orgId]/students` | 🟡 In Progress | `pages/institutions/[orgId]/students.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/orgs` | 🟡 In Progress | `pages/orgs/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+
+## learning (107)
+
+- ✅ Done: 61
+- 🟡 In Progress: 31
+- ⚪ Not Started: 15
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/ai` | 🟡 In Progress | `pages/ai/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/ai/coach` | 🟡 In Progress | `pages/ai/coach/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/ai/mistakes-book` | ✅ Done | `pages/ai/mistakes-book/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/ai/study-buddy` | 🟡 In Progress | `pages/ai/study-buddy/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/ai/study-buddy/session/[id]/practice` | ⚪ Not Started | `pages/ai/study-buddy/session/[id]/practice.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/ai/study-buddy/session/[id]/summary` | 🟡 In Progress | `pages/ai/study-buddy/session/[id]/summary.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/ai/writing/[id]` | ✅ Done | `pages/ai/writing/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/bookings` | ✅ Done | `pages/bookings/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/bookings/[id]` | ✅ Done | `pages/bookings/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/cert/[id]` | ✅ Done | `pages/cert/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/cert/writing/[attemptId]` | ✅ Done | `pages/cert/writing/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/classes` | 🟡 In Progress | `pages/classes/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/classes/[id]` | ✅ Done | `pages/classes/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/content/studio` | 🟡 In Progress | `pages/content/studio/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/content/studio/[id]` | ✅ Done | `pages/content/studio/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/internal/content/playground` | 🟡 In Progress | `pages/internal/content/playground.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/labs/ai-tutor` | 🟡 In Progress | `pages/labs/ai-tutor.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/learn/listening` | ✅ Done | `pages/learn/listening/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/learn/listening/coach` | 🟡 In Progress | `pages/learn/listening/coach.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/learn/listening/mistakes` | 🟡 In Progress | `pages/learn/listening/mistakes.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/learn/listening/tips` | 🟡 In Progress | `pages/learn/listening/tips.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/learning` | ✅ Done | `pages/learning/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/learning/[slug]` | ⚪ Not Started | `pages/learning/[slug].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/learning/drills` | ✅ Done | `pages/learning/drills.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/learning/skills` | ✅ Done | `pages/learning/skills/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/learning/skills/[skill]` | ✅ Done | `pages/learning/skills/[skill].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/learning/skills/lessons` | ✅ Done | `pages/learning/skills/lessons/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/learning/skills/lessons/[slug]` | ✅ Done | `pages/learning/skills/lessons/[slug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/learning/strategies` | 🟡 In Progress | `pages/learning/strategies/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/learning/strategies/[tipSlug]` | ✅ Done | `pages/learning/strategies/[tipSlug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/listening` | ✅ Done | `pages/listening/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/listening/[slug]` | 🟡 In Progress | `pages/listening/[slug].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/listening/[slug]/review` | ⚪ Not Started | `pages/listening/[slug]/review.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/reading` | 🟡 In Progress | `pages/reading/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/reading/[slug]` | ⚪ Not Started | `pages/reading/[slug].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/reading/[slug]/review` | 🟡 In Progress | `pages/reading/[slug]/review.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/reading/passage/[slug]` | ✅ Done | `pages/reading/passage/[slug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/reading/stats` | ✅ Done | `pages/reading/stats.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/review/listening/[id]` | ✅ Done | `pages/review/listening/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/review/reading/[id]` | ✅ Done | `pages/review/reading/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/review/share/[token]` | ⚪ Not Started | `pages/review/share/[token].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/review/speaking/[id]` | ✅ Done | `pages/review/speaking/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/review/writing/[id]` | ✅ Done | `pages/review/writing/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking` | ⚪ Not Started | `pages/speaking/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/speaking/[promptId]` | ⚪ Not Started | `pages/speaking/[promptId].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/speaking/attempts` | ✅ Done | `pages/speaking/attempts/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/attempts/[attemptId]/result` | ⚪ Not Started | `pages/speaking/attempts/[attemptId]/result.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/speaking/buddy` | ⚪ Not Started | `pages/speaking/buddy.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/speaking/coach` | ✅ Done | `pages/speaking/coach/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/coach/[slug]` | ⚪ Not Started | `pages/speaking/coach/[slug].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/speaking/coach/free` | 🟡 In Progress | `pages/speaking/coach/free.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/speaking/library` | ✅ Done | `pages/speaking/library.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/live` | ✅ Done | `pages/speaking/live/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/live/[id]` | ✅ Done | `pages/speaking/live/[id].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/packs/[slug]` | ✅ Done | `pages/speaking/packs/[slug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/partner` | 🟡 In Progress | `pages/speaking/partner.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/speaking/partner/history` | 🟡 In Progress | `pages/speaking/partner/history.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/speaking/partner/review/[attemptId]` | ✅ Done | `pages/speaking/partner/review/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/practice` | ✅ Done | `pages/speaking/practice.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/report` | ✅ Done | `pages/speaking/report.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/review/[id]` | 🟡 In Progress | `pages/speaking/review/[id].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/speaking/roleplay` | ✅ Done | `pages/speaking/roleplay/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/roleplay/[scenario]` | 🟡 In Progress | `pages/speaking/roleplay/[scenario].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/speaking/settings` | ✅ Done | `pages/speaking/settings.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/simulator` | ✅ Done | `pages/speaking/simulator/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/simulator/part1` | ⚪ Not Started | `pages/speaking/simulator/part1.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/speaking/simulator/part2` | ✅ Done | `pages/speaking/simulator/part2.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/speaking/simulator/part3` | ✅ Done | `pages/speaking/simulator/part3.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/tools/listening/accent-trainer` | 🟡 In Progress | `pages/tools/listening/accent-trainer.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/tools/listening/dictation` | 🟡 In Progress | `pages/tools/listening/dictation.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/tools/mark-sections/[slug]` | 🟡 In Progress | `pages/tools/mark-sections/[slug].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/vocab` | ✅ Done | `pages/vocab/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary` | ✅ Done | `pages/vocabulary/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/[word]` | ✅ Done | `pages/vocabulary/[word].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/ai-lab` | 🟡 In Progress | `pages/vocabulary/ai-lab.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/vocabulary/infiniteapplications` | ✅ Done | `pages/vocabulary/infiniteapplications.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/learned` | ⚪ Not Started | `pages/vocabulary/learned.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/vocabulary/linking-words` | ✅ Done | `pages/vocabulary/linking-words.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/lists` | ✅ Done | `pages/vocabulary/lists.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/my-words` | 🟡 In Progress | `pages/vocabulary/my-words.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/vocabulary/quizzes` | ✅ Done | `pages/vocabulary/quizzes/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/quizzes/today` | ✅ Done | `pages/vocabulary/quizzes/today.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/review` | ✅ Done | `pages/vocabulary/review.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/saved` | 🟡 In Progress | `pages/vocabulary/saved.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/vocabulary/speaking` | ✅ Done | `pages/vocabulary/speaking/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/speaking/[topic]` | ⚪ Not Started | `pages/vocabulary/speaking/[topic].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/vocabulary/synonyms` | ✅ Done | `pages/vocabulary/synonyms.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/topics` | ✅ Done | `pages/vocabulary/topics/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/vocabulary/topics/[topic]` | 🟡 In Progress | `pages/vocabulary/topics/[topic].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/word-of-the-day` | ⚪ Not Started | `pages/word-of-the-day.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/writing` | 🟡 In Progress | `pages/writing/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/writing/[slug]` | ✅ Done | `pages/writing/[slug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/drills` | ✅ Done | `pages/writing/drills/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/drills/[slug]` | 🟡 In Progress | `pages/writing/drills/[slug].tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/writing/learn` | ✅ Done | `pages/writing/learn/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/learn/coherence` | ✅ Done | `pages/writing/learn/coherence.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/learn/grammar` | ✅ Done | `pages/writing/learn/grammar.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/learn/lexical` | ✅ Done | `pages/writing/learn/lexical.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/learn/task1-overview` | ✅ Done | `pages/writing/learn/task1-overview.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/learn/task2-structure` | ✅ Done | `pages/writing/learn/task2-structure.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/library` | 🟡 In Progress | `pages/writing/library.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/writing/mock` | ✅ Done | `pages/writing/mock/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/overview` | ✅ Done | `pages/writing/overview.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/progress` | ⚪ Not Started | `pages/writing/progress.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/writing/resources` | 🟡 In Progress | `pages/writing/resources.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/writing/review/[attemptId]` | ✅ Done | `pages/writing/review/[attemptId].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/writing/review/calibrate` | ✅ Done | `pages/writing/review/calibrate.tsx` | Implemented page with substantial content; layout source: matcher |
+
+## marketing (17)
+
+- ✅ Done: 9
+- 🟡 In Progress: 4
+- ⚪ Not Started: 4
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/` | 🟡 In Progress | `pages/index.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/403` | ✅ Done | `pages/403.tsx` | Implemented page with substantial content; layout source: explicit |
+| `/404` | ⚪ Not Started | `pages/404.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/500` | ⚪ Not Started | `pages/500.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/accessibility` | 🟡 In Progress | `pages/accessibility.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/blog` | 🟡 In Progress | `pages/blog/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/blog/[slug]` | ✅ Done | `pages/blog/[slug].tsx` | Implemented page with substantial content; layout source: matcher |
+| `/data-deletion` | ✅ Done | `pages/data-deletion.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/developers` | ✅ Done | `pages/developers/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/faq` | 🟡 In Progress | `pages/faq.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/legal/privacy` | ✅ Done | `pages/legal/privacy.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/legal/terms` | ✅ Done | `pages/legal/terms.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/partners` | ✅ Done | `pages/partners/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/pwa/app` | ✅ Done | `pages/pwa/app.tsx` | Implemented page with substantial content; layout source: explicit |
+| `/r/[code]` | ⚪ Not Started | `pages/r/[code].tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/visa` | ⚪ Not Started | `pages/visa/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/welcome` | ✅ Done | `pages/welcome/index.tsx` | Implemented page with substantial content; layout source: matcher |
+
+## marketplace (16)
+
+- ✅ Done: 8
+- 🟡 In Progress: 6
+- ⚪ Not Started: 2
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/checkout` | 🟡 In Progress | `pages/checkout/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/checkout/cancel` | ✅ Done | `pages/checkout/cancel.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/checkout/confirm` | ✅ Done | `pages/checkout/confirm.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/checkout/crypto` | ✅ Done | `pages/checkout/crypto.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/checkout/save-card` | 🟡 In Progress | `pages/checkout/save-card.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/checkout/success` | ✅ Done | `pages/checkout/success.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/marketplace` | 🟡 In Progress | `pages/marketplace/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/premium` | ✅ Done | `pages/premium/index.tsx` | Implemented page with substantial content; layout source: explicit |
+| `/premium/PremiumExamPage` | ⚪ Not Started | `pages/premium/PremiumExamPage.tsx` | Scaffold-sized or placeholder implementation; layout source: explicit |
+| `/premium/listening/[slug]` | ✅ Done | `pages/premium/listening/[slug].tsx` | Implemented page with substantial content; layout source: explicit |
+| `/premium/pin` | ✅ Done | `pages/premium/pin.tsx` | Implemented page with substantial content; layout source: explicit |
+| `/premium/reading/[slug]` | 🟡 In Progress | `pages/premium/reading/[slug].tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/pricing` | 🟡 In Progress | `pages/pricing/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/pricing/overview` | 🟡 In Progress | `pages/pricing/overview.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/promotions` | ✅ Done | `pages/promotions/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/waitlist` | ⚪ Not Started | `pages/waitlist.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+
+## proctoring (2)
+
+- ✅ Done: 1
+- 🟡 In Progress: 1
+- ⚪ Not Started: 0
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/proctoring/check` | 🟡 In Progress | `pages/proctoring/check.tsx` | Contains WIP/TODO marker text; layout source: explicit |
+| `/proctoring/exam/[id]` | ✅ Done | `pages/proctoring/exam/[id].tsx` | Implemented page with substantial content; layout source: explicit |
+
+## profile (23)
+
+- ✅ Done: 13
+- 🟡 In Progress: 4
+- ⚪ Not Started: 6
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/me/listening/saved` | 🟡 In Progress | `pages/me/listening/saved.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/mistakes` | ⚪ Not Started | `pages/mistakes/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/profile` | 🟡 In Progress | `pages/profile/index.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/profile/account` | ✅ Done | `pages/profile/account/index.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/profile/account/activity` | 🟡 In Progress | `pages/profile/account/activity.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/profile/account/billing` | ✅ Done | `pages/profile/account/billing.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/profile/account/redeem` | 🟡 In Progress | `pages/profile/account/redeem.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/profile/account/referrals` | ✅ Done | `pages/profile/account/referrals.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/profile/billing` | ✅ Done | `pages/profile/billing.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/profile/setup` | ⚪ Not Started | `pages/profile/setup/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/profile/streak` | ✅ Done | `pages/profile/streak.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/profile/subscription` | ✅ Done | `pages/profile/subscription.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/roadmap` | ✅ Done | `pages/roadmap.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/saved` | ⚪ Not Started | `pages/saved/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/settings` | ⚪ Not Started | `pages/settings/index.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/settings/accessibility` | ✅ Done | `pages/settings/accessibility.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/settings/account` | ✅ Done | `pages/settings/account.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/settings/billing` | ⚪ Not Started | `pages/settings/billing.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/settings/language` | ✅ Done | `pages/settings/language.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/settings/notifications` | ⚪ Not Started | `pages/settings/notifications.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/settings/privacy` | ✅ Done | `pages/settings/privacy.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/settings/profile` | ✅ Done | `pages/settings/profile.tsx` | Implemented page with substantial content; layout source: matcher |
+| `/settings/security` | ✅ Done | `pages/settings/security.tsx` | Implemented page with substantial content; layout source: matcher |
+
+## reports (4)
+
+- ✅ Done: 0
+- 🟡 In Progress: 3
+- ⚪ Not Started: 1
+
+| Route | Status | Page file | Notes |
+|---|---|---|---|
+| `/analytics/listening` | 🟡 In Progress | `pages/analytics/listening.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/analytics/listening/trajectory` | 🟡 In Progress | `pages/analytics/listening/trajectory.tsx` | Contains WIP/TODO marker text; layout source: matcher |
+| `/analytics/writing` | ⚪ Not Started | `pages/analytics/writing.tsx` | Scaffold-sized or placeholder implementation; layout source: matcher |
+| `/reports/band-analytics` | 🟡 In Progress | `pages/reports/band-analytics.tsx` | Contains WIP/TODO marker text; layout source: matcher |


### PR DESCRIPTION
### Motivation
- Provide a single, human-friendly inventory of all app pages grouped by the layout resolved from `lib/routes/routeLayoutMap.ts` to help triage work and track progress. 
- Surface a quick implementation status per page using simple heuristics so reviewers can easily see which pages are done, in progress, or scaffolded.

### Description
- Added `docs/page-layout-status.md` which lists all non-API routes under `pages/`, grouped by the resolved layout and includes per-layout rollups and a tabular view of each route, status, source file, and a short note. 
- The status is determined by heuristics that inspect page source text and size (keywords like `TODO`, `WIP`, scaffold size, or `return null;`) and labels pages as `Done`, `In Progress`, or `Not Started`. 
- Route → layout resolution uses the existing logic in `lib/routes/routeLayoutMap.ts` (explicit map entries, dynamic patterns, then matcher fallbacks) so the document mirrors runtime layout assignment. 
- The markdown was generated programmatically to ensure consistent formatting and quick regeneration when routes change.

### Testing
- Ran the generator (a Python script) which produced `docs/page-layout-status.md` and wrote 347 routes to the document as expected. 
- Verified the generated file contents by opening the file with `sed`/`nl` to confirm formatting and grouping. 
- Attempted to run an alternative TypeScript runner (`npx tsx ...`) but it failed due to a remote package fetch restriction, so generation was validated with the Python run instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6ecfde50483338a9c81fc4af9c12c)