### PR TITLE
Add AI-generated study-plan handoff at end of onboarding

### DIFF
--- a/pages/onboarding/notifications.tsx
+++ b/pages/onboarding/notifications.tsx
@@ -71,11 +71,15 @@ const OnboardingNotificationsPage: NextPage = () => {
   // Final destination after onboarding
   const nextPath = useMemo(() => {
     const { next } = router.query;
-    const raw = typeof next === 'string' ? next : '/dashboard';
+    const raw = typeof next === 'string' ? next : '/onboarding/study-plan';
 
     // never loop back into onboarding from final step
-    if (!raw || raw.startsWith('/onboarding')) {
-      return '/dashboard';
+    if (!raw) {
+      return '/onboarding/study-plan';
+    }
+
+    if (raw.startsWith('/onboarding') && raw !== '/onboarding/study-plan') {
+      return '/onboarding/study-plan';
     }
     return raw;
   }, [router.query]);
@@ -230,7 +234,7 @@ const OnboardingNotificationsPage: NextPage = () => {
               <p className="hidden text-xs text-muted-foreground sm:inline">
                 Finish and go to{' '}
                 <span className="font-medium">
-                  {nextPath === '/dashboard' ? 'dashboard' : nextPath}
+                  {nextPath === '/onboarding/study-plan' ? 'your AI study plan' : nextPath}
                 </span>
               </p>
               <Button

--- a/pages/onboarding/study-plan.tsx
+++ b/pages/onboarding/study-plan.tsx
@@ -1,0 +1,269 @@
+import type { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/components/design-system/Button';
+import { Card } from '@/components/design-system/Card';
+import { Container } from '@/components/design-system/Container';
+import { generateStudyPlan } from '@/lib/studyPlan';
+import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import type { OnboardingState } from '@/lib/onboarding/schema';
+import type { PlanGenOptions, AvailabilitySlot } from '@/lib/studyPlan';
+import type { StudyPlan } from '@/types/plan';
+
+type GenerationStatus = 'generating' | 'ready' | 'saving' | 'error';
+
+const DAY_MAP: Record<string, AvailabilitySlot['day']> = {
+  mon: 'monday',
+  tue: 'tuesday',
+  wed: 'wednesday',
+  thu: 'thursday',
+  fri: 'friday',
+  sat: 'saturday',
+  sun: 'sunday',
+};
+
+const DAY_LABELS: Record<AvailabilitySlot['day'], string> = {
+  monday: 'Mon',
+  tuesday: 'Tue',
+  wednesday: 'Wed',
+  thursday: 'Thu',
+  friday: 'Fri',
+  saturday: 'Sat',
+  sunday: 'Sun',
+};
+
+const DEFAULT_DAYS: AvailabilitySlot['day'][] = ['monday', 'wednesday', 'friday', 'sunday'];
+
+function addDaysISO(days: number): string {
+  const base = new Date();
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString();
+}
+
+function buildPlanOptions(userId: string, state: OnboardingState): PlanGenOptions {
+  const targetBand = state.goalBand ?? 7;
+  const minutes = state.studyMinutesPerDay ?? 45;
+  const selectedDays =
+    state.studyDays?.map((d) => DAY_MAP[d]).filter(Boolean) ?? DEFAULT_DAYS;
+
+  const availability = selectedDays.map((day) => ({
+    day,
+    minutes,
+  }));
+
+  return {
+    userId,
+    targetBand,
+    startISO: new Date().toISOString(),
+    examDateISO: state.examDate ? new Date(state.examDate).toISOString() : addDaysISO(28),
+    availability,
+  };
+}
+
+const OnboardingStudyPlanPage: NextPage = () => {
+  const router = useRouter();
+
+  const [status, setStatus] = useState<GenerationStatus>('generating');
+  const [error, setError] = useState<string | null>(null);
+  const [plan, setPlan] = useState<StudyPlan | null>(null);
+  const [availability, setAvailability] = useState<AvailabilitySlot[]>([]);
+
+  const nextPath = useMemo(() => {
+    const raw = router.query.next;
+    if (typeof raw === 'string' && raw && raw !== '/dashboard') {
+      return raw;
+    }
+    return '/study-plan';
+  }, [router.query.next]);
+
+  const generatePlan = useCallback(async () => {
+    setStatus('generating');
+    setError(null);
+
+    const startedAt = Date.now();
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user?.id) {
+        setStatus('error');
+        setError('Please sign in again to generate your plan.');
+        return;
+      }
+
+      const onboardingRes = await fetch('/api/onboarding');
+      if (!onboardingRes.ok) {
+        setStatus('error');
+        setError('Could not read your onboarding preferences.');
+        return;
+      }
+
+      const onboardingState = (await onboardingRes.json()) as OnboardingState;
+      const options = buildPlanOptions(user.id, onboardingState);
+      const generatedPlan = generateStudyPlan(options);
+
+      const elapsed = Date.now() - startedAt;
+      if (elapsed < 1500) {
+        await new Promise((resolve) => setTimeout(resolve, 1500 - elapsed));
+      }
+
+      setAvailability(options.availability);
+      setPlan(generatedPlan);
+      setStatus('ready');
+    } catch (err) {
+      console.error('Failed to generate onboarding study plan', err);
+      setStatus('error');
+      setError('Something went wrong while generating your study plan.');
+    }
+  }, []);
+
+  useEffect(() => {
+    void generatePlan();
+  }, [generatePlan]);
+
+  const handleContinue = useCallback(async () => {
+    if (!plan) return;
+
+    try {
+      setStatus('saving');
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user?.id) {
+        setStatus('error');
+        setError('Please sign in again to save your plan.');
+        return;
+      }
+
+      const { error: saveError } = await supabase.from('study_plans').upsert(
+        {
+          user_id: user.id,
+          plan_json: plan as unknown as Record<string, unknown>,
+          start_iso: plan.startISO,
+          weeks: plan.weeks,
+          goal_band: plan.goalBand ?? null,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id' },
+      );
+
+      if (saveError) {
+        setStatus('error');
+        setError('Could not save your study plan. Please try again.');
+        return;
+      }
+
+      await router.replace(nextPath);
+    } catch (err) {
+      console.error('Failed to save onboarding study plan', err);
+      setStatus('error');
+      setError('Could not save your study plan. Please try again.');
+    }
+  }, [nextPath, plan, router]);
+
+  const firstThreeDays = plan?.days.slice(0, 3) ?? [];
+
+  return (
+    <main className="min-h-screen bg-background">
+      <Container className="flex min-h-screen items-center justify-center py-10">
+        <Card className="w-full max-w-3xl space-y-6 p-6 sm:p-8" insetBorder>
+          {(status === 'generating' || status === 'saving') && (
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                Buddy AI is working
+              </p>
+              <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+                {status === 'generating'
+                  ? 'Generating your personalized study plan…'
+                  : 'Saving your study plan…'}
+              </h1>
+              <p className="text-sm text-muted-foreground sm:text-base">
+                We are combining your exam timeline, target band, and preferred study rhythm.
+              </p>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                <div className="h-full w-1/3 animate-pulse rounded-full bg-primary" />
+              </div>
+            </div>
+          )}
+
+          {status === 'ready' && plan && (
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                  Your Buddy AI draft is ready
+                </p>
+                <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+                  Review your generated study plan
+                </h1>
+                <p className="text-sm text-muted-foreground sm:text-base">
+                  Confirm this plan to continue, or regenerate if you want a different balance.
+                </p>
+              </div>
+
+              <div className="grid gap-3 rounded-2xl border border-border bg-card/60 p-4 text-sm sm:grid-cols-3">
+                <div>
+                  <p className="text-muted-foreground">Target band</p>
+                  <p className="font-semibold">{plan.goalBand?.toFixed(1) ?? '7.0'}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">Study days</p>
+                  <p className="font-semibold">{availability.map((slot) => DAY_LABELS[slot.day]).join(', ')}</p>
+                </div>
+                <div>
+                  <p className="text-muted-foreground">Plan duration</p>
+                  <p className="font-semibold">{plan.weeks} weeks</p>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <p className="text-sm font-semibold">First sessions</p>
+                {firstThreeDays.map((day) => (
+                  <div key={day.iso} className="rounded-xl border border-border p-3">
+                    <p className="text-sm font-medium">{new Date(day.iso).toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' })}</p>
+                    <ul className="mt-2 list-disc pl-5 text-sm text-muted-foreground">
+                      {day.tasks.slice(0, 2).map((task) => (
+                        <li key={task.id}>
+                          {task.title} · {task.estMinutes} mins
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <Button onClick={handleContinue}>Continue with this plan</Button>
+                <Button variant="secondary" onClick={() => void generatePlan()}>
+                  Regenerate plan
+                </Button>
+                <Button variant="ghost" onClick={() => void router.push('/profile/setup')}>
+                  Change onboarding details
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {status === 'error' && (
+            <div className="space-y-4">
+              <h1 className="text-2xl font-semibold tracking-tight">We couldn’t finish your study plan</h1>
+              <p className="text-sm text-destructive">{error ?? 'Please try again.'}</p>
+              <div className="flex gap-3">
+                <Button onClick={() => void generatePlan()}>Try again</Button>
+                <Button variant="ghost" onClick={() => void router.push('/dashboard')}>
+                  Go to dashboard
+                </Button>
+              </div>
+            </div>
+          )}
+        </Card>
+      </Container>
+    </main>
+  );
+};
+
+export default OnboardingStudyPlanPage;


### PR DESCRIPTION
### Motivation
- Users finishing onboarding should be taken to an AI-generated study-plan review flow instead of landing immediately on the dashboard so they can review and consent to a personalised plan from Buddy AI. 
- Provide a clear loading/generation state and a simple review/consent UI that lets learners accept, regenerate, or change onboarding details before the plan is persisted. 

### Description
- Changed the notifications onboarding final destination logic so the default `next` target becomes `/onboarding/study-plan` and prevented looping back into other onboarding routes by normalising `next` handling in `pages/onboarding/notifications.tsx`. 
- Added a new page `pages/onboarding/study-plan.tsx` which: fetches onboarding preferences via `/api/onboarding`, builds `PlanGenOptions`, calls `generateStudyPlan` from `lib/studyPlan`, shows a `generating | ready | saving | error` UI branded as Buddy AI, and displays plan highlights and the first few sessions for review. 
- Implemented consent persistence in the new page: when the user confirms, the generated plan is upserted into the `study_plans` table (via `supabaseBrowser.from('study_plans').upsert(...)`) and the user is redirected to the chosen `next` path (defaults to `/study-plan`). 

### Testing
- Ran a targeted lint invocation (`npm run lint -- --file pages/onboarding/notifications.tsx --file pages/onboarding/study-plan.tsx`), which failed in this environment because the `next` binary was not available (`next: not found`). 
- Attempted dependency install (`npm ci`) to activate local tooling, but it failed due to a lockfile / package mismatch (`npm ci` aborted; lockfile needs updating with `npm install`). 
- Tried a Playwright screenshot of `http://127.0.0.1:3000/onboarding/study-plan` to validate runtime UI, but the request failed with `ERR_EMPTY_RESPONSE` because no local Next server was running in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acac40feb0832f82954b025ed55ce1)