### PR TITLE
Fix auth session race conditions and unify browser Supabase client

### DIFF
--- a/components/auth/AuthOptions.tsx
+++ b/components/auth/AuthOptions.tsx
@@ -14,7 +14,7 @@ import {
   SmsIcon,
 } from '@/components/design-system/icons';
 import { SectionLabel } from '@/components/design-system/SectionLabel';
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { supabase } from '@/lib/supabaseClient';
 import { destinationByRole } from '@/lib/routeAccess';
 
 type AuthMode = 'login' | 'signup';
@@ -53,7 +53,7 @@ export default function AuthOptions({ mode }: AuthOptionsProps) {
         const {
           data: { session },
           error,
-        } = await supabaseBrowser.auth.getSession();
+        } = await supabase.auth.getSession();
 
         if (!mounted) return;
 
@@ -149,7 +149,7 @@ export default function AuthOptions({ mode }: AuthOptionsProps) {
 
       const redirectTo = `${origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
 
-      const { error } = await supabaseBrowser.auth.signInWithOAuth({
+      const { error } = await supabase.auth.signInWithOAuth({
         provider,
         options: {
           redirectTo,

--- a/context/UserContext.tsx
+++ b/context/UserContext.tsx
@@ -79,7 +79,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
     [],
   );
 
-  const load = useCallback(async () => {
+  const loadSession = useCallback(async () => {
     setLoading(true);
     try {
       const {
@@ -100,7 +100,7 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
   useEffect(() => {
     mounted.current = true;
 
-    void load();
+    void loadSession();
 
     const {
       data: { subscription },
@@ -109,22 +109,23 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const nextUser = session?.user ?? null;
       setUser(nextUser);
       applyRole(nextUser?.id);
+      setLoading(false);
     });
 
     return () => {
       mounted.current = false;
       subscription?.unsubscribe?.();
     };
-  }, [load, applyRole]);
+  }, [loadSession, applyRole]);
 
   const value = useMemo<UserContextValue>(
     () => ({
       user,
       role,
       loading,
-      refresh: load,
+      refresh: loadSession,
     }),
-    [user, role, loading, load]
+    [user, role, loading, loadSession]
   );
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/hooks/useEmailLoginMFA.ts
+++ b/hooks/useEmailLoginMFA.ts
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { supabase } from '@/lib/supabaseClient'; // Use supabaseClient as the single source of truth
-import { redirectByRole } from '@/lib/routeAccess';
+import type { User } from '@supabase/supabase-js';
+
+import { supabase } from '@/lib/supabaseClient';
 import { getAuthErrorMessage } from '@/lib/authErrors';
 
-// Helper to initiate an MFA challenge for a given user
-export async function createMfaChallengeForUser(user: any) {
+export async function createMfaChallengeForUser(user: User | null) {
   const factors = (user as any)?.factors ?? [];
   if (!factors.length) return { factorId: null, challengeId: null };
   const f = factors[0];
@@ -15,15 +15,25 @@ export async function createMfaChallengeForUser(user: any) {
   return { factorId: f.id as string, challengeId: challenge?.id ?? null };
 }
 
-// Helper to verify an MFA challenge
-export async function verifyMfaOtp(factorId: string, challengeId: string, code: string) {
+export async function verifyMfaOtp(
+  factorId: string,
+  challengeId: string,
+  code: string,
+  onVerified?: () => void | Promise<void>,
+) {
   const { error } = await supabase.auth.mfa.verify({ factorId, challengeId, code });
   if (error) {
     return { error: getAuthErrorMessage(error) };
   }
-  try { await fetch('/api/auth/login-event', { method: 'POST' }); } catch {}
-  const { data: { user } } = await supabase.auth.getUser();
-  if (user) redirectByRole(user);
+
+  await supabase.auth.getSession();
+
+  setTimeout(() => {
+    void onVerified?.();
+  }, 50);
+
+  void fetch('/api/auth/login-event', { method: 'POST' }).catch(console.error);
+
   return { error: null };
 }
 
@@ -35,7 +45,7 @@ export default function useEmailLoginMFA() {
   const [verifying, setVerifying] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function createChallenge(user: any) {
+  async function createChallenge(user: User | null, onVerified?: () => void | Promise<void>) {
     const res = await createMfaChallengeForUser(user);
     if (res.error) {
       setError(res.error);
@@ -47,14 +57,20 @@ export default function useEmailLoginMFA() {
       setOtpSent(true);
       return true;
     }
+
+    if (onVerified) {
+      await onVerified();
+      return true;
+    }
+
     return false;
   }
 
-  async function verifyOtp(e?: React.FormEvent) {
+  async function verifyOtp(e?: React.FormEvent, onVerified?: () => void | Promise<void>) {
     if (e) e.preventDefault();
     if (!factorId || !challengeId) return;
     setVerifying(true);
-    const res = await verifyMfaOtp(factorId, challengeId, otp);
+    const res = await verifyMfaOtp(factorId, challengeId, otp, onVerified);
     setVerifying(false);
     if (res.error) setError(res.error);
   }

--- a/hooks/useRequireAuth.ts
+++ b/hooks/useRequireAuth.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+import { useUserContext } from '@/context/UserContext';
+
+export function useRequireAuth() {
+  const router = useRouter();
+  const { user, loading } = useUserContext();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      void router.replace('/login');
+    }
+  }, [loading, user, router]);
+
+  return { user, loading, isAuthenticated: !!user };
+}

--- a/hooks/useSupabaseSessionUser.ts
+++ b/hooks/useSupabaseSessionUser.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { supabase } from '@/lib/supabaseClient';
 
 export function useSupabaseSessionUser() {
   const [user, setUser] = useState<User | null>(null);
@@ -12,7 +12,7 @@ export function useSupabaseSessionUser() {
 
     const loadSession = async () => {
       try {
-        const { data } = await supabaseBrowser.auth.getSession();
+        const { data } = await supabase.auth.getSession();
         if (!cancelled) {
           setUser(data.session?.user ?? null);
         }
@@ -30,7 +30,7 @@ export function useSupabaseSessionUser() {
 
     void loadSession();
 
-    const { data: authListener } = supabaseBrowser.auth.onAuthStateChange((_, session) => {
+    const { data: authListener } = supabase.auth.onAuthStateChange((_, session) => {
       if (!cancelled) {
         setUser(session?.user ?? null);
       }

--- a/lib/safeRouterPush.ts
+++ b/lib/safeRouterPush.ts
@@ -1,0 +1,7 @@
+import type { NextRouter } from 'next/router';
+
+export function safePush(router: NextRouter, href: string) {
+  if (router.asPath !== href) {
+    void router.push(href);
+  }
+}

--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -1,68 +1,11 @@
-// lib/supabaseBrowser.ts
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/lib/supabaseClient';
 
-import type { Database } from '@/types/supabase';
-
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-const isConfigured = Boolean(url && anon);
-
-if (!isConfigured) {
-  const message =
-    'Supabase environment variables are not configured. Falling back to a disabled client.';
-  if (typeof console !== 'undefined') {
-    // eslint-disable-next-line no-console -- surfaced once to aid debugging in non-configured envs
-    console.warn(message);
-  }
-}
-
-type GlobalWithSupabase = typeof globalThis & {
-  __supabaseBrowser?: SupabaseClient<Database>;
-};
-
-const globalScope = globalThis as GlobalWithSupabase;
-const isTestEnv =
-  typeof process !== 'undefined' &&
-  (process.env.NODE_ENV === 'test' || process.env.VITEST || process.env.JEST_WORKER_ID);
-
-const shouldCacheClient = typeof window !== 'undefined' && !isTestEnv;
-
-const FALLBACK_URL = 'https://app.supabase.invalid';
-const FALLBACK_ANON_KEY = 'public-anon-key-placeholder';
-
-const noopFetch: typeof fetch = async () =>
-  new Response(
-    JSON.stringify({ error: 'Supabase client disabled: missing environment variables.' }),
-    {
-      status: 503,
-      headers: { 'Content-Type': 'application/json' },
-    }
-  );
-
-const createSupabaseBrowserClient = () =>
-  createClient<Database>(isConfigured ? url! : FALLBACK_URL, isConfigured ? anon! : FALLBACK_ANON_KEY, {
-    auth: {
-      flowType: 'pkce',
-      autoRefreshToken: false,      // ✅ disable auto-refresh – errors will stop
-      detectSessionInUrl: true,
-      persistSession: true,
-    },
-    ...(isConfigured ? {} : { global: { fetch: noopFetch } }),
-  });
-
-export const supabaseBrowser: SupabaseClient<Database> =
-  shouldCacheClient && globalScope.__supabaseBrowser
-    ? globalScope.__supabaseBrowser
-    : createSupabaseBrowserClient();
-
-if (shouldCacheClient) {
-  globalScope.__supabaseBrowser = supabaseBrowser;
-}
+export const supabaseBrowser = supabase;
 
 export const authHeaders = async (extra: Record<string, string> = {}) => {
   const {
     data: { session },
-  } = await supabaseBrowser.auth.getSession();
+  } = await supabase.auth.getSession();
 
   const token = session?.access_token;
   if (!token) return { ...extra };

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,1 +1,21 @@
-export { supabaseBrowser as supabase } from './supabaseBrowser';
+import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type { Database } from '@/types/supabase';
+
+type GlobalWithSupabase = typeof globalThis & {
+  __gramorxSupabase?: SupabaseClient<Database>;
+};
+
+const globalScope = globalThis as GlobalWithSupabase;
+
+export const supabase: SupabaseClient<Database> =
+  globalScope.__gramorxSupabase ??
+  createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+
+if (!globalScope.__gramorxSupabase) {
+  globalScope.__gramorxSupabase = supabase;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,7 @@ import { AnimationProvider } from '@/components/providers/AnimationProvider';
 
 import { ToastProvider } from '@/components/design-system/Toaster';
 import { NotificationProvider } from '@/components/notifications/NotificationProvider';
-import { supabaseBrowser as supabaseClientSource } from '@/lib/supabaseBrowser';
+import { supabase as supabaseClientSource } from '@/lib/supabaseClient';
 import { env } from '@/lib/env';
 import { LocaleProvider, useLocale } from '@/lib/locale';
 import { initIdleTimeout } from '@/utils/idleTimeout';

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -10,13 +10,14 @@ import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Alert } from '@/components/design-system/Alert';
 
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { supabase } from '@/lib/supabaseClient';
 import { useStreak } from '@/hooks/useStreak';
 import { getDayKeyInTZ } from '@/lib/streak';
 import { useSignedAvatar } from '@/hooks/useSignedAvatar';
 import { useChallengeEnrollments } from '@/hooks/useChallengeEnrollments';
 import { useNextTask } from '@/hooks/useNextTask';
 import { useStudyPlan } from '@/hooks/useStudyPlan';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
 
 import { badges } from '@/data/badges';
 import { VocabularySpotlightFeature } from '@/components/feature/VocabularySpotlight';
@@ -72,6 +73,7 @@ const loadingSkeleton = (
 );
 
 const Dashboard: NextPage = () => {
+  useRequireAuth();
   const [loading, setLoading] = useState(true);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [needsSetup, setNeedsSetup] = useState(false);
@@ -123,7 +125,7 @@ const Dashboard: NextPage = () => {
         if (typeof window !== 'undefined') {
           const url = window.location.href;
           if (url.includes('code=') || url.includes('access_token=')) {
-            const { error } = await supabaseBrowser.auth.exchangeCodeForSession(url);
+            const { error } = await supabase.auth.exchangeCodeForSession(url);
             if (!error) {
               await window.history.replaceState({}, '', '/dashboard');
             }
@@ -132,7 +134,7 @@ const Dashboard: NextPage = () => {
 
         const {
           data: { session },
-        } = await supabaseBrowser.auth.getSession();
+        } = await supabase.auth.getSession();
 
         const authUser = session?.user ?? null;
         setSessionUserId(authUser?.id ?? null);
@@ -144,7 +146,7 @@ const Dashboard: NextPage = () => {
         }
 
         // Load or create minimal profile
-        const { data, error } = await supabaseBrowser
+        const { data, error } = await supabase
           .from('profiles')
           .select('*')
           .eq('user_id', authUser.id)
@@ -169,7 +171,7 @@ const Dashboard: NextPage = () => {
             onboarding_complete: false,
           };
 
-          const { data: created, error: insertErr } = await supabaseBrowser
+          const { data: created, error: insertErr } = await supabase
             .from('profiles')
             .insert(minimal)
             .select('*')

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -9,14 +9,16 @@ import { Input } from '@/components/design-system/Input';
 import { PasswordInput } from '@/components/design-system/PasswordInput';
 import { Button } from '@/components/design-system/Button';
 import { Alert } from '@/components/design-system/Alert';
-import { supabaseBrowser } from '@/lib/supabaseBrowser';
+import { supabase } from '@/lib/supabaseClient';
 import { destinationByRole } from '@/lib/routeAccess';
 import { isValidEmail } from '@/utils/validation';
 import { getAuthErrorMessage } from '@/lib/authErrors';
 import useEmailLoginMFA from '@/hooks/useEmailLoginMFA';
+import { useUserContext } from '@/context/UserContext';
 
 export default function LoginWithEmail() {
   const router = useRouter();
+  const { user, loading: userLoading } = useUserContext();
   const [email, setEmail] = useState('');
   const [pw, setPw] = useState('');
   const [emailErr, setEmailErr] = useState<string | null>(null);
@@ -33,6 +35,35 @@ export default function LoginWithEmail() {
     error: mfaErr,
     setError: setMfaErr,
   } = useEmailLoginMFA();
+
+  React.useEffect(() => {
+    if (!userLoading && user) {
+      void router.replace('/dashboard');
+    }
+  }, [user, userLoading, router]);
+
+
+  const resolveTarget = React.useCallback((currentUser: { id?: string } | null) => {
+    const rawNext = typeof router.query.next === 'string' ? router.query.next : '';
+    const safeNext = rawNext && rawNext.startsWith('/') && rawNext !== '/login' ? rawNext : null;
+    const fallback = currentUser ? destinationByRole(currentUser as any) : '/dashboard';
+    return safeNext ?? fallback;
+  }, [router.query.next]);
+
+  const navigateAfterAuth = React.useCallback(async (currentUser: { id?: string } | null) => {
+    const target = resolveTarget(currentUser);
+    await supabase.auth.getSession();
+    setTimeout(() => {
+      void router.replace(target);
+    }, 50);
+  }, [resolveTarget, router]);
+
+  const handleVerifyOtp = React.useCallback((e: React.FormEvent) =>
+    verifyOtp(e, async () => {
+      const { data: { user: sessionUser } } = await supabase.auth.getUser();
+      await navigateAfterAuth(sessionUser);
+    }),
+  [navigateAfterAuth, verifyOtp]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -132,7 +163,7 @@ export default function LoginWithEmail() {
       }
 
       // If login is successful, set session and proceed
-      await supabaseBrowser.auth
+      await supabase.auth
         .setSession({
           access_token: body.session.access_token,
           refresh_token: body.session.refresh_token,
@@ -144,7 +175,7 @@ export default function LoginWithEmail() {
       const {
         data: { user },
         error: userError,
-      } = await supabaseBrowser.auth.getUser();
+      } = await supabase.auth.getUser();
       if (userError) console.error('Get user failed:', userError);
 
       // Skip OTP if both email and password are provided
@@ -153,25 +184,22 @@ export default function LoginWithEmail() {
           await syncServerSession(body.session);
         }
 
-        await recordLoginEvent(body.session);
-
-        const rawNext = typeof router.query.next === 'string' ? router.query.next : '';
-        const safeNext = rawNext && rawNext.startsWith('/') && rawNext !== '/login' ? rawNext : null;
-
-        const fallback = user ? destinationByRole(user) : '/dashboard';
-        const target = safeNext ?? fallback;
-
         try {
-          await router.replace(target);
+          await navigateAfterAuth(user);
+          void recordLoginEvent(body.session);
         } catch (err) {
+          const target = resolveTarget(user);
           console.error('Redirect after login failed:', err);
           if (typeof window !== 'undefined') window.location.assign(target);
+          void recordLoginEvent(body.session);
         }
         return;
       }
 
       // If MFA (OTP) is required, trigger the challenge
-      const challenged = await createChallenge(user).catch(err => console.error('Create challenge failed:', err));
+      const challenged = await createChallenge(user, async () => {
+        await navigateAfterAuth(user);
+      }).catch(err => console.error('Create challenge failed:', err));
       if (challenged) return;
 
       // Rely on _app.tsx onAuthStateChange to redirect
@@ -227,7 +255,7 @@ export default function LoginWithEmail() {
           </p>
         </form>
       ) : (
-        <form onSubmit={verifyOtp} className="space-y-6 mt-2 max-w-xs">
+        <form onSubmit={handleVerifyOtp} className="space-y-6 mt-2 max-w-xs">
           <Input
             label="Enter OTP"
             value={otp}

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,8 +1,21 @@
 // pages/login/index.tsx
 'use client';
 
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
 import AuthOptions from '@/components/auth/AuthOptions';
+import { useUserContext } from '@/context/UserContext';
 
 export default function LoginOptions() {
+  const router = useRouter();
+  const { user, loading } = useUserContext();
+
+  useEffect(() => {
+    if (!loading && user) {
+      void router.replace('/dashboard');
+    }
+  }, [user, loading, router]);
+
   return <AuthOptions mode="login" />;
 }

--- a/pages/premium/index.tsx
+++ b/pages/premium/index.tsx
@@ -7,6 +7,7 @@ import { ThemeSwitcherPremium } from '@/premium-ui/theme/ThemeSwitcher';
 import { PrCard } from '@/premium-ui/components/PrCard';
 import { PrButton } from '@/premium-ui/components/PrButton';
 import { supabase } from '@/lib/supabaseClient';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
 import {
   ShieldCheck,
   Lock,
@@ -92,6 +93,7 @@ function usePremiumStatus(token: string | null) {
 
 /* ----------------------------- page ----------------------------- */
 export default function PremiumHome() {
+  useRequireAuth();
   const router = useRouter();
   const token = useAccessToken();
   const { data: status, loading } = usePremiumStatus(token);

--- a/pages/profile/account/index.tsx
+++ b/pages/profile/account/index.tsx
@@ -9,8 +9,10 @@ import { Container } from '@/components/design-system/Container';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import { Card } from '@/components/design-system/Card';
-import { supabaseBrowser as supabase } from '@/lib/supabaseBrowser';
+import { supabase } from '@/lib/supabaseClient';
 import { getPlan, isPaidPlan, type PlanId } from '@/types/pricing';
+import { safePush } from '@/lib/safeRouterPush';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
 
 import {
   Timeline,
@@ -51,6 +53,7 @@ type BillingSummaryResponse =
   | { ok: false; error: string };
 
 export default function AccountHubPage() {
+  useRequireAuth();
   const router = useRouter();
   const [email, setEmail] = React.useState<string | null>(null);
   const [sending, setSending] = React.useState(false);
@@ -278,10 +281,6 @@ export default function AccountHubPage() {
     }
     return parts;
   }, [summary, dateFormatter]);
-
-  const safePush = (href: string) => {
-    if (router.asPath !== href) void router.push(href);
-  };
 
   const handleReset = async () => {
     if (!email || sending) return;
@@ -604,7 +603,7 @@ export default function AccountHubPage() {
               <div className="mt-4">
                 <Button
                   variant="soft"
-                  onClick={() => safePush('/settings/language')}
+                  onClick={() => safePush(router, '/settings/language')}
                   className="w-full"
                 >
                   <Globe className="mr-2 h-4 w-4" />
@@ -639,7 +638,7 @@ export default function AccountHubPage() {
                 </div>
                 <Button
                   variant="soft"
-                  onClick={() => safePush('/settings/notifications')}
+                  onClick={() => safePush(router, '/settings/notifications')}
                   className="mt-3 w-full"
                 >
                   <Bell className="mr-2 h-4 w-4" />
@@ -665,7 +664,7 @@ export default function AccountHubPage() {
               </div>
               <Button
                 variant="soft"
-                onClick={() => safePush('/settings/accessibility')}
+                onClick={() => safePush(router, '/settings/accessibility')}
                 className="w-full"
               >
                 <SettingsIcon className="mr-2 h-4 w-4" />
@@ -713,7 +712,7 @@ export default function AccountHubPage() {
                 </Button>
                 <Button
                   variant="soft"
-                  onClick={() => safePush('/settings/security')}
+                  onClick={() => safePush(router, '/settings/security')}
                   className="w-full"
                 >
                   <Shield className="mr-2 h-4 w-4" />

--- a/pages/teacher/cohorts/[id].tsx
+++ b/pages/teacher/cohorts/[id].tsx
@@ -6,13 +6,15 @@ import { useRouter } from "next/router";
 import { Container } from "@/components/design-system/Container";
 import { CohortTable, type CohortRow } from "@/components/teacher/CohortTable";
 import { AssignTaskModal } from "@/components/teacher/AssignTaskModal";
-import { supabaseBrowser } from "@/lib/supabaseBrowser";
+import { supabase } from "@/lib/supabaseClient";
+import { useRequireAuth } from "@/hooks/useRequireAuth";
 import { resolveAvatarUrl } from '@/lib/avatar';
 
 type Cohort = { id: string; name: string; created_at: string };
 
 export default function CohortDetail() {
   const router = useRouter();
+  useRequireAuth();
   const cohortId = (router.query.id as string) || "";
 
   const [loading, setLoading] = React.useState(true);
@@ -28,7 +30,7 @@ export default function CohortDetail() {
       setError(null);
 
       // Load cohort shell (enforced by RLS: must be teacher's cohort)
-      const { data: cRow, error: e1 } = await supabaseBrowser
+      const { data: cRow, error: e1 } = await supabase
         .from("teacher_cohorts")
         .select("*")
         .eq("id", cohortId)
@@ -38,7 +40,7 @@ export default function CohortDetail() {
       setCohort(cRow as Cohort);
 
       // Load members with profile info if available
-      const { data: members, error: e2 } = await supabaseBrowser
+      const { data: members, error: e2 } = await supabase
         .from("teacher_cohort_members")
         .select("id, cohort_id, student_id, joined_at, progress, profiles(full_name, email, avatar_url)")
         .eq("cohort_id", cohortId);
@@ -94,7 +96,7 @@ export default function CohortDetail() {
 
   const onRemove = async (membershipId: string) => {
     // RLS delete policy not defined earlier; may fail until policy is added.
-    const { error } = await supabaseBrowser
+    const { error } = await supabase
       .from("teacher_cohort_members")
       .delete()
       .eq("id", membershipId);


### PR DESCRIPTION
### Motivation
- Users who signed in with OTP saw the login form remain until a manual refresh because navigation happened before the React auth context fully reflected the new Supabase session. 
- The codebase had multiple browser Supabase entrypoints (`supabaseBrowser` / `supabaseClient` variants) causing inconsistent auth state observations. 
- The goal is to ensure session creation, context hydration, and navigation happen in a deterministic order without UI changes.

### Description
- Introduced a single browser client in `lib/supabaseClient.ts` using `createBrowserClient` and made `lib/supabaseBrowser.ts` a lightweight compatibility re-export to point at the unified `supabase`. 
- Hardened `context/UserContext.tsx` to load session on mount, subscribe to `onAuthStateChange`, update `user`/`role` immediately, clear `loading` promptly, and expose `refresh` as `loadSession`. 
- Fixed OTP/login redirect races in `pages/login/email.tsx` and `hooks/useEmailLoginMFA.ts` by waiting for `supabase.auth.getSession()` and deferring client navigation with a short `setTimeout(..., 50)` so React state can propagate before calling `router.replace(...)`, and moved `recordLoginEvent` to run non-blocking after navigation begins. 
- Added auto-redirect for authenticated users on the login entry (`pages/login/index.tsx`) using `useUserContext`. 
- Added `useRequireAuth` hook (`hooks/useRequireAuth.ts`) for simple protected-route guarding and a `safePush` helper (`lib/safeRouterPush.ts`) to avoid same-route navigation loops, and applied `useRequireAuth` / `safePush` to key protected pages (dashboard, premium, profile, teacher routes). 

### Testing
- Ran ESLint on the touched files via `npx eslint ...` and it failed due to environment dependency resolution (`@eslint/eslintrc` missing), so static lint could not be fully validated. (failed)
- Attempted targeted unit tests with `npx vitest run tests/auth/login-success.test.ts` and that run failed because the environment blocked package resolution from the npm registry. (failed)
- Attempted repository test harness via `npm run test -- tests/auth/login-success.test.ts` and it failed because the runtime lacked the `tsx` binary used by the test runner in this environment. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69addd944cf88328ace7cd252dbdaedc)