### PR TITLE
Refactor dashboard challenge data flow into shared SWR hook

### DIFF
--- a/components/dashboard/ChallengeSpotlightCard.tsx
+++ b/components/dashboard/ChallengeSpotlightCard.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/design-system/Button';
 import { ProgressBar } from '@/components/design-system/ProgressBar';
 import { BadgeStrip } from '@/components/challenge/BadgeStrip';
 import { badges } from '@/data/badges';
-import type { ChallengeLeaderboardEntry } from '@/types/challenge';
+import { useChallenges } from '@/hooks/useChallenges';
 
 const MILESTONE_THRESHOLDS: Record<string, number> = {
   'lesson-1': 1,
@@ -22,9 +22,14 @@ type ChallengeSpotlightCardProps = {
 };
 
 export function ChallengeSpotlightCard({ cohortId, progress }: ChallengeSpotlightCardProps) {
-  const [entries, setEntries] = React.useState<ChallengeLeaderboardEntry[]>([]);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState<string | null>(null);
+  const {
+    leaderboard: entries,
+    leaderboardError: error,
+    isLeaderboardLoading,
+    isLeaderboardValidating,
+    retryLeaderboard,
+  } = useChallenges(cohortId, { leaderboardLimit: 3 });
+
   const snapshotDate = React.useMemo(() => entries[0]?.snapshotDate ?? null, [entries]);
 
   const completedTasks = React.useMemo(() => {
@@ -34,7 +39,9 @@ export function ChallengeSpotlightCard({ cohortId, progress }: ChallengeSpotligh
 
   const unlockedBadges = React.useMemo(() => {
     return badges.milestones
-      .filter((badge) => completedTasks >= (MILESTONE_THRESHOLDS[badge.id] ?? Number.POSITIVE_INFINITY))
+      .filter(
+        (badge) => completedTasks >= (MILESTONE_THRESHOLDS[badge.id] ?? Number.POSITIVE_INFINITY),
+      )
       .map((badge) => badge.id);
   }, [completedTasks]);
 
@@ -47,42 +54,8 @@ export function ChallengeSpotlightCard({ cohortId, progress }: ChallengeSpotligh
     return DEFAULT_TOTAL_TASKS;
   }, [entries, progress]);
 
-  React.useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(`/api/challenge/leaderboard?cohort=${encodeURIComponent(cohortId)}`);
-        if (!res.ok) throw new Error('Failed to fetch leaderboard');
-        const json = (await res.json()) as {
-          ok: boolean;
-          leaderboard?: ChallengeLeaderboardEntry[];
-          error?: string;
-        };
-        if (!json.ok || !json.leaderboard) throw new Error(json.error || 'Unknown error');
-        if (!cancelled) {
-          setEntries(json.leaderboard.slice(0, 3));
-        }
-      } catch (err: any) {
-        if (!cancelled) {
-          setError(err?.message || 'Unable to load leaderboard.');
-          setEntries([]);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [cohortId]);
-
-  const progressPct = totalTasks > 0 ? Math.min(100, Math.round((completedTasks / totalTasks) * 100)) : 0;
+  const progressPct =
+    totalTasks > 0 ? Math.min(100, Math.round((completedTasks / totalTasks) * 100)) : 0;
 
   return (
     <Card className="space-y-6 rounded-ds-2xl border border-border/70 bg-card/80 p-6 shadow-sm">
@@ -90,7 +63,8 @@ export function ChallengeSpotlightCard({ cohortId, progress }: ChallengeSpotligh
         <div>
           <h3 className="font-slab text-h3 text-foreground">Weekly Challenge</h3>
           <p className="text-small text-muted-foreground">
-            You&apos;re enrolled in <strong>{cohortId}</strong>. {completedTasks}/{totalTasks} tasks completed.
+            You&apos;re enrolled in <strong>{cohortId}</strong>. {completedTasks}/{totalTasks} tasks
+            completed.
           </p>
         </div>
         <BadgeStrip badges={badges.milestones} unlocked={unlockedBadges} />
@@ -109,42 +83,30 @@ export function ChallengeSpotlightCard({ cohortId, progress }: ChallengeSpotligh
           <span>Leaderboard snapshot</span>
           {snapshotDate ? (
             <span className="text-caption">
-              {new Date(snapshotDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+              {new Date(snapshotDate).toLocaleDateString(undefined, {
+                month: 'short',
+                day: 'numeric',
+              })}
             </span>
           ) : null}
           <button
             type="button"
             onClick={() => {
-              void (async () => {
-                setLoading(true);
-                try {
-                  const res = await fetch(`/api/challenge/leaderboard?cohort=${encodeURIComponent(cohortId)}`);
-                  if (!res.ok) throw new Error('Failed');
-                  const json = (await res.json()) as {
-                    ok: boolean;
-                    leaderboard?: ChallengeLeaderboardEntry[];
-                    error?: string;
-                  };
-                  if (!json.ok || !json.leaderboard) throw new Error(json.error || 'Unknown error');
-                  setEntries(json.leaderboard.slice(0, 3));
-                  setError(null);
-                } catch (err: any) {
-                  setError(err?.message || 'Unable to refresh.');
-                } finally {
-                  setLoading(false);
-                }
-              })();
+              void retryLeaderboard();
             }}
             className="rounded-lg border border-border bg-background px-2 py-1 text-caption hover:bg-border/30 disabled:opacity-60"
-            disabled={loading}
+            disabled={isLeaderboardValidating}
           >
-            {loading ? 'Updating…' : 'Refresh'}
+            {isLeaderboardValidating ? 'Updating…' : 'Refresh'}
           </button>
         </div>
         <div className="space-y-2">
-          {loading && !entries.length ? (
+          {isLeaderboardLoading && !entries.length ? (
             Array.from({ length: 3 }).map((_, idx) => (
-              <div key={idx} className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-muted/40 p-3">
+              <div
+                key={idx}
+                className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-muted/40 p-3"
+              >
                 <div className="h-4 w-20 animate-pulse rounded bg-border" />
                 <div className="h-3 w-12 animate-pulse rounded bg-border" />
               </div>
@@ -158,7 +120,9 @@ export function ChallengeSpotlightCard({ cohortId, progress }: ChallengeSpotligh
                 <div className="flex items-center gap-3">
                   <span
                     className={`grid h-7 w-7 place-items-center rounded-full text-caption font-semibold ${
-                      entry.rank <= 3 ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
+                      entry.rank <= 3
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted text-foreground'
                     }`}
                   >
                     {entry.rank}
@@ -166,7 +130,8 @@ export function ChallengeSpotlightCard({ cohortId, progress }: ChallengeSpotligh
                   <span className="text-small font-medium text-foreground">{entry.fullName}</span>
                 </div>
                 <span className="text-caption text-muted-foreground">
-                  {entry.completedTasks} tasks{typeof entry.xp === 'number' ? ` • ${entry.xp} XP` : ''}
+                  {entry.completedTasks} tasks
+                  {typeof entry.xp === 'number' ? ` • ${entry.xp} XP` : ''}
                 </span>
               </div>
             ))

--- a/components/dashboard/DailyWeeklyChallenges.tsx
+++ b/components/dashboard/DailyWeeklyChallenges.tsx
@@ -5,8 +5,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Skeleton } from '@/components/design-system/Skeleton';
-import { authHeaders } from '@/lib/supabaseBrowser';
-import type { ChallengeDefinition } from '@/pages/api/gamification/challenges';
+import { useChallenges } from '@/hooks/useChallenges';
 
 const SCOPE_LABEL: Record<'daily' | 'weekly', string> = {
   daily: 'Daily Challenge',
@@ -29,110 +28,44 @@ function formatReset(resetsAt: string | null): string {
   return `Resets in ${hours} hour${hours === 1 ? '' : 's'}`;
 }
 
-type ChallengeItem = ChallengeDefinition;
-
-type State = {
-  loading: boolean;
-  error: string | null;
-  challenges: ChallengeItem[];
-  busyId: string | null;
-  xpFlash?: { id: string; value: number } | null;
-};
-
 export function DailyWeeklyChallenges() {
-  const [state, setState] = React.useState<State>({
-    loading: true,
-    error: null,
-    challenges: [],
-    busyId: null,
-  });
+  const {
+    challenges,
+    challengesError,
+    progressError,
+    isChallengesLoading,
+    isChallengesValidating,
+    updatingChallengeId,
+    retryChallenges,
+    updateProgress,
+  } = useChallenges();
+  const [xpFlash, setXpFlash] = React.useState<{ id: string; value: number } | null>(null);
 
-  const load = React.useCallback(async () => {
-    setState((s) => ({ ...s, loading: true, error: null }));
-    try {
-      const res = await fetch('/api/gamification/challenges', {
-        headers: await authHeaders(),
-      });
-      if (!res.ok) {
-        throw new Error('Unable to load challenges');
-      }
-      const json = (await res.json()) as { ok: boolean; challenges?: ChallengeItem[]; error?: string };
-      if (!json.ok || !json.challenges) {
-        throw new Error(json.error || 'Unable to load challenges');
-      }
-      setState((s) => ({ ...s, loading: false, challenges: json.challenges }));
-    } catch (error: any) {
-      setState((s) => ({ ...s, loading: false, error: error?.message || 'Failed to load challenges' }));
-    }
-  }, []);
-
-  React.useEffect(() => {
-    void load();
-  }, [load]);
+  const error = challengesError || progressError;
 
   const increment = React.useCallback(
     async (challengeId: string) => {
-      setState((s) => ({ ...s, busyId: challengeId, error: null }));
       try {
-        const res = await fetch('/api/gamification/challenges/progress', {
-          method: 'POST',
-          headers: await authHeaders({ 'Content-Type': 'application/json' }),
-          body: JSON.stringify({ challengeId }),
-        });
-        const json = (await res.json().catch(() => null)) as
-          | {
-              ok: boolean;
-              xpAwarded?: number;
-              progress?: {
-                challengeId: string;
-                progressCount: number;
-                totalMastered: number;
-                target: number;
-                lastIncrementedAt: string | null;
-                resetsAt: string | null;
-              };
-              error?: string;
-            }
-          | null;
-        if (!res.ok || !json || !json.ok || !json.progress) {
-          throw new Error(json?.error || 'Failed to update progress');
+        const result = await updateProgress(challengeId);
+        if (result.xpAwarded) {
+          setXpFlash({ id: challengeId, value: result.xpAwarded });
         }
-        setState((s) => ({
-          ...s,
-          busyId: null,
-          xpFlash: json.xpAwarded ? { id: challengeId, value: json.xpAwarded } : null,
-          challenges: s.challenges.map((challenge) =>
-            challenge.id === challengeId
-              ? {
-                  ...challenge,
-                  progress: {
-                    challengeId,
-                    progressCount: json.progress?.progressCount ?? 0,
-                    totalMastered: json.progress?.totalMastered ?? 0,
-                    target: json.progress?.target ?? challenge.goal,
-                    lastIncrementedAt: json.progress?.lastIncrementedAt ?? null,
-                    resetsAt: json.progress?.resetsAt ?? null,
-                  },
-                }
-              : challenge,
-          ),
-        }));
-      } catch (error: any) {
-        setState((s) => ({ ...s, busyId: null, error: error?.message || 'Failed to update challenge' }));
+      } catch {
+        // Error state is managed by the hook.
       }
     },
-    [],
+    [updateProgress],
   );
 
   React.useEffect(() => {
-    if (!state.xpFlash) return;
+    if (!xpFlash) return;
     const timer = setTimeout(() => {
-      setState((s) => ({ ...s, xpFlash: null }));
+      setXpFlash(null);
     }, 2000);
     return () => clearTimeout(timer);
-  }, [state.xpFlash]);
+  }, [xpFlash]);
 
-  if (state.loading) {
+  if (isChallengesLoading) {
     return (
       <Card className="rounded-ds-2xl border border-border/60 bg-card/70 p-6">
         <div className="flex items-center justify-between">
@@ -148,38 +81,48 @@ export function DailyWeeklyChallenges() {
     );
   }
 
-  if (state.error) {
+  if (error) {
     return (
       <Card className="rounded-ds-2xl border border-danger/40 bg-danger/5 p-6 text-danger">
-        <h3 className="font-slab text-h5">{state.error}</h3>
+        <h3 className="font-slab text-h5">{error}</h3>
         <p className="mt-2 text-small">Please refresh or try again later.</p>
-        <Button variant="secondary" className="mt-4 rounded-ds-xl" onClick={() => void load()}>
+        <Button
+          variant="secondary"
+          className="mt-4 rounded-ds-xl"
+          onClick={() => void retryChallenges()}
+        >
           Retry
         </Button>
       </Card>
     );
   }
 
-  if (!state.challenges.length) {
+  if (!challenges.length) {
     return null;
   }
 
   return (
     <div className="grid gap-4 md:grid-cols-2">
-      {state.challenges.map((challenge) => {
+      {challenges.map((challenge) => {
         const progress = challenge.progress;
         const completed = progress?.progressCount ?? 0;
         const target = progress?.target ?? challenge.goal;
         const pct = target > 0 ? Math.min(100, Math.round((completed / target) * 100)) : 0;
-        const busy = state.busyId === challenge.id;
-        const xpFlash = state.xpFlash?.id === challenge.id ? state.xpFlash.value : null;
+        const busy = updatingChallengeId === challenge.id;
+        const flash = xpFlash?.id === challenge.id ? xpFlash.value : null;
+
         return (
-          <Card key={challenge.id} className="rounded-ds-2xl border border-border/60 bg-card/70 p-6">
+          <Card
+            key={challenge.id}
+            className="rounded-ds-2xl border border-border/60 bg-card/70 p-6"
+          >
             <div className="flex items-center justify-between">
               <Badge variant="secondary" size="sm">
                 {SCOPE_LABEL[challenge.type]}
               </Badge>
-              <span className="text-caption text-muted-foreground">{formatReset(progress?.resetsAt ?? null)}</span>
+              <span className="text-caption text-muted-foreground">
+                {formatReset(progress?.resetsAt ?? null)}
+              </span>
             </div>
             <h3 className="mt-3 font-slab text-h4 text-foreground">{challenge.title}</h3>
             <p className="mt-2 text-small text-muted-foreground">{challenge.description}</p>
@@ -192,9 +135,9 @@ export function DailyWeeklyChallenges() {
               <span>Total mastered: {progress?.totalMastered ?? 0}</span>
               <span className="hidden md:inline">•</span>
               <span>XP +{challenge.xpReward}</span>
-              {xpFlash ? (
+              {flash ? (
                 <span className="ml-2 rounded-full bg-primary/10 px-2 py-0.5 text-primary">
-                  +{xpFlash} XP!
+                  +{flash} XP!
                 </span>
               ) : null}
             </div>
@@ -207,7 +150,13 @@ export function DailyWeeklyChallenges() {
               aria-valuenow={completed}
             >
               <svg className="h-full w-full" aria-hidden focusable="false">
-                <rect width={`${pct}%`} height="100%" fill="currentColor" className="text-primary" rx="9999" />
+                <rect
+                  width={`${pct}%`}
+                  height="100%"
+                  fill="currentColor"
+                  className="text-primary"
+                  rx="9999"
+                />
               </svg>
             </div>
 
@@ -219,8 +168,13 @@ export function DailyWeeklyChallenges() {
               >
                 {busy ? 'Saving…' : completed >= target ? 'Completed' : 'Log collocation'}
               </Button>
-              <Button variant="secondary" className="rounded-ds-xl" onClick={() => void load()} disabled={busy}>
-                Refresh
+              <Button
+                variant="secondary"
+                className="rounded-ds-xl"
+                onClick={() => void retryChallenges()}
+                disabled={busy || isChallengesValidating}
+              >
+                {isChallengesValidating ? 'Refreshing…' : 'Refresh'}
               </Button>
             </div>
           </Card>

--- a/hooks/useChallenges.ts
+++ b/hooks/useChallenges.ts
@@ -1,0 +1,197 @@
+import * as React from 'react';
+import useSWR from 'swr';
+
+import { authHeaders } from '@/lib/supabaseBrowser';
+import type { ChallengeLeaderboardEntry } from '@/types/challenge';
+import type { ChallengeDefinition, ChallengeProgress } from '@/pages/api/gamification/challenges';
+
+type LeaderboardResponse = {
+  ok: boolean;
+  leaderboard?: ChallengeLeaderboardEntry[];
+  error?: string;
+};
+
+type ChallengesResponse = {
+  ok: boolean;
+  challenges?: ChallengeDefinition[];
+  error?: string;
+};
+
+type ProgressMutationResponse =
+  | {
+      ok: true;
+      xpAwarded: number;
+      progress: ChallengeProgress;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+type UseChallengesOptions = {
+  leaderboardLimit?: number;
+};
+
+async function fetchLeaderboard(url: string): Promise<ChallengeLeaderboardEntry[]> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Failed to fetch leaderboard');
+  }
+
+  const payload = (await response.json()) as LeaderboardResponse;
+  if (!payload.ok || !payload.leaderboard) {
+    throw new Error(payload.error || 'Unable to load leaderboard.');
+  }
+
+  return payload.leaderboard;
+}
+
+async function fetchChallenges(url: string): Promise<ChallengeDefinition[]> {
+  const response = await fetch(url, {
+    headers: await authHeaders(),
+  });
+  if (!response.ok) {
+    throw new Error('Unable to load challenges');
+  }
+
+  const payload = (await response.json()) as ChallengesResponse;
+  if (!payload.ok || !payload.challenges) {
+    throw new Error(payload.error || 'Unable to load challenges');
+  }
+
+  return payload.challenges;
+}
+
+export function useChallenges(cohortId?: string, options?: UseChallengesOptions) {
+  const leaderboardLimit = options?.leaderboardLimit ?? 3;
+  const leaderboardKey = cohortId
+    ? `/api/challenge/leaderboard?cohort=${encodeURIComponent(cohortId)}`
+    : null;
+  const challengesKey = '/api/gamification/challenges';
+
+  const {
+    data: leaderboardData,
+    error: leaderboardError,
+    isLoading: isLeaderboardLoading,
+    isValidating: isLeaderboardValidating,
+    mutate: mutateLeaderboard,
+  } = useSWR<ChallengeLeaderboardEntry[]>(leaderboardKey, fetchLeaderboard);
+
+  const {
+    data: challengesData,
+    error: challengesError,
+    isLoading: isChallengesLoading,
+    isValidating: isChallengesValidating,
+    mutate: mutateChallenges,
+  } = useSWR<ChallengeDefinition[]>(challengesKey, fetchChallenges);
+
+  const [updatingChallengeId, setUpdatingChallengeId] = React.useState<string | null>(null);
+  const [progressError, setProgressError] = React.useState<string | null>(null);
+
+  const updateProgress = React.useCallback(
+    async (challengeId: string) => {
+      setUpdatingChallengeId(challengeId);
+      setProgressError(null);
+
+      const previousChallenges = challengesData;
+      const optimisticChallenges = (challengesData ?? []).map((challenge) => {
+        if (challenge.id !== challengeId) return challenge;
+
+        const currentProgress = challenge.progress;
+        const optimisticTarget = currentProgress?.target ?? challenge.goal;
+        const optimisticProgressCount = Math.min(
+          optimisticTarget,
+          (currentProgress?.progressCount ?? 0) + 1,
+        );
+
+        return {
+          ...challenge,
+          progress: {
+            challengeId,
+            progressCount: optimisticProgressCount,
+            totalMastered: (currentProgress?.totalMastered ?? 0) + 1,
+            target: optimisticTarget,
+            lastIncrementedAt: currentProgress?.lastIncrementedAt ?? null,
+            resetsAt: currentProgress?.resetsAt ?? null,
+          },
+        };
+      });
+
+      await mutateChallenges(optimisticChallenges, false);
+
+      try {
+        const response = await fetch('/api/gamification/challenges/progress', {
+          method: 'POST',
+          headers: await authHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({ challengeId }),
+        });
+
+        const payload = (await response
+          .json()
+          .catch(() => null)) as ProgressMutationResponse | null;
+
+        if (!response.ok || !payload || !payload.ok) {
+          throw new Error(payload?.error || 'Failed to update challenge');
+        }
+
+        await mutateChallenges(
+          (currentChallenges) =>
+            (currentChallenges ?? []).map((challenge) =>
+              challenge.id === challengeId
+                ? {
+                    ...challenge,
+                    progress: payload.progress,
+                  }
+                : challenge,
+            ),
+          false,
+        );
+
+        await mutateChallenges();
+
+        return payload;
+      } catch (error: any) {
+        await mutateChallenges(previousChallenges, false);
+        const message = error?.message || 'Failed to update challenge';
+        setProgressError(message);
+        throw error;
+      } finally {
+        setUpdatingChallengeId(null);
+      }
+    },
+    [challengesData, mutateChallenges],
+  );
+
+  const retryLeaderboard = React.useCallback(async () => {
+    await mutateLeaderboard();
+  }, [mutateLeaderboard]);
+
+  const retryChallenges = React.useCallback(async () => {
+    setProgressError(null);
+    await mutateChallenges();
+  }, [mutateChallenges]);
+
+  const retryAll = React.useCallback(async () => {
+    setProgressError(null);
+    await Promise.all([mutateLeaderboard(), mutateChallenges()]);
+  }, [mutateChallenges, mutateLeaderboard]);
+
+  return {
+    leaderboard: (leaderboardData ?? []).slice(0, leaderboardLimit),
+    challenges: challengesData ?? [],
+    leaderboardError: leaderboardError ? leaderboardError.message : null,
+    challengesError: challengesError ? challengesError.message : null,
+    progressError,
+    isLeaderboardLoading,
+    isChallengesLoading,
+    isLeaderboardValidating,
+    isChallengesValidating,
+    updatingChallengeId,
+    retryLeaderboard,
+    retryChallenges,
+    retryAll,
+    updateProgress,
+  };
+}
+
+export default useChallenges;


### PR DESCRIPTION
### Motivation
- Consolidate duplicated networking and state logic for challenges and leaderboard into a single reusable hook to reduce duplication and simplify components.
- Use SWR caching and revalidation semantics for leaderboard and challenges reads and to enable optimistic updates on progress mutations.

### Description
- Added `hooks/useChallenges.ts` which centralizes leaderboard fetch (`/api/challenge/leaderboard`), challenges fetch (`/api/gamification/challenges`), and progress mutation (`/api/gamification/challenges/progress`) using `useSWR` and `mutate` for optimistic updates and revalidation.
- Exposed a stable API from the hook including `leaderboard`, `challenges`, `updateProgress`, `retryLeaderboard`, `retryChallenges`, `retryAll`, loading/validating flags, error fields, and `updatingChallengeId`.
- Refactored `components/dashboard/ChallengeSpotlightCard.tsx` to consume `useChallenges` for leaderboard state and refresh behavior, removing local `fetch`/`useEffect` duplication and local loading/error state.
- Refactored `components/dashboard/DailyWeeklyChallenges.tsx` to consume `useChallenges` for challenge list, optimistic progress updates via `updateProgress`, retry handling, and shared loading/error state while preserving existing UI behavior (including XP flash handling).

### Testing
- Ran code formatting with `npx prettier --write` on the changed files, which completed successfully.
- Ran linting with `npx eslint hooks/useChallenges.ts components/dashboard/ChallengeSpotlightCard.tsx components/dashboard/DailyWeeklyChallenges.tsx`, which failed in this environment due to a missing ESLint runtime package (`@eslint/eslintrc`) unrelated to the change.
- Ran typecheck with `npx tsc --noEmit --pretty false`, which failed due to a pre-existing parse/type error in `pages/writing/index.tsx` that is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8d92c21c832fa4140b2f8db2e049)