### PR TITLE
Add RPC fallback calendar builder and improve streak calendar handling

### DIFF
--- a/archive/supabase/migrations/202604050001_action_only_streaks.sql
+++ b/archive/supabase/migrations/202604050001_action_only_streaks.sql
@@ -1,0 +1,43 @@
+-- Action-only streak schema support
+
+create table if not exists public.streak_activity_log (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  day_key date not null,
+  activity_type text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists streak_activity_log_user_day_activity_uq
+  on public.streak_activity_log (user_id, day_key, activity_type);
+
+create index if not exists streak_activity_log_user_day_idx
+  on public.streak_activity_log (user_id, day_key desc);
+
+alter table public.streaks
+  add column if not exists date date,
+  add column if not exists current_streak integer,
+  add column if not exists longest_streak integer,
+  add column if not exists activity_type text,
+  add column if not exists metadata jsonb not null default '{}'::jsonb;
+
+create unique index if not exists streaks_user_date_activity_uq
+  on public.streaks (user_id, date, activity_type)
+  where date is not null and activity_type is not null;
+
+create or replace function public.touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists streak_activity_log_touch_updated_at on public.streak_activity_log;
+create trigger streak_activity_log_touch_updated_at
+before update on public.streak_activity_log
+for each row execute function public.touch_updated_at();

--- a/components/design-system/StreakIndicator.tsx
+++ b/components/design-system/StreakIndicator.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useStreak } from '@/hooks/useStreak';
-import { getDayKeyInTZ } from '@/lib/streak';
 
 const cx = (...xs: Array<string | false | null | undefined>) => xs.filter(Boolean).join(' ');
 
@@ -9,7 +8,7 @@ type Props = {
   className?: string;
   value?: number; // external streak value; disables autoClaim
   compact?: boolean;
-  autoClaim?: boolean; // default: true (ignored if value is provided)
+  autoClaim?: boolean; // kept for compatibility; no passive auto-claim
   tone?: Tone;
 };
 
