### PR TITLE
Fix email confirmation redirect and add manual OTP verification

### DIFF
--- a/lib/routeAccess.test.ts
+++ b/lib/routeAccess.test.ts
@@ -40,3 +40,9 @@ test('redirectByRole sends unverified users to verification', () => {
 test('verification page is considered public', () => {
   assert.strictEqual(isPublicRoute('/auth/verify'), true);
 });
+
+
+test('auth confirmation and callback pages are public', () => {
+  assert.strictEqual(isPublicRoute('/auth/confirm'), true);
+  assert.strictEqual(isPublicRoute('/auth/callback'), true);
+});

--- a/lib/routeAccess.ts
+++ b/lib/routeAccess.ts
@@ -15,6 +15,8 @@ const PUBLIC_ROUTES: RouteMatcher[] = [
   /^\/contact$/,
   /^\/roadmap$/,
   /^\/vocabulary(\/|$)/,
+  '/auth/confirm',
+  '/auth/callback',
   '/auth/verify',
   '/403', // keep these public to avoid loops
   /^\/legal(\/|$)/,

--- a/lib/routes/routeLayoutMap.ts
+++ b/lib/routes/routeLayoutMap.ts
@@ -20,6 +20,7 @@ export const ROUTE_LAYOUT_MAP: Record<string, RouteConfig> = {
   '/auth/reset': { layout: 'default', showChrome: false },
   '/auth/mfa': { layout: 'default', showChrome: false },
   '/auth/verify': { layout: 'default', showChrome: false },
+  '/auth/confirm': { layout: 'default', showChrome: false },
 
   '/login': { layout: 'default', showChrome: false },
   '/login/index': { layout: 'default', showChrome: false },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -79,7 +79,7 @@ function GuardSkeleton() {
 // ---------- Route type helpers ----------
 const isAuthPage = (pathname: string) =>
   /^\/(login|signup|register)(\/|$)/.test(pathname) ||
-  /^\/auth\/(login|signup|register|mfa|verify)(\/|$)/.test(pathname) ||
+  /^\/auth\/(login|signup|register|mfa|verify|confirm|callback)(\/|$)/.test(pathname) ||
   pathname === '/forgot-password';
 
 const isPremiumRoomRoute = (pathname: string) =>
@@ -177,7 +177,7 @@ function useAuthBridge() {
         }
 
         if (event === 'SIGNED_OUT') {
-          if (!['/login', '/signup', '/forgot-password'].includes(router.pathname)) {
+          if (!['/login', '/signup', '/forgot-password', '/auth/confirm', '/auth/callback', '/signup/verify'].includes(router.pathname)) {
             router.replace('/login');
           }
         }

--- a/pages/signup/email.tsx
+++ b/pages/signup/email.tsx
@@ -76,6 +76,13 @@ export default function SignUpWithEmail() {
 
       const redirectTarget = `${origin}/auth/confirm?${verificationParams.toString()}`;
 
+      const sendVerificationCode = async () => {
+        await supabase.auth.signInWithOtp({
+          email: trimmedEmail,
+          options: { shouldCreateUser: false },
+        });
+      };
+
       try {
         await submitPkceSignup({
           email: trimmedEmail,
@@ -97,6 +104,8 @@ export default function SignUpWithEmail() {
             },
           });
 
+          await sendVerificationCode();
+
           const verifyParams = new URLSearchParams({ email: trimmedEmail });
           if (role) verifyParams.set('role', role);
           if (ref) verifyParams.set('ref', ref);
@@ -112,6 +121,8 @@ export default function SignUpWithEmail() {
       }
 
       // Success: move user away from the form
+      await sendVerificationCode();
+
       const verifyParams = new URLSearchParams({ email: trimmedEmail });
       if (role) verifyParams.set('role', role);
       if (ref) verifyParams.set('ref', ref);

--- a/pages/signup/verify.tsx
+++ b/pages/signup/verify.tsx
@@ -7,9 +7,10 @@ import { useRouter } from 'next/router';
 import { SectionLabel } from '@/components/design-system/SectionLabel';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
+import { Input } from '@/components/design-system/Input';
 import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
 import { readStoredPkceVerifier } from '@/lib/auth/pkce';
-import { ONBOARDING, SIGNUP, LOGIN } from '@/lib/constants/routes';
+import { ONBOARDING, SIGNUP } from '@/lib/constants/routes';
 import { withQuery } from '@/lib/constants/routes';
 
 export default function VerifyEmailPage() {
@@ -33,6 +34,8 @@ export default function VerifyEmailPage() {
   const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
   const [err, setErr] = useState<string | null>(null);
   const [cooldown, setCooldown] = useState(0);
+  const [code, setCode] = useState('');
+  const [codeStatus, setCodeStatus] = useState<'idle' | 'verifying' | 'verified' | 'error'>('idle');
 
   // Auto-redirect if already signed in (e.g., they verified in another tab)
   useEffect(() => {
@@ -102,6 +105,37 @@ export default function VerifyEmailPage() {
     }
   }
 
+  async function onVerifyCode(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+
+    const trimmedCode = code.trim();
+    if (!email) {
+      setErr('We could not detect your email address.');
+      return;
+    }
+    if (!trimmedCode) {
+      setErr('Enter the verification code from your email.');
+      return;
+    }
+
+    setCodeStatus('verifying');
+    const { error } = await supabase.auth.verifyOtp({
+      email,
+      token: trimmedCode,
+      type: 'signup',
+    });
+
+    if (error) {
+      setCodeStatus('error');
+      setErr(error.message || 'Invalid verification code.');
+      return;
+    }
+
+    setCodeStatus('verified');
+    await router.replace(next);
+  }
+
   // If the page was opened without an email param, nudge them back
   if (!email) {
     return (
@@ -138,9 +172,35 @@ export default function VerifyEmailPage() {
         </Alert>
       )}
 
+      {codeStatus === 'verified' && !err && (
+        <Alert variant="success" title="Verified" className="mt-4" role="status" aria-live="polite">
+          Email verified successfully. Redirecting...
+        </Alert>
+      )}
+
       <p className="mt-6 text-muted-foreground">
-        We sent a verification link to <strong>{email}</strong>. Click it to verify and continue setup.
+        We sent a verification link to <strong>{email}</strong>. You can either click the link in your
+        email or enter the verification code below.
       </p>
+
+      <form onSubmit={onVerifyCode} className="mt-6 rounded-xl border border-border p-4 space-y-3">
+        <Input
+          label="Verification Code"
+          type="text"
+          placeholder="Enter the code from your email"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          autoComplete="one-time-code"
+          required
+        />
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={codeStatus === 'verifying'}
+        >
+          {codeStatus === 'verifying' ? 'Verifying code…' : 'Verify code'}
+        </Button>
+      </form>
 
       <div className="mt-6 space-y-4">
         <Button onClick={onResend} className="w-full" disabled={status === 'sending' || cooldown > 0}>

--- a/pages/signup/verify.tsx
+++ b/pages/signup/verify.tsx
@@ -1,7 +1,7 @@
 // pages/signup/verify.tsx
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { SectionLabel } from '@/components/design-system/SectionLabel';
@@ -36,6 +36,7 @@ export default function VerifyEmailPage() {
   const [cooldown, setCooldown] = useState(0);
   const [code, setCode] = useState('');
   const [codeStatus, setCodeStatus] = useState<'idle' | 'verifying' | 'verified' | 'error'>('idle');
+  const hasAutoSentCode = useRef(false);
 
   // Auto-redirect if already signed in (e.g., they verified in another tab)
   useEffect(() => {
@@ -59,6 +60,27 @@ export default function VerifyEmailPage() {
     typeof router.query.code_verifier === 'string' && router.query.code_verifier.length > 0
       ? router.query.code_verifier
       : readStoredPkceVerifier() || '';
+
+
+  async function sendVerificationCode() {
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        shouldCreateUser: false,
+      },
+    });
+    if (error) throw error;
+  }
+
+
+
+  useEffect(() => {
+    if (!email || hasAutoSentCode.current) return;
+    hasAutoSentCode.current = true;
+    void sendVerificationCode().catch(() => {
+      // no-op: user can still use resend button
+    });
+  }, [email]);
 
   async function onResend() {
     setErr(null);
@@ -97,6 +119,7 @@ export default function VerifyEmailPage() {
         return;
       }
 
+      await sendVerificationCode();
       setStatus('sent');
       setCooldown(30);
     } catch {
@@ -120,15 +143,26 @@ export default function VerifyEmailPage() {
     }
 
     setCodeStatus('verifying');
-    const { error } = await supabase.auth.verifyOtp({
+    let verificationError: Error | null = null;
+
+    const signupAttempt = await supabase.auth.verifyOtp({
       email,
       token: trimmedCode,
       type: 'signup',
     });
 
-    if (error) {
+    if (signupAttempt.error) {
+      const emailAttempt = await supabase.auth.verifyOtp({
+        email,
+        token: trimmedCode,
+        type: 'email',
+      });
+      verificationError = emailAttempt.error;
+    }
+
+    if (signupAttempt.error && verificationError) {
       setCodeStatus('error');
-      setErr(error.message || 'Invalid verification code.');
+      setErr(verificationError.message || signupAttempt.error.message || 'Invalid verification code.');
       return;
     }
 
@@ -168,7 +202,7 @@ export default function VerifyEmailPage() {
 
       {status === 'sent' && !err && (
         <Alert variant="success" title="Sent" className="mt-4" role="status" aria-live="polite">
-          Verification email sent. Please check your inbox.
+          Verification email sent. We also sent a verification code to your inbox.
         </Alert>
       )}
 
@@ -180,7 +214,7 @@ export default function VerifyEmailPage() {
 
       <p className="mt-6 text-muted-foreground">
         We sent a verification link to <strong>{email}</strong>. You can either click the link in your
-        email or enter the verification code below.
+        email or enter the verification code below. If the code is missing, tap resend to get a fresh code.
       </p>
 
       <form onSubmit={onVerifyCode} className="mt-6 rounded-xl border border-border p-4 space-y-3">


### PR DESCRIPTION
### Motivation
- Users clicking the signup confirmation link were being redirected to the login page (`/login?next=...`) before verification could run, preventing email confirmation from completing.  
- Provide a fallback verification path so users can verify their email either by clicking the link or entering the verification code from the email.

### Description
- Treat `/auth/confirm` and `/auth/callback` as public routes by adding them to the `PUBLIC_ROUTES` list in `lib/routeAccess.ts`.  
- Add `/auth/confirm` to the auth route map in `lib/routes/routeLayoutMap.ts` so the page is rendered as an auth/no‑chrome page.  
- Implement manual code verification UI and flow in `pages/signup/verify.tsx`, including an `Input` for the code, `onVerifyCode` that calls `supabase.auth.verifyOtp`, UI states for `verifying`/`verified`/`error`, and redirect to the `next` path on success.  
- Add unit assertions in `lib/routeAccess.test.ts` that verify `/auth/confirm` and `/auth/callback` are considered public routes.

### Testing
- Added a unit test in `lib/routeAccess.test.ts` asserting `isPublicRoute('/auth/confirm')` and `isPublicRoute('/auth/callback')`; test file was added but could not be executed in this environment due to tooling access constraints.  
- Attempted to run `npx eslint ...` but linting failed in this environment due to a missing local dependency `@eslint/eslintrc`.  
- Attempted to run the test runner (`tsx --test`) and start the dev server (`npm run dev:3001`) but both failed because required packages/registry access are not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac98bb4fa8832fbb9198c4620054a1)