### PR TITLE
Fix dashboard hook import and prefill profile name from email

### DIFF
--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -18,6 +18,7 @@ import { useChallengeEnrollments } from '@/hooks/useChallengeEnrollments';
 import { useNextTask } from '@/hooks/useNextTask';
 import { useStudyPlan } from '@/hooks/useStudyPlan';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 import { badges } from '@/data/badges';
 import { VocabularySpotlightFeature } from '@/components/feature/VocabularySpotlight';
@@ -71,6 +72,20 @@ const loadingSkeleton = (
     </Container>
   </section>
 );
+
+const deriveNameFromEmail = (email: string | null | undefined): string => {
+  if (!email) return '';
+
+  const localPart = email.split('@')[0]?.trim();
+  if (!localPart) return '';
+
+  return localPart
+    .replace(/[._-]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
 
 const Dashboard: NextPage = () => {
   useRequireAuth();
@@ -167,6 +182,7 @@ const Dashboard: NextPage = () => {
           const minimal: Partial<Profile> = {
             user_id: authUser.id,
             email: authUser.email ?? undefined,
+            full_name: deriveNameFromEmail(authUser.email),
             preferred_language: 'en',
             onboarding_complete: false,
           };

--- a/pages/profile/setup/index.tsx
+++ b/pages/profile/setup/index.tsx
@@ -31,6 +31,21 @@ const LANGUAGE_LABELS: Record<string, string> = {
 
 type OnboardingLanguageOption = { value: string; label?: string };
 
+
+const deriveNameFromEmail = (email: string | null | undefined): string => {
+  if (!email) return '';
+
+  const localPart = email.split('@')[0]?.trim();
+  if (!localPart) return '';
+
+  return localPart
+    .replace(/[._-]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
 export default function ProfileSetupPage() {
   const router = useRouter();
   const { t } = useLocale();
@@ -73,7 +88,8 @@ export default function ProfileSetupPage() {
 
           // Pre-fill if any data exists
           if (profile) {
-            setFullName(profile.full_name ?? '');
+            const emailFallback = deriveNameFromEmail(sessionData.session.user.email);
+            setFullName(profile.full_name?.trim() ? profile.full_name : emailFallback);
             setPreferredLanguage(profile.preferred_language ?? 'en');
             setTargetBand(
               typeof profile.target_band === 'number'
@@ -81,6 +97,8 @@ export default function ProfileSetupPage() {
                 : ''
             );
             setExamDate(profile.exam_date?.slice?.(0, 10) ?? '');
+          } else {
+            setFullName(deriveNameFromEmail(sessionData.session.user.email));
           }
         }
       } catch (err) {


### PR DESCRIPTION
### Motivation

- Resolve a runtime crash where `useLocalStorage` was referenced but not imported on the dashboard page. 
- Improve onboarding UX by seeding a sensible `full_name` when a profile row is missing or when the profile name is blank by deriving a display name from the user's email local-part.

### Description

- Import `useLocalStorage` in `pages/dashboard/index.tsx` and restore the `tipsDismissed` state hook usage via `useLocalStorage` to fix the `ReferenceError`.
- Add a small helper `deriveNameFromEmail(email)` in both `pages/dashboard/index.tsx` and `pages/profile/setup/index.tsx` that converts the email local-part into a capitalized name (replacing dots/underscores/dashes with spaces).
- Use the helper when creating a minimal profile in the dashboard bootstrap to populate `full_name` from `authUser.email` if no profile exists.
- Update profile-setup prefill logic in `pages/profile/setup/index.tsx` to use the derived name fallback when `profile.full_name` is empty and to prefill the field when no profile row exists.

### Testing

- Ran `npx eslint pages/dashboard/index.tsx pages/profile/setup/index.tsx` which failed in this environment due to missing local eslint dependency resolution (`@eslint/eslintrc` not found), so static linting could not be completed here.
- Ran the project's lint script with `npm run lint -- --file pages/dashboard/index.tsx --file pages/profile/setup/index.tsx` which failed because the `next` binary/dependencies are not available in the execution environment, so full targeted linting could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf244bbe083288f670aba8dc0da70)