### PR TITLE
Refactor dashboard into typed, reusable section components

### DIFF
--- a/components/dashboard/sections/AIWorkspaceSection.tsx
+++ b/components/dashboard/sections/AIWorkspaceSection.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+
+import { Badge } from '@/components/design-system/Badge';
+import { Button } from '@/components/design-system/Button';
+import { Card } from '@/components/design-system/Card';
+import Icon from '@/components/design-system/Icon';
+
+import type { InnovationTile, TileAction } from './types';
+
+type AIWorkspaceSectionProps = {
+  innovationTiles: InnovationTile[];
+};
+
+const accentClass: Record<NonNullable<InnovationTile['accent']>, string> = {
+  primary: 'bg-primary/15 text-primary',
+  secondary: 'bg-secondary/15 text-secondary',
+  success: 'bg-success/15 text-success',
+  info: 'bg-electricBlue/15 text-electricBlue',
+};
+
+function renderTileAction(key: string, action: TileAction, variant: 'primary' | 'ghost') {
+  return 'href' in action ? (
+    <Button key={key} size="sm" variant={variant} className="rounded-ds-xl" asChild>
+      <Link href={action.href}>{action.label}</Link>
+    </Button>
+  ) : (
+    <Button
+      key={key}
+      size="sm"
+      variant={variant}
+      className="rounded-ds-xl"
+      onClick={action.action}
+    >
+      {action.label}
+    </Button>
+  );
+}
+
+export function AIWorkspaceSection({ innovationTiles }: AIWorkspaceSectionProps) {
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-slab text-h2">AI workspace</h2>
+          <p className="text-grayish">
+            Keep your adaptive tools in one consistent hub—jump in wherever you need support.
+          </p>
+        </div>
+        <Badge variant="neutral" size="sm">
+          Always improving
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {innovationTiles.map((tile) => {
+          const iconBg = tile.accent ? accentClass[tile.accent] : accentClass.primary;
+          const badgeVariant: 'accent' | 'success' | 'neutral' =
+            tile.badge === 'Rocket' ? 'accent' : tile.badge === 'New' ? 'success' : 'neutral';
+
+          return (
+            <Card
+              key={tile.id}
+              className="group flex h-full flex-col justify-between gap-6 rounded-ds-2xl border border-border/60 bg-card/60 p-6 shadow-sm transition hover:-translate-y-1 hover:bg-card/90 hover:shadow-lg"
+            >
+              <div className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <span
+                    className={`inline-flex h-10 w-10 items-center justify-center rounded-xl ${iconBg}`}
+                  >
+                    <Icon name={tile.icon} size={20} />
+                  </span>
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-semibold text-lg text-foreground">{tile.title}</h3>
+                      {tile.badge ? (
+                        <Badge variant={badgeVariant} size="xs">
+                          {tile.badge}
+                        </Badge>
+                      ) : null}
+                    </div>
+                    <p className="text-sm text-muted-foreground">{tile.description}</p>
+                  </div>
+                </div>
+                {tile.meta ? <p className="text-xs text-muted-foreground">{tile.meta}</p> : null}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                {renderTileAction(`${tile.id}-primary`, tile.primary, 'primary')}
+                {tile.secondary
+                  ? renderTileAction(`${tile.id}-secondary`, tile.secondary, 'ghost')
+                  : null}
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/sections/CalendarSection.tsx
+++ b/components/dashboard/sections/CalendarSection.tsx
@@ -1,0 +1,27 @@
+import type { ComponentType } from 'react';
+import Link from 'next/link';
+
+import { Button } from '@/components/design-system/Button';
+
+type CalendarSectionProps = {
+  StudyCalendar: ComponentType;
+};
+
+export function CalendarSection({ StudyCalendar }: CalendarSectionProps) {
+  return (
+    <div className="mt-10 space-y-4" id="study-calendar">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-slab text-h2">Weekly momentum</h2>
+          <p className="text-grayish">Protect your streak by finishing the scheduled sessions.</p>
+        </div>
+        <Link href="/study-plan" className="shrink-0">
+          <Button variant="ghost" size="sm" className="rounded-ds-xl">
+            Adjust schedule
+          </Button>
+        </Link>
+      </div>
+      <StudyCalendar />
+    </div>
+  );
+}

--- a/components/dashboard/sections/ChallengeSection.tsx
+++ b/components/dashboard/sections/ChallengeSection.tsx
@@ -1,0 +1,41 @@
+import { Card } from '@/components/design-system/Card';
+
+import ChallengeSpotlightCard from '@/components/dashboard/ChallengeSpotlightCard';
+import DailyWeeklyChallenges from '@/components/dashboard/DailyWeeklyChallenges';
+import JoinWeeklyChallengeCard from '@/components/dashboard/JoinWeeklyChallengeCard';
+
+type ChallengeEnrollment = {
+  cohort: string;
+  progress: Record<string, 'pending' | 'done' | 'skipped'> | null;
+};
+
+type ChallengeSectionProps = {
+  loading: boolean;
+  challengeEnrollment: ChallengeEnrollment | null;
+};
+
+export function ChallengeSection({ loading, challengeEnrollment }: ChallengeSectionProps) {
+  return (
+    <>
+      <div className="mt-10" id="weekly-challenge">
+        {loading ? (
+          <Card className="rounded-ds-2xl border border-border/60 bg-card/70 p-6">
+            <div className="h-6 w-40 animate-pulse rounded bg-border" />
+            <div className="mt-4 h-24 w-full animate-pulse rounded bg-border" />
+          </Card>
+        ) : challengeEnrollment ? (
+          <ChallengeSpotlightCard
+            cohortId={challengeEnrollment.cohort}
+            progress={challengeEnrollment.progress ?? null}
+          />
+        ) : (
+          <JoinWeeklyChallengeCard />
+        )}
+      </div>
+
+      <div className="mt-6">
+        <DailyWeeklyChallenges />
+      </div>
+    </>
+  );
+}

--- a/components/dashboard/sections/PriorityActionsSection.tsx
+++ b/components/dashboard/sections/PriorityActionsSection.tsx
@@ -1,0 +1,93 @@
+import { Badge } from '@/components/design-system/Badge';
+import { Button } from '@/components/design-system/Button';
+import { Card } from '@/components/design-system/Card';
+import Icon from '@/components/design-system/Icon';
+import Link from 'next/link';
+
+import type { ActionItem, InnovationTile, TileAction } from './types';
+
+type PriorityActionsSectionProps = {
+  actionItems: ActionItem[];
+};
+
+const accentClass: Record<NonNullable<InnovationTile['accent']>, string> = {
+  primary: 'bg-primary/15 text-primary',
+  secondary: 'bg-secondary/15 text-secondary',
+  success: 'bg-success/15 text-success',
+  info: 'bg-electricBlue/15 text-electricBlue',
+};
+
+function renderTileAction(key: string, action: TileAction, variant: 'primary' | 'ghost') {
+  return 'href' in action ? (
+    <Button key={key} size="sm" variant={variant} className="rounded-ds-xl" asChild>
+      <Link href={action.href}>{action.label}</Link>
+    </Button>
+  ) : (
+    <Button
+      key={key}
+      size="sm"
+      variant={variant}
+      className="rounded-ds-xl"
+      onClick={action.action}
+    >
+      {action.label}
+    </Button>
+  );
+}
+
+export function PriorityActionsSection({ actionItems }: PriorityActionsSectionProps) {
+  return (
+    <section className="mt-10 space-y-4" id="goal-summary">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-slab text-h2">Today&apos;s priorities</h2>
+          <p className="text-grayish">Move the needle with the highest leverage actions first.</p>
+        </div>
+        <Badge variant="neutral" size="sm">
+          Action-first view
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {actionItems.map((item) => (
+          <Card
+            key={item.id}
+            className="flex h-full flex-col justify-between gap-5 rounded-ds-2xl border border-border/60 bg-card/60 p-6"
+          >
+            <div className="space-y-3">
+              <div className="flex items-start gap-3">
+                <span
+                  className={`inline-flex h-10 w-10 items-center justify-center rounded-xl ${accentClass[item.accent]}`}
+                >
+                  <Icon name={item.icon} size={20} />
+                </span>
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-semibold text-lg text-foreground">{item.title}</h3>
+                    {item.done ? (
+                      <Badge variant="success" size="xs">
+                        Done
+                      </Badge>
+                    ) : null}
+                    {item.chip ? (
+                      <Badge variant="neutral" size="xs">
+                        {item.chip}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <p className="text-sm text-muted-foreground">{item.caption}</p>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {renderTileAction(`${item.id}-primary`, item.primary, 'primary')}
+              {item.secondary
+                ? renderTileAction(`${item.id}-secondary`, item.secondary, 'ghost')
+                : null}
+            </div>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/sections/ProfileHeaderSection.tsx
+++ b/components/dashboard/sections/ProfileHeaderSection.tsx
@@ -1,0 +1,180 @@
+import Image from 'next/image';
+
+import { Badge } from '@/components/design-system/Badge';
+import { Button } from '@/components/design-system/Button';
+import Icon from '@/components/design-system/Icon';
+import { StreakIndicator } from '@/components/design-system/StreakIndicator';
+
+type BadgeMeta = {
+  id: string;
+  name: string;
+  icon: string;
+};
+
+type ProfileHeaderSectionProps = {
+  profileAvatarUrl: string | null;
+  fullName?: string | null;
+  preferredLanguage?: string | null;
+  goalBand: number | null;
+  targetStudyTime: string;
+  streak: number;
+  shields: number;
+  topBadges: BadgeMeta[];
+  onClaimShield: () => void;
+  onUseShield: () => void;
+  onOpenAICoach: () => void;
+  onOpenStudyBuddy: () => void;
+  onOpenMistakesBook: () => void;
+  onOpenWhatsAppTasks: () => void;
+  onShareProgress: () => void;
+};
+
+function getInitials(fullName?: string | null) {
+  return (
+    (fullName || 'Learner')
+      .split(' ')
+      .slice(0, 2)
+      .map((part) => part.charAt(0).toUpperCase())
+      .join('') || 'L'
+  );
+}
+
+export function ProfileHeaderSection({
+  profileAvatarUrl,
+  fullName,
+  preferredLanguage,
+  goalBand,
+  targetStudyTime,
+  streak,
+  shields,
+  topBadges,
+  onClaimShield,
+  onUseShield,
+  onOpenAICoach,
+  onOpenStudyBuddy,
+  onOpenMistakesBook,
+  onOpenWhatsAppTasks,
+  onShareProgress,
+}: ProfileHeaderSectionProps) {
+  return (
+    <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+      <div className="flex items-start gap-4">
+        {profileAvatarUrl ? (
+          <Image
+            src={profileAvatarUrl}
+            alt={fullName ? `${fullName} avatar` : 'Profile avatar'}
+            width={64}
+            height={64}
+            className="h-16 w-16 rounded-full object-cover ring-2 ring-primary/40"
+          />
+        ) : (
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-h3 font-semibold text-primary">
+            {getInitials(fullName)}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <div>
+            <h1 className="font-slab text-display text-gradient-primary">
+              Welcome back, {fullName || 'Learner'}
+            </h1>
+            <p className="text-grayish">
+              Every module below is wired into your IELTS goal—choose where to dive in next.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-small text-muted-foreground">
+            <span>Preferred language: {(preferredLanguage ?? 'en').toUpperCase()}</span>
+            {typeof goalBand === 'number' ? (
+              <span>• Target band {goalBand.toFixed(1)}</span>
+            ) : (
+              <span>• Set your goal to unlock tailored guidance</span>
+            )}
+            {targetStudyTime ? <span>• Study rhythm: {targetStudyTime}</span> : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-start gap-3 md:items-end">
+        <div className="flex flex-wrap items-center gap-3">
+          <StreakIndicator value={streak} />
+          {streak >= 7 && (
+            <Badge variant="success" size="sm">
+              🔥 {streak}-day streak!
+            </Badge>
+          )}
+          <Badge size="sm">🛡 {shields}</Badge>
+          <Button onClick={onClaimShield} variant="secondary" className="rounded-ds-xl">
+            Claim Shield
+          </Button>
+          {shields > 0 && (
+            <Button onClick={onUseShield} variant="secondary" className="rounded-ds-xl">
+              Use Shield
+            </Button>
+          )}
+        </div>
+
+        {topBadges.length ? (
+          <div className="flex flex-wrap items-center gap-2 text-2xl">
+            {topBadges.map((meta) => (
+              <span key={meta.id} aria-label={meta.name} title={meta.name}>
+                {meta.icon}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            onClick={onOpenAICoach}
+            variant="soft"
+            tone="primary"
+            size="sm"
+            className="rounded-ds-xl"
+            leadingIcon={<Icon name="Sparkles" size={16} className="text-primary" />}
+          >
+            AI Coach
+          </Button>
+          <Button
+            onClick={onOpenStudyBuddy}
+            variant="soft"
+            tone="secondary"
+            size="sm"
+            className="rounded-ds-xl"
+            leadingIcon={<Icon name="Users" size={16} className="text-secondary" />}
+          >
+            Study Buddy
+          </Button>
+          <Button
+            onClick={onOpenMistakesBook}
+            variant="soft"
+            tone="success"
+            size="sm"
+            className="rounded-ds-xl"
+            leadingIcon={<Icon name="NotebookPen" size={16} className="text-success" />}
+          >
+            Mistakes Book
+          </Button>
+          <Button
+            onClick={onOpenWhatsAppTasks}
+            variant="soft"
+            tone="info"
+            size="sm"
+            className="rounded-ds-xl"
+            leadingIcon={<Icon name="MessageCircle" size={16} className="text-electricBlue" />}
+          >
+            WhatsApp Tasks
+          </Button>
+          <Button
+            onClick={onShareProgress}
+            variant="ghost"
+            size="sm"
+            className="rounded-ds-xl"
+            leadingIcon={<Icon name="Share2" size={16} />}
+          >
+            Share progress
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/sections/QuickActionsSection.tsx
+++ b/components/dashboard/sections/QuickActionsSection.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+import { ReadingStatsCard } from '@/components/reading/ReadingStatsCard';
+import QuickDrillButton from '@/components/quick/QuickDrillButton';
+
+type QuickActionsSectionProps = {
+  speakingVocabSlug: string;
+  onShareDashboard: () => void;
+};
+
+export function QuickActionsSection({
+  speakingVocabSlug,
+  onShareDashboard,
+}: QuickActionsSectionProps) {
+  return (
+    <div className="mt-10 grid gap-6 lg:grid-cols-[1fr_.9fr]">
+      <Card className="rounded-ds-2xl p-6">
+        <h2 className="font-slab text-h2">Quick actions</h2>
+        <p className="mt-1 text-grayish">Jump back in with one click.</p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <QuickDrillButton />
+          <Link href="/learning">
+            <Button variant="primary" className="rounded-ds-xl">
+              Start today&apos;s lesson
+            </Button>
+          </Link>
+          <Link href="/mock">
+            <Button variant="secondary" className="rounded-ds-xl">
+              Take a mock test
+            </Button>
+          </Link>
+          <Link href="/writing">
+            <Button variant="accent" className="rounded-ds-xl">
+              Practice writing
+            </Button>
+          </Link>
+          <Link href="/reading">
+            <Button variant="secondary" className="rounded-ds-xl">
+              Practice reading
+            </Button>
+          </Link>
+          <Link href={`/vocabulary/speaking/${speakingVocabSlug}`}>
+            <Button variant="secondary" className="rounded-ds-xl">
+              Speaking vocab today
+            </Button>
+          </Link>
+          <Link href="/progress">
+            <Button variant="ghost" className="rounded-ds-xl">
+              Review progress report
+            </Button>
+          </Link>
+          <Link href="#visa-target">
+            <Button variant="ghost" className="rounded-ds-xl">
+              Check visa target
+            </Button>
+          </Link>
+          <Button onClick={onShareDashboard} variant="secondary" className="rounded-ds-xl">
+            Share progress
+          </Button>
+        </div>
+      </Card>
+
+      <ReadingStatsCard />
+    </div>
+  );
+}

--- a/components/dashboard/sections/RoadmapSection.tsx
+++ b/components/dashboard/sections/RoadmapSection.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+import { GoalRoadmap } from '@/components/feature/GoalRoadmap';
+import { Button } from '@/components/design-system/Button';
+
+type RoadmapSectionProps = {
+  examDate: string | null;
+};
+
+export function RoadmapSection({ examDate }: RoadmapSectionProps) {
+  return (
+    <div className="mt-10">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-slab text-h2">Roadmap to exam day</h2>
+          <p className="text-grayish">See which stage you are in and what to do next.</p>
+        </div>
+        <Link href="/exam-day" className="shrink-0">
+          <Button variant="ghost" size="sm" className="rounded-ds-xl">
+            Plan exam day
+          </Button>
+        </Link>
+      </div>
+      <GoalRoadmap examDate={examDate} />
+    </div>
+  );
+}

--- a/components/dashboard/sections/SavedItemsSection.tsx
+++ b/components/dashboard/sections/SavedItemsSection.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+
+import SavedItems from '@/components/dashboard/SavedItems';
+import ShareLinkCard from '@/components/dashboard/ShareLinkCard';
+import WhatsAppOptIn from '@/components/dashboard/WhatsAppOptIn';
+import { Button } from '@/components/design-system/Button';
+import { Card } from '@/components/design-system/Card';
+import Icon from '@/components/design-system/Icon';
+
+export function SavedItemsSection() {
+  return (
+    <div className="mt-10 grid gap-6 md:grid-cols-2" id="saved-items">
+      <Card className="rounded-ds-2xl p-6 space-y-4">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-slab text-h2">Saved for later</h2>
+            <p className="text-grayish">Jump back to lessons and drills you flagged.</p>
+          </div>
+          <Link href="/saved" className="shrink-0">
+            <Button variant="ghost" size="sm" className="rounded-ds-xl">
+              Manage saved items
+            </Button>
+          </Link>
+        </div>
+        <SavedItems />
+      </Card>
+
+      <div className="space-y-4">
+        <ShareLinkCard />
+        <Card className="flex flex-col gap-4 rounded-ds-2xl border border-border/60 bg-card/60 p-5">
+          <div className="flex items-start gap-3">
+            <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-electricBlue/15 text-electricBlue">
+              <Icon name="MessageCircle" size={18} />
+            </span>
+            <div className="space-y-1">
+              <h4 className="font-semibold text-foreground">WhatsApp Tasks</h4>
+              <p className="text-sm text-muted-foreground">
+                Receive daily micro-tasks and reminders via WhatsApp.
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Also available in the AI workspace section above.
+              </p>
+            </div>
+          </div>
+          <WhatsAppOptIn />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/sections/UpgradeSection.tsx
+++ b/components/dashboard/sections/UpgradeSection.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+
+import { Alert } from '@/components/design-system/Alert';
+import { Button } from '@/components/design-system/Button';
+import { Card } from '@/components/design-system/Card';
+
+type UpgradeSectionProps = {
+  aiNotes: string[];
+};
+
+export function UpgradeSection({ aiNotes }: UpgradeSectionProps) {
+  return (
+    <div className="mt-10 grid gap-6 md:grid-cols-2">
+      <Card className="rounded-ds-2xl p-6">
+        <h3 className="mb-2 font-slab text-h3">Upgrade to Rocket 🚀</h3>
+        <p className="text-body opacity-90">
+          Unlock AI deep feedback, speaking evaluator, and full analytics.
+        </p>
+        <div className="mt-4">
+          <Link href="/pricing">
+            <Button variant="primary" className="rounded-ds-xl">
+              See Plans
+            </Button>
+          </Link>
+        </div>
+      </Card>
+
+      <Card className="rounded-ds-2xl p-6">
+        <h3 className="font-slab text-h3">Coach Notes</h3>
+        {aiNotes.length ? (
+          <ul className="mt-3 list-disc pl-6 text-body">
+            {aiNotes.map((note, i) => (
+              <li key={i}>{note}</li>
+            ))}
+          </ul>
+        ) : (
+          <Alert variant="info" className="mt-3">
+            Add more details in <b>Profile</b> to refine your AI plan.
+          </Alert>
+        )}
+        <div className="mt-4">
+          <Link href="/profile/setup">
+            <Button variant="secondary" className="rounded-ds-xl">
+              Edit Profile
+            </Button>
+          </Link>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/components/dashboard/sections/types.ts
+++ b/components/dashboard/sections/types.ts
@@ -1,0 +1,29 @@
+import type { IconName } from '@/components/design-system/Icon';
+
+export type TileAction =
+  | { label: string; href: string; action?: never }
+  | { label: string; action: () => void; href?: never };
+
+export type InnovationTile = {
+  id: string;
+  title: string;
+  description: string;
+  icon: IconName;
+  accent?: 'primary' | 'secondary' | 'success' | 'info';
+  badge?: string;
+  meta?: string;
+  primary: TileAction;
+  secondary?: TileAction;
+};
+
+export type ActionItem = {
+  id: string;
+  title: string;
+  caption: string;
+  icon: IconName;
+  accent: NonNullable<InnovationTile['accent']>;
+  primary: TileAction;
+  secondary?: TileAction;
+  chip?: string | null;
+  done?: boolean;
+};

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type { NextPage } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 
@@ -9,9 +8,7 @@ import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
-import Icon, { type IconName } from '@/components/design-system/Icon';
 import { Alert } from '@/components/design-system/Alert';
-import { StreakIndicator } from '@/components/design-system/StreakIndicator';
 
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
 import { useStreak } from '@/hooks/useStreak';
@@ -19,27 +16,27 @@ import { getDayKeyInTZ } from '@/lib/streak';
 import { useSignedAvatar } from '@/hooks/useSignedAvatar';
 import { useChallengeEnrollments } from '@/hooks/useChallengeEnrollments';
 import { useNextTask } from '@/hooks/useNextTask';
-import { useStudyPlan } from '@/hooks/useStudyPlan'; // New hook
+import { useStudyPlan } from '@/hooks/useStudyPlan';
 
 import { badges } from '@/data/badges';
-import { ReadingStatsCard } from '@/components/reading/ReadingStatsCard';
-import QuickDrillButton from '@/components/quick/QuickDrillButton';
 import { VocabularySpotlightFeature } from '@/components/feature/VocabularySpotlight';
 import { StreakCounter } from '@/components/streak/StreakCounter';
 import { NextTaskCard } from '@/components/reco/NextTaskCard';
 
-import SavedItems from '@/components/dashboard/SavedItems';
-import ShareLinkCard from '@/components/dashboard/ShareLinkCard';
-import WhatsAppOptIn from '@/components/dashboard/WhatsAppOptIn';
-import JoinWeeklyChallengeCard from '@/components/dashboard/JoinWeeklyChallengeCard';
-import ChallengeSpotlightCard from '@/components/dashboard/ChallengeSpotlightCard';
-import DailyWeeklyChallenges from '@/components/dashboard/DailyWeeklyChallenges';
 import GapToGoal from '@/components/visa/GapToGoal';
-import GoalRoadmap from '@/components/feature/GoalRoadmap';
+import { AIWorkspaceSection } from '@/components/dashboard/sections/AIWorkspaceSection';
+import { CalendarSection } from '@/components/dashboard/sections/CalendarSection';
+import { ChallengeSection } from '@/components/dashboard/sections/ChallengeSection';
+import { PriorityActionsSection } from '@/components/dashboard/sections/PriorityActionsSection';
+import { ProfileHeaderSection } from '@/components/dashboard/sections/ProfileHeaderSection';
+import { QuickActionsSection } from '@/components/dashboard/sections/QuickActionsSection';
+import { RoadmapSection } from '@/components/dashboard/sections/RoadmapSection';
+import { SavedItemsSection } from '@/components/dashboard/sections/SavedItemsSection';
+import { UpgradeSection } from '@/components/dashboard/sections/UpgradeSection';
+import type { ActionItem, InnovationTile } from '@/components/dashboard/sections/types';
 
 import type { Profile, AIPlan } from '@/types/profile';
 import type { SubscriptionTier } from '@/lib/navigation/types';
-import type { StudyDay } from '@/types/plan';
 
 const StudyCalendar = dynamic(() => import('@/components/feature/StudyCalendar'), {
   ssr: false,
@@ -73,34 +70,6 @@ const loadingSkeleton = (
     </Container>
   </section>
 );
-
-type TileAction =
-  | { label: string; href: string; action?: never }
-  | { label: string; action: () => void; href?: never };
-
-type InnovationTile = {
-  id: string;
-  title: string;
-  description: string;
-  icon: IconName;
-  accent?: 'primary' | 'secondary' | 'success' | 'info';
-  badge?: string;
-  meta?: string;
-  primary: TileAction;
-  secondary?: TileAction;
-};
-
-type ActionItem = {
-  id: string;
-  title: string;
-  caption: string;
-  icon: IconName;
-  accent: NonNullable<InnovationTile['accent']>;
-  primary: TileAction;
-  secondary?: TileAction;
-  chip?: string | null;
-  done?: boolean;
-};
 
 const Dashboard: NextPage = () => {
   const [loading, setLoading] = useState(true);
@@ -492,34 +461,6 @@ const Dashboard: NextPage = () => {
 
   if (loading) return loadingSkeleton;
 
-  const accentClass: Record<NonNullable<InnovationTile['accent']>, string> = {
-    primary: 'bg-primary/15 text-primary',
-    secondary: 'bg-secondary/15 text-secondary',
-    success: 'bg-success/15 text-success',
-    info: 'bg-electricBlue/15 text-electricBlue',
-  };
-
-  const renderTileAction = (
-    key: string,
-    action: TileAction,
-    variant: 'primary' | 'ghost',
-  ) =>
-    'href' in action ? (
-      <Button key={key} size="sm" variant={variant} className="rounded-ds-xl" asChild>
-        <Link href={action.href}>{action.label}</Link>
-      </Button>
-    ) : (
-      <Button
-        key={key}
-        size="sm"
-        variant={variant}
-        className="rounded-ds-xl"
-        onClick={action.action}
-      >
-        {action.label}
-      </Button>
-    );
-
   return (
     <>
       <Head>
@@ -548,158 +489,26 @@ const Dashboard: NextPage = () => {
                 </div>
               </Alert>
             )}
-
-            {/* HERO */}
-            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-              <div className="flex items-start gap-4">
-                {profileAvatarUrl ? (
-                  <Image
-                    src={profileAvatarUrl}
-                    alt={
-                      profile?.full_name ? `${profile.full_name} avatar` : 'Profile avatar'
-                    }
-                    width={64}
-                    height={64}
-                    className="h-16 w-16 rounded-full object-cover ring-2 ring-primary/40"
-                  />
-                ) : (
-                  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-h3 font-semibold text-primary">
-                    {(profile?.full_name || 'Learner')
-                      .split(' ')
-                      .slice(0, 2)
-                      .map((p) => p.charAt(0).toUpperCase())
-                      .join('') || 'L'}
-                  </div>
-                )}
-
-                <div className="space-y-2">
-                  <div>
-                    <h1 className="font-slab text-display text-gradient-primary">
-                      Welcome back, {profile?.full_name || 'Learner'}
-                    </h1>
-                    <p className="text-grayish">
-                      Every module below is wired into your IELTS goal—choose where to dive
-                      in next.
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2 text-small text-muted-foreground">
-                    <span>
-                      Preferred language: {(profile?.preferred_language ?? 'en').toUpperCase()}
-                    </span>
-                    {typeof goalBand === 'number' ? (
-                      <span>• Target band {goalBand.toFixed(1)}</span>
-                    ) : (
-                      <span>• Set your goal to unlock tailored guidance</span>
-                    )}
-                    {targetStudyTime ? (
-                      <span>• Study rhythm: {targetStudyTime}</span>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex flex-col items-start gap-3 md:items-end">
-                <div className="flex flex-wrap items-center gap-3">
-                  <StreakIndicator value={streak} />
-                  {streak >= 7 && (
-                    <Badge variant="success" size="sm">
-                      🔥 {streak}-day streak!
-                    </Badge>
-                  )}
-                  <Badge size="sm">🛡 {shields}</Badge>
-                  <Button
-                    onClick={claimShield}
-                    variant="secondary"
-                    className="rounded-ds-xl"
-                  >
-                    Claim Shield
-                  </Button>
-                  {shields > 0 && (
-                    <Button
-                      onClick={useShield}
-                      variant="secondary"
-                      className="rounded-ds-xl"
-                    >
-                      Use Shield
-                    </Button>
-                  )}
-                </div>
-
-                {topBadges.length ? (
-                  <div className="flex flex-wrap items-center gap-2 text-2xl">
-                    {topBadges.map((meta) => (
-                      <span key={meta.id} aria-label={meta.name} title={meta.name}>
-                        {meta.icon}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    onClick={openAICoach}
-                    variant="soft"
-                    tone="primary"
-                    size="sm"
-                    className="rounded-ds-xl"
-                    leadingIcon={
-                      <Icon name="Sparkles" size={16} className="text-primary" />
-                    }
-                  >
-                    AI Coach
-                  </Button>
-                  <Button
-                    onClick={openStudyBuddy}
-                    variant="soft"
-                    tone="secondary"
-                    size="sm"
-                    className="rounded-ds-xl"
-                    leadingIcon={<Icon name="Users" size={16} className="text-secondary" />}
-                  >
-                    Study Buddy
-                  </Button>
-                  <Button
-                    onClick={openMistakesBook}
-                    variant="soft"
-                    tone="success"
-                    size="sm"
-                    className="rounded-ds-xl"
-                    leadingIcon={
-                      <Icon name="NotebookPen" size={16} className="text-success" />
-                    }
-                  >
-                    Mistakes Book
-                  </Button>
-                  <Button
-                    onClick={openWhatsAppTasks}
-                    variant="soft"
-                    tone="info"
-                    size="sm"
-                    className="rounded-ds-xl"
-                    leadingIcon={
-                      <Icon
-                        name="MessageCircle"
-                        size={16}
-                        className="text-electricBlue"
-                      />
-                    }
-                  >
-                    WhatsApp Tasks
-                  </Button>
-                  <Button
-                    onClick={shareDashboard}
-                    variant="ghost"
-                    size="sm"
-                    className="rounded-ds-xl"
-                    leadingIcon={<Icon name="Share2" size={16} />}
-                  >
-                    Share progress
-                  </Button>
-                </div>
-              </div>
-            </div>
+            <ProfileHeaderSection
+              profileAvatarUrl={profileAvatarUrl}
+              fullName={profile?.full_name}
+              preferredLanguage={profile?.preferred_language}
+              goalBand={goalBand}
+              targetStudyTime={targetStudyTime}
+              streak={streak}
+              shields={shields}
+              topBadges={topBadges}
+              onClaimShield={claimShield}
+              onUseShield={useShield}
+              onOpenAICoach={openAICoach}
+              onOpenStudyBuddy={openStudyBuddy}
+              onOpenMistakesBook={openMistakesBook}
+              onOpenWhatsAppTasks={openWhatsAppTasks}
+              onShareProgress={shareDashboard}
+            />
 
             {/* STUDY PLAN TASKS FOR TODAY */}
+
             {!planLoading && todayTasks && todayTasks.length > 0 && (
               <Card className="p-6 rounded-ds-2xl border border-primary/20 bg-primary/5">
                 <div className="flex items-center justify-between mb-4">
@@ -735,80 +544,10 @@ const Dashboard: NextPage = () => {
               error={nextTaskError}
               onRefresh={() => refreshNextTask()}
             />
-
-            {/* AI WORKSPACE */}
-            <section className="space-y-4">
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h2 className="font-slab text-h2">AI workspace</h2>
-                  <p className="text-grayish">
-                    Keep your adaptive tools in one consistent hub—jump in wherever you
-                    need support.
-                  </p>
-                </div>
-                <Badge variant="neutral" size="sm">
-                  Always improving
-                </Badge>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                {innovationTiles.map((tile) => {
-                  const iconBg = tile.accent
-                    ? accentClass[tile.accent]
-                    : accentClass.primary;
-                  const badgeVariant: 'accent' | 'success' | 'neutral' =
-                    tile.badge === 'Rocket'
-                      ? 'accent'
-                      : tile.badge === 'New'
-                      ? 'success'
-                      : 'neutral';
-
-                  return (
-                    <Card
-                      key={tile.id}
-                      className="group flex h-full flex-col justify-between gap-6 rounded-ds-2xl border border-border/60 bg-card/60 p-6 shadow-sm transition hover:-translate-y-1 hover:bg-card/90 hover:shadow-lg"
-                    >
-                      <div className="space-y-4">
-                        <div className="flex items-start gap-3">
-                          <span
-                            className={`inline-flex h-10 w-10 items-center justify-center rounded-xl ${iconBg}`}
-                          >
-                            <Icon name={tile.icon} size={20} />
-                          </span>
-                          <div className="space-y-2">
-                            <div className="flex items-center gap-2">
-                              <h3 className="font-semibold text-lg text-foreground">
-                                {tile.title}
-                              </h3>
-                              {tile.badge ? (
-                                <Badge variant={badgeVariant} size="xs">
-                                  {tile.badge}
-                                </Badge>
-                              ) : null}
-                            </div>
-                            <p className="text-sm text-muted-foreground">
-                              {tile.description}
-                            </p>
-                          </div>
-                        </div>
-                        {tile.meta ? (
-                          <p className="text-xs text-muted-foreground">{tile.meta}</p>
-                        ) : null}
-                      </div>
-
-                      <div className="flex flex-wrap items-center gap-2">
-                        {renderTileAction(`${tile.id}-primary`, tile.primary, 'primary')}
-                        {tile.secondary
-                          ? renderTileAction(`${tile.id}-secondary`, tile.secondary, 'ghost')
-                          : null}
-                      </div>
-                    </Card>
-                  );
-                })}
-              </div>
-            </section>
+            <AIWorkspaceSection innovationTiles={innovationTiles} />
 
             {/* STREAK PANEL */}
+
             <div id="streak-panel">
               <StreakCounter
                 current={streak}
@@ -856,95 +595,21 @@ const Dashboard: NextPage = () => {
               </div>
               <VocabularySpotlightFeature />
             </div>
-
-            {/* WEEKLY CHALLENGE */}
-            <div className="mt-10" id="weekly-challenge">
-              {challengeLoading ? (
-                <Card className="rounded-ds-2xl border border-border/60 bg-card/70 p-6">
-                  <div className="h-6 w-40 animate-pulse rounded bg-border" />
-                  <div className="mt-4 h-24 w-full animate-pulse rounded bg-border" />
-                </Card>
-              ) : challengeEnrollment ? (
-                <ChallengeSpotlightCard
-                  cohortId={challengeEnrollment.cohort}
-                  progress={challengeEnrollment.progress ?? null}
-                />
-              ) : (
-                <JoinWeeklyChallengeCard />
-              )}
-            </div>
-
-            <div className="mt-6">
-              <DailyWeeklyChallenges />
-            </div>
-
-            {/* TODAY&apos;S PRIORITIES */}
-            <section className="mt-10 space-y-4" id="goal-summary">
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h2 className="font-slab text-h2">Today&apos;s priorities</h2>
-                  <p className="text-grayish">
-                    Move the needle with the highest leverage actions first.
-                  </p>
-                </div>
-                <Badge variant="neutral" size="sm">
-                  Action-first view
-                </Badge>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                {actionItems.map((item) => (
-                  <Card
-                    key={item.id}
-                    className="flex h-full flex-col justify-between gap-5 rounded-ds-2xl border border-border/60 bg-card/60 p-6"
-                  >
-                    <div className="space-y-3">
-                      <div className="flex items-start gap-3">
-                        <span
-                          className={`inline-flex h-10 w-10 items-center justify-center rounded-xl ${accentClass[item.accent]}`}
-                        >
-                          <Icon name={item.icon} size={20} />
-                        </span>
-                        <div className="space-y-2">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <h3 className="font-semibold text-lg text-foreground">
-                              {item.title}
-                            </h3>
-                            {item.done ? (
-                              <Badge variant="success" size="xs">
-                                Done
-                              </Badge>
-                            ) : null}
-                            {item.chip ? (
-                              <Badge variant="neutral" size="xs">
-                                {item.chip}
-                              </Badge>
-                            ) : null}
-                          </div>
-                          <p className="text-sm text-muted-foreground">{item.caption}</p>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      {renderTileAction(
-                        `${item.id}-primary`,
-                        item.primary,
-                        'primary',
-                      )}
-                      {item.secondary
-                        ? renderTileAction(
-                            `${item.id}-secondary`,
-                            item.secondary,
-                            'ghost',
-                          )
-                        : null}
-                    </div>
-                  </Card>
-                ))}
-              </div>
-            </section>
+            <ChallengeSection
+              loading={challengeLoading}
+              challengeEnrollment={
+                challengeEnrollment
+                  ? {
+                      cohort: challengeEnrollment.cohort,
+                      progress: challengeEnrollment.progress ?? null,
+                    }
+                  : null
+              }
+            />
+            <PriorityActionsSection actionItems={actionItems} />
 
             {/* NEXT LESSONS */}
+
             {((ai.sessionMix ?? ai.sequence) ?? []).length > 0 && (
               <div className="mt-10" id="next-sessions">
                 <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
@@ -1010,176 +675,14 @@ const Dashboard: NextPage = () => {
               </div>
               <GapToGoal />
             </div>
-
-            {/* STUDY CALENDAR */}
-            <div className="mt-10 space-y-4" id="study-calendar">
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h2 className="font-slab text-h2">Weekly momentum</h2>
-                  <p className="text-grayish">
-                    Protect your streak by finishing the scheduled sessions.
-                  </p>
-                </div>
-                <Link href="/study-plan" className="shrink-0">
-                  <Button variant="ghost" size="sm" className="rounded-ds-xl">
-                    Adjust schedule
-                  </Button>
-                </Link>
-              </div>
-              <StudyCalendar />
-            </div>
-
-            {/* ROADMAP */}
-            <div className="mt-10">
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h2 className="font-slab text-h2">Roadmap to exam day</h2>
-                  <p className="text-grayish">
-                    See which stage you are in and what to do next.
-                  </p>
-                </div>
-                <Link href="/exam-day" className="shrink-0">
-                  <Button variant="ghost" size="sm" className="rounded-ds-xl">
-                    Plan exam day
-                  </Button>
-                </Link>
-              </div>
-              <GoalRoadmap examDate={profile?.exam_date ?? null} />
-            </div>
-
-            {/* QUICK ACTIONS + READING */}
-            <div className="mt-10 grid gap-6 lg:grid-cols-[1fr_.9fr]">
-              <Card className="rounded-ds-2xl p-6">
-                <h2 className="font-slab text-h2">Quick actions</h2>
-                <p className="mt-1 text-grayish">Jump back in with one click.</p>
-                <div className="mt-6 flex flex-wrap gap-3">
-                  <QuickDrillButton />
-                  <Link href="/learning">
-                    <Button variant="primary" className="rounded-ds-xl">
-                      Start today&apos;s lesson
-                    </Button>
-                  </Link>
-                  <Link href="/mock">
-                    <Button variant="secondary" className="rounded-ds-xl">
-                      Take a mock test
-                    </Button>
-                  </Link>
-                  <Link href="/writing">
-                    <Button variant="accent" className="rounded-ds-xl">
-                      Practice writing
-                    </Button>
-                  </Link>
-                  <Link href="/reading">
-                    <Button variant="secondary" className="rounded-ds-xl">
-                      Practice reading
-                    </Button>
-                  </Link>
-                  {/* Speaking vocab quick access */}
-                  <Link href={`/vocabulary/speaking/${speakingVocabSlug}`}>
-                    <Button variant="secondary" className="rounded-ds-xl">
-                      Speaking vocab today
-                    </Button>
-                  </Link>
-                  <Link href="/progress">
-                    <Button variant="ghost" className="rounded-ds-xl">
-                      Review progress report
-                    </Button>
-                  </Link>
-                  <Link href="#visa-target">
-                    <Button variant="ghost" className="rounded-ds-xl">
-                      Check visa target
-                    </Button>
-                  </Link>
-                  <Button
-                    onClick={shareDashboard}
-                    variant="secondary"
-                    className="rounded-ds-xl"
-                  >
-                    Share progress
-                  </Button>
-                </div>
-              </Card>
-
-              <ReadingStatsCard />
-            </div>
-
-            {/* SAVED / WHATSAPP / SHARE */}
-            <div className="mt-10 grid gap-6 md:grid-cols-2" id="saved-items">
-              <Card className="rounded-ds-2xl p-6 space-y-4">
-                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <h2 className="font-slab text-h2">Saved for later</h2>
-                    <p className="text-grayish">Jump back to lessons and drills you flagged.</p>
-                  </div>
-                  <Link href="/saved" className="shrink-0">
-                    <Button variant="ghost" size="sm" className="rounded-ds-xl">
-                      Manage saved items
-                    </Button>
-                  </Link>
-                </div>
-                <SavedItems />
-              </Card>
-
-              <div className="space-y-4">
-                <ShareLinkCard />
-                <Card className="flex flex-col gap-4 rounded-ds-2xl border border-border/60 bg-card/60 p-5">
-                  <div className="flex items-start gap-3">
-                    <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-electricBlue/15 text-electricBlue">
-                      <Icon name="MessageCircle" size={18} />
-                    </span>
-                    <div className="space-y-1">
-                      <h4 className="font-semibold text-foreground">WhatsApp Tasks</h4>
-                      <p className="text-sm text-muted-foreground">
-                        Receive daily micro-tasks and reminders via WhatsApp.
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Also available in the AI workspace section above.
-                      </p>
-                    </div>
-                  </div>
-                  <WhatsAppOptIn />
-                </Card>
-              </div>
-            </div>
-
-            {/* UPGRADE & COACH NOTES */}
-            <div className="mt-10 grid gap-6 md:grid-cols-2">
-              <Card className="rounded-ds-2xl p-6">
-                <h3 className="mb-2 font-slab text-h3">Upgrade to Rocket 🚀</h3>
-                <p className="text-body opacity-90">
-                  Unlock AI deep feedback, speaking evaluator, and full analytics.
-                </p>
-                <div className="mt-4">
-                  <Link href="/pricing">
-                    <Button variant="primary" className="rounded-ds-xl">
-                      See Plans
-                    </Button>
-                  </Link>
-                </div>
-              </Card>
-
-              <Card className="rounded-ds-2xl p-6">
-                <h3 className="font-slab text-h3">Coach Notes</h3>
-                {Array.isArray(ai?.notes) && ai.notes.length ? (
-                  <ul className="mt-3 list-disc pl-6 text-body">
-                    {ai.notes.map((n: string, i: number) => (
-                      <li key={i}>{n}</li>
-                    ))}
-                  </ul>
-                ) : (
-                  <Alert variant="info" className="mt-3">
-                    Add more details in <b>Profile</b> to refine your AI plan.
-                  </Alert>
-                )}
-                <div className="mt-4">
-                  <Link href="/profile/setup">
-                    <Button variant="secondary" className="rounded-ds-xl">
-                      Edit Profile
-                    </Button>
-                  </Link>
-                </div>
-              </Card>
-            </div>
+            <CalendarSection StudyCalendar={StudyCalendar} />
+            <RoadmapSection examDate={profile?.exam_date ?? null} />
+            <QuickActionsSection
+              speakingVocabSlug={speakingVocabSlug}
+              onShareDashboard={shareDashboard}
+            />
+            <SavedItemsSection />
+            <UpgradeSection aiNotes={Array.isArray(ai?.notes) ? ai.notes : []} />
           </div>
         </Container>
       </section>


### PR DESCRIPTION
### Motivation
- Break the large, monolithic `pages/dashboard/index.tsx` into focused, reusable UI sections to improve readability and maintainability.
- Enforce explicit, minimal props for each section to avoid passing whole `profile` objects and to encapsulate section-local handlers and rendering logic.
- Keep page-level state only for cross-section coordination such as auth/session identity and global modal toggles.

### Description
- Extracted multiple visual/functional blocks into new components under `components/dashboard/sections/`: `ProfileHeaderSection`, `AIWorkspaceSection`, `ChallengeSection`, `PriorityActionsSection`, `CalendarSection`, `RoadmapSection`, `QuickActionsSection`, `SavedItemsSection`, and `UpgradeSection`.
- Introduced shared typed contracts in `components/dashboard/sections/types.ts` (`TileAction`, `InnovationTile`, `ActionItem`) and updated `pages/dashboard/index.tsx` to import and use them.
- Replaced large inline JSX regions in `pages/dashboard/index.tsx` with the new section components and passed only the explicit, required props and callbacks (e.g., avatar URL, goal band, modal open handlers, tile lists, study calendar component).
- Moved section-local helper logic (accent mapping and tile action rendering) into the corresponding section files so the page retains only orchestration, data composition, and modal state.

### Testing
- Ran `npx tsc -v` which executed successfully and reported the TypeScript compiler version.
- Ran ESLint on the new files which failed in this environment due to a toolchain/config resolution issue (`@eslint/eslintrc` import not found), so lint checks could not complete here.
- Ran `npm run lint -- --file pages/dashboard/index.tsx` which could not run in this container because the `next` binary was not available in PATH, so the project linter step was not executed locally.
- Ran `npx tsc --noEmit -p tsconfig.json` which surfaced an existing, unrelated TypeScript error elsewhere in the repo (`pages/writing/index.tsx`), preventing a full type-check pass in this environment.
- Attempted a Playwright screenshot of `http://localhost:3000/dashboard` which failed because no local dev server was running in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8d92c5a4832fbd2db7d939d432f6)