@@ -28,26 +27,15 @@ export const StreakIndicator: React.FC<Props> = ({
   className = '',
   value,
   compact = false,
-  autoClaim = true,
+  autoClaim = false,
   tone = 'electric',
 }) => {
-  const { current, lastDayKey, completeToday, loading, shields = 0, error } = useStreak();
-  const todayKey = React.useMemo(() => getDayKeyInTZ(), []);
-  const autoTriedRef = React.useRef(false);
+  const { current, loading, shields = 0, error } = useStreak();
+  void autoClaim;
 
   const streakValue = value ?? current;
 
-  // Auto-claim once (only when using internal hook value)
-  React.useEffect(() => {
-    if (value !== undefined) return; // external control → don't auto-claim
-    if (autoTriedRef.current || loading) return;
-    autoTriedRef.current = true;
-    if (autoClaim && lastDayKey !== todayKey) {
-      completeToday().catch((err) => {
-        console.error('Auto-claim failed:', err);
-      });
-    }
-  }, [value, autoClaim, loading, lastDayKey, todayKey, completeToday]);
+  // autoClaim intentionally disabled to avoid passive streak increments
 
   // subtle glow on change
   const [pulse, setPulse] = React.useState(false);
@@ -101,4 +89,4 @@ export const StreakIndicator: React.FC<Props> = ({
   );
 };
 
-export default StreakIndicator; 
+export default StreakIndicator;

--- a/components/learning/DrillRunner.tsx
+++ b/components/learning/DrillRunner.tsx
@@ -1,14 +1,11 @@
 // components/learning/DrillRunner.tsx (example)
 import React from 'react';
-import { useStreak } from '@/hooks/useStreak';
 import { Button } from '@/components/design-system/Button';
 
 export const DrillRunner: React.FC = () => {
-  const { completeToday } = useStreak();
-
   const onDrillCompleted = async () => {
     // ... existing save/score logic
-    await completeToday(); // increments streak safely (server-validated)
+    // completion is persisted by actionable API submissions only
   };
 
   return (

--- a/docs/streak-action-policy.md
+++ b/docs/streak-action-policy.md
@@ -1,0 +1,46 @@
+# Action-only streak policy
+
+Streaks are updated only from **action submissions** (API-side), not from passive page views.
+
+## Actions that trigger streak updates
+
+- Writing submissions (`writing`)
+  - `/writing`
+  - `/ai/writing/[id]`
+- Speaking completions (`speaking`)
+  - `/speaking/practice`
+  - `/speaking/roleplay/[scenario]`
+  - `/speaking/simulator/*`
+- Reading submissions (`reading`)
+  - `/reading/[slug]/review`
+  - `/reading/passage/[slug]`
+- Vocabulary drill completions (`vocabulary`)
+  - `/vocabulary/review`
+  - `/vocabulary/quizzes/today`
+  - `/vocabulary/my-words`
+  - `/vocabulary/linking-words`
+- AI / micro-lessons (`ai_lesson`)
+  - `/ai/mistakes-book`
+  - `/ai/study-buddy/session/[id]/practice`
+  - `/ai/writing/[id]`
+- Mock/exam final submissions (`mock`)
+  - `/mock`
+  - `/writing/exam/[id]`
+  - `/speaking/roleplay`
+
+## Non-triggering behavior
+
+The following must not auto-increment streaks:
+
+- Visiting dashboards or analytics pages
+- Opening streak widgets/indicators
+- Loading study plan pages without a real submission event
+- Passive content reads without submission/attempt completion
+
+## Implementation notes
+
+- `lib/streak.ts` exports `completeToday(client, userId, activityType, metadata)`.
+- API routes call `completeToday` only after successful actionable submissions.
+- The API endpoint `/api/streak` accepts `activityType` and only updates for allow-listed activity types.
+- Idempotency is enforced by per-day activity uniqueness in `streak_activity_log` (`user_id`, `day_key`, `activity_type`).
+- Core streak progression remains PKT (`Asia/Karachi`) day-based.

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -289,7 +289,7 @@ export async function getUserStreak(client: SupabaseClient, userId: string): Pro
   const timeZone = await resolveUserTimezone(client, userId);
   const today = getDayKeyInTZ(new Date(), timeZone);
 
-  const [{ data: streakData, error: streakErr }, { data: shieldData }, todayTasks, activityHistory, calendar] =
+  const [{ data: streakData, error: streakErr }, { data: shieldData }, todayTasks, activityHistory] =
     await Promise.all([
       client
         .from('streaks')
@@ -299,12 +299,16 @@ export async function getUserStreak(client: SupabaseClient, userId: string): Pro
       client.from('streak_shields').select('tokens').eq('user_id', userId).maybeSingle(),
       buildTaskStatusForDay(client, userId, today),
       buildRecentActivityHistory(client, userId, timeZone, 21),
-      getStreakCalendar(client, userId, 84),
     ]);
 
   if (streakErr) throw streakErr;
 
-  const heatmap: StreakCalendarEntry[] = calendar;
+  let heatmap: StreakCalendarEntry[] = [];
+  try {
+    heatmap = await getStreakCalendar(client, userId, 84);
+  } catch (error) {
+    console.warn('[streak] failed to build heatmap calendar; using empty heatmap', error);
+  }
 
   const lastActivity = streakData?.last_active_date ?? null;
 

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -209,11 +209,87 @@ async function buildRecentActivityHistory(
   return history.sort((a, b) => a.date.localeCompare(b.date));
 }
 
+async function buildCalendarFromAttempts(
+  client: SupabaseClient,
+  userId: string,
+  daysBack: number,
+): Promise<StreakCalendarEntry[]> {
+  const boundedDaysBack = Math.max(1, Math.min(365, Math.floor(daysBack)));
+  const today = new Date();
+  const start = new Date(today.getTime() - (boundedDaysBack - 1) * DAY_MS);
+
+  const fromIso = start.toISOString();
+  const toIso = new Date(today.getTime() + DAY_MS).toISOString();
+
+  const [writingRows, speakingRows, mockRows, readingRows, taskRunRows] = await Promise.all([
+    client
+      .from('writing_attempts')
+      .select('updated_at')
+      .eq('user_id', userId)
+      .gte('updated_at', fromIso)
+      .lt('updated_at', toIso),
+    client
+      .from('speaking_attempts')
+      .select('created_at')
+      .eq('user_id', userId)
+      .gte('created_at', fromIso)
+      .lt('created_at', toIso),
+    client
+      .from('mock_full_attempts')
+      .select('submitted_at')
+      .eq('user_id', userId)
+      .gte('submitted_at', fromIso)
+      .lt('submitted_at', toIso),
+    client
+      .from('reading_responses')
+      .select('created_at')
+      .eq('user_id', userId)
+      .gte('created_at', fromIso)
+      .lt('created_at', toIso),
+    client
+      .from('task_runs')
+      .select('completed_at')
+      .eq('user_id', userId)
+      .gte('completed_at', fromIso)
+      .lt('completed_at', toIso),
+  ]);
+
+  const responses = [writingRows, speakingRows, mockRows, readingRows, taskRunRows];
+  const responseTables = ['writing_attempts', 'speaking_attempts', 'mock_full_attempts', 'reading_responses', 'task_runs'];
+  responses.forEach((response, index) => {
+    if (response.error) {
+      const tableName = responseTables[index];
+      console.warn(`[streak] calendar fallback query failed for ${tableName}`, response.error.message);
+    }
+  });
+
+  const activeDays = new Set<string>();
+  const pushDate = (value: unknown) => {
+    if (typeof value !== 'string' || !value) return;
+    activeDays.add(getDayKeyInTZ(new Date(value), 'UTC'));
+  };
+
+  writingRows.data?.forEach((row: any) => pushDate(row?.updated_at));
+  speakingRows.data?.forEach((row: any) => pushDate(row?.created_at));
+  mockRows.data?.forEach((row: any) => pushDate(row?.submitted_at));
+  readingRows.data?.forEach((row: any) => pushDate(row?.created_at));
+  taskRunRows.data?.forEach((row: any) => pushDate(row?.completed_at));
+
+  const calendar: StreakCalendarEntry[] = [];
+  for (let offset = boundedDaysBack - 1; offset >= 0; offset -= 1) {
+    const date = new Date(today.getTime() - offset * DAY_MS);
+    const dayKey = getDayKeyInTZ(date, 'UTC');
+    calendar.push({ date: dayKey, active: activeDays.has(dayKey) });
+  }
+
+  return calendar;
+}
+
 export async function getUserStreak(client: SupabaseClient, userId: string): Promise<StreakSummary> {
   const timeZone = await resolveUserTimezone(client, userId);
   const today = getDayKeyInTZ(new Date(), timeZone);
 
-  const [{ data: streakData, error: streakErr }, { data: shieldData }, { data: historyData }, todayTasks, activityHistory] =
+  const [{ data: streakData, error: streakErr }, { data: shieldData }, todayTasks, activityHistory, calendar] =
     await Promise.all([
       client
         .from('streaks')
@@ -221,19 +297,14 @@ export async function getUserStreak(client: SupabaseClient, userId: string): Pro
         .eq('user_id', userId)
         .maybeSingle(),
       client.from('streak_shields').select('tokens').eq('user_id', userId).maybeSingle(),
-      client.rpc('get_streak_history', { p_user_id: userId, p_days_back: 84 }),
       buildTaskStatusForDay(client, userId, today),
       buildRecentActivityHistory(client, userId, timeZone, 21),
+      getStreakCalendar(client, userId, 84),
     ]);
 
   if (streakErr) throw streakErr;
 
-  const heatmap: StreakCalendarEntry[] = Array.isArray(historyData)
-    ? historyData.map((entry: any) => ({
-        date: String(entry?.date ?? ''),
-        active: Number(entry?.completed ?? 0) > 0,
-      }))
-    : [];
+  const heatmap: StreakCalendarEntry[] = calendar;
 
   const lastActivity = streakData?.last_active_date ?? null;
 
@@ -300,18 +371,27 @@ export async function getStreakCalendar(
   userId: string,
   daysBack = 84,
 ): Promise<StreakCalendarEntry[]> {
+  const boundedDaysBack = Math.max(1, Math.min(365, Math.floor(daysBack)));
   const { data, error } = await client.rpc('get_streak_history', {
     p_user_id: userId,
-    p_days_back: Math.max(1, Math.min(365, Math.floor(daysBack))),
+    p_days_back: boundedDaysBack,
   });
 
-  if (error) throw error;
+  if (!error && Array.isArray(data)) {
+    return data.map((entry: any) => ({
+      date: String(entry?.date ?? ''),
+      active: Number(entry?.completed ?? 0) > 0,
+    }));
+  }
 
-  if (!Array.isArray(data)) return [];
-  return data.map((entry: any) => ({
-    date: String(entry?.date ?? ''),
-    active: Number(entry?.completed ?? 0) > 0,
-  }));
+  if (error) {
+    console.warn('[streak] get_streak_history rpc failed; using fallback calendar builder', {
+      code: error.code,
+      message: error.message,
+    });
+  }
+
+  return buildCalendarFromAttempts(client, userId, boundedDaysBack);
 }
 
 export function computeDailyStreak(entries: { date: string | Date }[]): { currentStreak: number; longestStreak: number } {

--- a/lib/streak.ts
+++ b/lib/streak.ts
@@ -12,6 +12,20 @@ import type {
 const STREAK_TIMEOUT_MS = 10_000;
 const DAY_MS = 86_400_000;
 
+export const ACTIONABLE_STREAK_ACTIVITY_TYPES = [
+  'writing',
+  'speaking',
+  'reading',
+  'vocabulary',
+  'ai_lesson',
+  'mock',
+] as const;
+
+export type ActionableStreakActivityType = (typeof ACTIONABLE_STREAK_ACTIVITY_TYPES)[number];
+
+export const isActionableStreakActivityType = (value: string): value is ActionableStreakActivityType =>
+  ACTIONABLE_STREAK_ACTIVITY_TYPES.includes(value as ActionableStreakActivityType);
+
 const STREAK_TASKS: Array<{ key: StreakTaskKey; label: string; href: string }> = [
   { key: 'writing', label: 'Writing submission', href: '/writing' },
   { key: 'speaking', label: 'Speaking practice', href: '/speaking/practice' },
@@ -360,6 +374,39 @@ export async function updateStreak(client: SupabaseClient, userId: string, now: 
   }
 
   return getUserStreak(client, userId);
+}
+
+export async function completeToday(
+  client: SupabaseClient,
+  userId: string,
+  activityType: ActionableStreakActivityType,
+  metadata: Record<string, unknown> = {},
+  now: Date = new Date(),
+): Promise<StreakSummary> {
+  const timeZone = await resolveUserTimezone(client, userId);
+  const dayKey = getDayKeyInTZ(now, timeZone);
+
+  const { error: insertError } = await client.from('streak_activity_log').insert({
+    user_id: userId,
+    day_key: dayKey,
+    activity_type: activityType,
+    metadata,
+  });
+
+  if (insertError) {
+    const code = insertError.code ?? '';
+    if (code === '23505') {
+      return getUserStreak(client, userId);
+    }
+
+    if (code !== '42P01') {
+      throw insertError;
+    }
+
+    console.warn('[streak] streak_activity_log missing; falling back to aggregate streak update only');
+  }
+
+  return updateStreak(client, userId, now);
 }
 
 export async function resetStreak(client: SupabaseClient, userId: string): Promise<StreakSummary> {

--- a/pages/api/mock/full/submit-final.ts
+++ b/pages/api/mock/full/submit-final.ts
@@ -1,7 +1,7 @@
 // pages/api/mock/full/submit-final.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getServerClient } from '@/lib/supabaseServer';
-import { updateStreak } from '@/lib/streak';
+import { completeToday } from '@/lib/streak';
 // import { computeListeningBand, computeReadingBand, computeOverallBand } from '@/lib/scoring/mock'; // example
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -102,7 +102,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(500).json({ error: 'Failed to finalize attempt' });
     }
 
-    await updateStreak(supabase, user.id);
+    await completeToday(supabase, user.id, 'mock', { fullAttemptId });
 
     return res.status(200).json({
       ok: true,

--- a/pages/api/mock/writing/submit.ts
+++ b/pages/api/mock/writing/submit.ts
@@ -4,7 +4,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { getServerClient } from '@/lib/supabaseServer';
-import { updateStreak } from '@/lib/streak';
+import { completeToday } from '@/lib/streak';
 import { normalizeScorePayload } from '@/lib/writing/scoring';
 import { evaluateEssayWithAi } from '@/lib/writing/ai-evaluator';
 import { writingSubmitSchema } from '@/lib/validation/writing';
@@ -173,7 +173,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     },
   });
 
-  await updateStreak(supabase, user.id);
+  await completeToday(supabase, user.id, 'mock', { attemptId, scope: 'writing_exam' });
 
   return res.status(200).json({ ok: true, attemptId, results });
 }

--- a/pages/api/reading/submit.ts
+++ b/pages/api/reading/submit.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { getServerClient } from '@/lib/supabaseServer';
-import { updateStreak } from '@/lib/streak';
+import { completeToday } from '@/lib/streak';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { trackor } from '@/lib/analytics/trackor.server';
 import { gradeReadingAttempt } from '@/lib/reading/grade';
@@ -278,7 +278,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     console.warn('[reading.submit] difficulty analytics failed', error);
   }
 
-  await updateStreak(supabase, user.id);
+  await completeToday(supabase, user.id, 'reading', { attemptId, slug: testSlug });
 
   return res.status(200).json({
     attemptId,

--- a/pages/api/speaking/attempts/index.ts
+++ b/pages/api/speaking/attempts/index.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { updateStreak } from '@/lib/streak';
+import { completeToday } from '@/lib/streak';
 
 const SectionSchema = z.enum(['part1', 'part2', 'part3']);
 const ScoreSchema = z.object({
@@ -71,7 +71,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (error) return res.status(400).json({ error: error.message });
 
-    await updateStreak(supabaseAdmin, user.id);
+    await completeToday(supabaseAdmin, user.id, 'speaking', { attemptId: data?.id, section });
 
     return res.status(200).json({
       ok: true,

--- a/pages/api/streak.ts
+++ b/pages/api/streak.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
-import { getUserStreak, updateStreak } from '@/lib/streak';
+import { completeToday, getUserStreak, isActionableStreakActivityType } from '@/lib/streak';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const supabase = createSupabaseServerClient({ req, res });
@@ -18,13 +18,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     if (req.method === 'POST') {
       const action = (req.body as { action?: string } | null)?.action;
+      const activityType = (req.body as { activityType?: string } | null)?.activityType;
+      const metadata = (req.body as { metadata?: Record<string, unknown> } | null)?.metadata ?? {};
       if (action === 'schedule' || action === 'claim' || action === 'use') {
         // Shield/recovery actions remain no-op for current streak engine but keep API compatibility.
         const streak = await getUserStreak(supabase, user.id);
         return res.status(200).json(streak);
       }
 
-      const streak = await updateStreak(supabase, user.id);
+      if (typeof activityType === 'string' && isActionableStreakActivityType(activityType)) {
+        const streak = await completeToday(supabase, user.id, activityType, metadata);
+        return res.status(200).json(streak);
+      }
+
+      const streak = await getUserStreak(supabase, user.id);
       return res.status(200).json(streak);
     }
 

--- a/pages/api/writing/attempts/submit.ts
+++ b/pages/api/writing/attempts/submit.ts
@@ -6,7 +6,7 @@ import { trackor } from '@/lib/analytics/trackor.server';
 import { createRequestLogger } from '@/lib/obs/logger';
 import { rateLimit } from '@/lib/rateLimit';
 import { getServerClient } from '@/lib/supabaseServer';
-import { updateStreak } from '@/lib/streak';
+import { completeToday } from '@/lib/streak';
 import { SubmitBody } from '@/lib/writing/schemas';
 
 interface AcceptedResponse {
@@ -99,7 +99,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
     ip: clientIp,
   });
 
-  await updateStreak(supabase, user.id);
+  await completeToday(supabase, user.id, 'writing', { attemptId });
 
   // TODO: enqueue scoring job via background worker
   return res.status(202).json({ accepted: true, attemptId });

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -104,7 +104,6 @@ const Dashboard: NextPage = () => {
     longest,
     lastDayKey,
     loading: streakLoading,
-    completeToday,
     nextRestart,
     shields,
     claimShield,
@@ -224,15 +223,6 @@ const Dashboard: NextPage = () => {
   const dismissTips = () => {
     setTipsDismissed('1');
   };
-
-  useEffect(() => {
-    if (streakLoading) return;
-    const today = getDayKeyInTZ();
-    if (lastDayKey !== today) {
-      void completeToday().catch(() => {});
-    }
-  }, [streakLoading, lastDayKey, completeToday]);
-
   const { signedUrl: profileAvatarUrl } = useSignedAvatar(profile?.avatar_url ?? null);
 
   // Wrap ai in useMemo to avoid recreating it on every render (fix for exhaustive-deps warning)

--- a/pages/profile/streak.tsx
+++ b/pages/profile/streak.tsx
@@ -11,7 +11,7 @@ import { StreakChip } from '@/components/user/StreakChip';
 import { Alert } from '@/components/design-system/Alert';
 import { Skeleton } from '@/components/design-system/Skeleton';
 import { getServerClient } from '@/lib/supabaseServer';
-import { getStreakCalendar, getUserStreak } from '@/lib/streak';
+import { getUserStreak } from '@/lib/streak';
 import { useLocale } from '@/lib/locale';
 
 const Heatmap = dynamic(
@@ -241,15 +241,10 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
     };
   }
 
-  const DAYS_BACK = 84;
-
   try {
-    const [streakSummary, calendar] = await Promise.all([
-      getUserStreak(supabase, user.id),
-      getStreakCalendar(supabase, user.id, DAYS_BACK),
-    ]);
+    const streakSummary = await getUserStreak(supabase, user.id);
 
-    const history = calendar.map((entry) => ({
+    const history = streakSummary.heatmap.map((entry) => ({
       date: entry.date,
       completed: entry.active ? 1 : 0,
       total: 1,

--- a/pages/study-plan/index.tsx
+++ b/pages/study-plan/index.tsx
@@ -116,7 +116,7 @@ export default function StudyPlanPage() {
   const planProgressRef = useRef<number>(0);
 
   const { success: toastSuccess, error: toastError } = useToast();
-  const { current: streak, loading: streakLoading, completeToday, reload: reloadStreak } = useStreak();
+  const { current: streak, loading: streakLoading } = useStreak();
   const { plan: subscriptionPlan, loading: planLoading } = usePlan();
   const showUpgradeBanner = !planLoading && subscriptionPlan === 'free';
 
@@ -286,15 +286,6 @@ export default function StudyPlanPage() {
         await persistPlan(next);
         track('studyplan_update', { day: dayKey, taskId, completed: checked });
         void logStudyPlanEvent('studyplan_update', { day: dayKey, taskId, completed: checked });
-        const shouldStartStreak = checked && !wasComplete && !hadOtherCompleted && dayKey === todayKey;
-        if (shouldStartStreak) {
-          try {
-            const data = await completeToday();
-            if (!data) await reloadStreak();
-          } catch (err) {
-            console.error('Streak update failed', err);
-          }
-        }
         if (checked && !wasComplete) {
           track('studyplan_task_complete', { day: dayKey, taskId });
           void logStudyPlanEvent('studyplan_task_complete', { day: dayKey, taskId });
@@ -308,7 +299,7 @@ export default function StudyPlanPage() {
         setBusyTask(null);
       }
     },
-    [plan, t, userId, persistPlan, completeToday, reloadStreak, toastError, todayKey],
+    [plan, t, userId, persistPlan, toastError, todayKey],
   );
 
   const hasPlan = !!plan && plan.days.length > 0;

--- a/pages/vocab/index.tsx
+++ b/pages/vocab/index.tsx
@@ -90,7 +90,7 @@ const VocabPage: NextPage<PageProps> = ({ initialDate, initialWord, initialSourc
   const [source, setSource] = React.useState<'rpc' | 'view' | null>(initialSource);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
-  const { loading: streakLoading, current: streakCurrent, completeToday } = useStreak();
+  const { loading: streakLoading, current: streakCurrent } = useStreak();
   const [streakError, setStreakError] = React.useState<string | null>(null);
   const [xpTotal, setXpTotal] = React.useState(0);
   const [attempts, setAttempts] = React.useState<{
@@ -139,23 +139,11 @@ const VocabPage: NextPage<PageProps> = ({ initialDate, initialWord, initialSourc
     setXpTotal(0);
   }, [word]);
 
-  const recordXp = React.useCallback(
-    (xp: number) => {
-      if (xp <= 0) return;
-      setXpTotal((current) => current + xp);
-      void completeToday()
-        .then(() => setStreakError(null))
-        .catch((err: unknown) => {
-          console.warn('[pages/vocab] streak update failed', err);
-          const message =
-            err instanceof Error && /unauthorized/i.test(err.message)
-              ? 'Sign in to sync your streak automatically.'
-              : 'Streak sync delayed — your XP is safe.';
-          setStreakError(message);
-        });
-    },
-    [completeToday],
-  );
+  const recordXp = React.useCallback((xp: number) => {
+    if (xp <= 0) return;
+    setXpTotal((current) => current + xp);
+    setStreakError(null);
+  }, []);
 
   const handleMeaningComplete = React.useCallback(
     (result: { correct: boolean; xpAwarded: number }) => {

--- a/tests/api/streak.action-only.test.ts
+++ b/tests/api/streak.action-only.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment node
+ */
+import httpMocks from 'node-mocks-http';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getUserStreakMock = vi.fn();
+const completeTodayMock = vi.fn();
+
+vi.mock('@/lib/streak', async () => {
+  const actual = await vi.importActual<any>('@/lib/streak');
+  return {
+    ...actual,
+    getUserStreak: getUserStreakMock,
+    completeToday: completeTodayMock,
+  };
+});
+
+const supabaseStub = {
+  auth: {
+    getUser: vi.fn(async () => ({ data: { user: { id: 'user-1' } }, error: null })),
+  },
+};
+
+vi.mock('@/lib/supabaseServer', () => ({
+  createSupabaseServerClient: vi.fn(() => supabaseStub),
+}));
+
+import handler from '@/pages/api/streak';
+
+describe('/api/streak action-only behavior', () => {
+  beforeEach(() => {
+    getUserStreakMock.mockReset();
+    completeTodayMock.mockReset();
+    getUserStreakMock.mockResolvedValue({ current_streak: 3 });
+    completeTodayMock.mockResolvedValue({ current_streak: 4 });
+  });
+
+  it('does not increment streak without activityType', async () => {
+    const req = httpMocks.createRequest({ method: 'POST', body: {} });
+    const res = httpMocks.createResponse();
+
+    await handler(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(completeTodayMock).not.toHaveBeenCalled();
+    expect(getUserStreakMock).toHaveBeenCalled();
+  });
+
+  it('increments streak for actionable activityType', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: { activityType: 'writing', metadata: { attemptId: 'a-1' } },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(completeTodayMock).toHaveBeenCalledWith(supabaseStub, 'user-1', 'writing', { attemptId: 'a-1' });
+  });
+
+  it('ignores non-actionable activityType', async () => {
+    const req = httpMocks.createRequest({ method: 'POST', body: { activityType: 'dashboard' } });
+    const res = httpMocks.createResponse();
+
+    await handler(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(completeTodayMock).not.toHaveBeenCalled();
+    expect(getUserStreakMock).toHaveBeenCalled();
+  });
+});

--- a/tests/lib/streak.action-only.test.ts
+++ b/tests/lib/streak.action-only.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, expect, it } from 'vitest';
+
+import { computeStreakUpdate, isActionableStreakActivityType } from '@/lib/streak';
+
+describe('streak action-only helpers', () => {
+  it('accepts only allow-listed activity types', () => {
+    expect(isActionableStreakActivityType('writing')).toBe(true);
+    expect(isActionableStreakActivityType('speaking')).toBe(true);
+    expect(isActionableStreakActivityType('reading')).toBe(true);
+    expect(isActionableStreakActivityType('vocabulary')).toBe(true);
+    expect(isActionableStreakActivityType('ai_lesson')).toBe(true);
+    expect(isActionableStreakActivityType('mock')).toBe(true);
+    expect(isActionableStreakActivityType('dashboard')).toBe(false);
+    expect(isActionableStreakActivityType('lesson_view')).toBe(false);
+  });
+
+  it('increments streak on consecutive PKT days and resets after a miss', () => {
+    const day1 = new Date('2026-04-05T10:00:00+05:00');
+    const day2 = new Date('2026-04-06T10:00:00+05:00');
+    const day4 = new Date('2026-04-08T10:00:00+05:00');
+
+    const first = computeStreakUpdate({ now: day1, row: null });
+    expect(first.current).toBe(1);
+
+    const consecutive = computeStreakUpdate({
+      now: day2,
+      row: {
+        current_streak: first.current,
+        longest_streak: first.longest,
+        last_activity_date: first.todayKey,
+      },
+    });
+    expect(consecutive.current).toBe(2);
+
+    const missed = computeStreakUpdate({
+      now: day4,
+      row: {
+        current_streak: consecutive.current,
+        longest_streak: consecutive.longest,
+        last_activity_date: consecutive.todayKey,
+      },
+    });
+
+    expect(missed.reason).toBe('reset');
+    expect(missed.current).toBe(1);
+    expect(missed.longest).toBe(2);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a robust fallback for building the streak heatmap when the `get_streak_history` RPC fails or is unavailable.
- Avoid out-of-range `daysBack` values by bounding the requested window to 1..365 days.
- Consolidate calendar construction so `getUserStreak` always receives a valid heatmap even if the RPC errors.

### Description
- Added `buildCalendarFromAttempts` which queries attempt/activity tables (`writing_attempts`, `speaking_attempts`, `mock_full_attempts`, `reading_responses`, `task_runs`) and builds a UTC day-based calendar for the requested window.
- Updated `getStreakCalendar` to bound `daysBack` to `1..365`, return the RPC data when available, log RPC failures, and fall back to `buildCalendarFromAttempts` on error.
- Updated `getUserStreak` to use `getStreakCalendar` and to use the returned calendar as the streak `heatmap`.
- Added console warnings when any attempt-table query or the RPC fails to assist debugging.

### Testing
- Ran the TypeScript build (`tsc`) which completed successfully.
- Executed the unit test suite (`yarn test`) and all tests passed.
- Verified the new RPC-fallback path by simulating an RPC error and confirming the fallback calendar is returned (local integration check).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ade7de59f0832885f036cb1900746c)