### PR TITLE
Add shared ActionSupportPanel and migrate QuickActions; add audit doc

### DIFF
--- a/components/activity/QuickActions.tsx
+++ b/components/activity/QuickActions.tsx
@@ -1,20 +1,18 @@
-// components/activity/QuickActions.tsx
-import * as React from "react";
-import { Card } from "@/components/design-system/Card";
-import { Button } from "@/components/design-system/Button";
-import type { ActivityStats } from "@/types/activity";
+import * as React from 'react';
+import type { ActivityStats } from '@/types/activity';
+import ActionSupportPanel from '@/components/shared/ActionSupportPanel';
 import {
   Plus,
   FileText,
   Mic,
   Headphones,
   BookOpen,
-  Target,
-  TrendingUp,
   Download,
   Share2,
   Bell,
-} from "lucide-react";
+  TrendingUp,
+  ListChecks,
+} from 'lucide-react';
 
 interface QuickActionsProps {
   stats: ActivityStats;
@@ -23,119 +21,87 @@ interface QuickActionsProps {
 }
 
 export default function QuickActions({ stats, onTaskCreate, onViewAllTasks }: QuickActionsProps) {
-  const quickActions = [
-    {
-      icon: <FileText className="h-4 w-4" />,
-      label: "Start Writing",
-      description: "Practice task 2 essay",
-      color: "indigo",
-      href: "/writing/practice",
-    },
-    {
-      icon: <Mic className="h-4 w-4" />,
-      label: "Speaking Practice",
-      description: "Part 2 cue card",
-      color: "pink",
-      href: "/speaking/practice",
-    },
-    {
-      icon: <Headphones className="h-4 w-4" />,
-      label: "Listening Exercise",
-      description: "Section 3 practice",
-      color: "orange",
-      href: "/listening/practice",
-    },
-    {
-      icon: <BookOpen className="h-4 w-4" />,
-      label: "Reading Passage",
-      description: "Academic passage 1",
-      color: "teal",
-      href: "/reading/practice",
-    },
-  ];
-
-  const getColorClasses = (color: string) => {
-    const classes = {
-      indigo: "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400",
-      pink: "bg-pink-100 dark:bg-pink-900/30 text-pink-600 dark:text-pink-400",
-      orange: "bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400",
-      teal: "bg-teal-100 dark:bg-teal-900/30 text-teal-600 dark:text-teal-400",
-    };
-    return classes[color as keyof typeof classes] || classes.indigo;
-  };
-
   return (
-    <Card className="p-5">
-      <h3 className="font-semibold mb-4 flex items-center gap-2">
-        <Target className="h-5 w-5 text-primary" />
-        Quick Actions
-      </h3>
-
-      <div className="space-y-3">
-        {/* Create Task Button */}
-        <Button
-          variant="solid"
-          tone="primary"
-          className="w-full"
-          onClick={onTaskCreate}
-        >
-          <Plus className="mr-2 h-4 w-4" />
-          Create New Task
-        </Button>
-
-        {/* Practice Actions */}
-        <div className="grid grid-cols-2 gap-2">
-          {quickActions.map((action, index) => (
-            <a
-              key={index}
-              href={action.href}
-              className="block p-3 border border-border rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
-            >
-              <div className="flex items-center gap-3">
-                <div className={`p-2 rounded-lg ${getColorClasses(action.color)}`}>
-                  {action.icon}
-                </div>
-                <div>
-                  <p className="text-sm font-medium">{action.label}</p>
-                  <p className="text-xs text-muted-foreground">{action.description}</p>
-                </div>
-              </div>
-            </a>
-          ))}
-        </div>
-
-        {/* View All Tasks */}
-        <Button
-          variant="outline"
-          className="w-full"
-          onClick={onViewAllTasks}
-        >
-          View All Tasks ({stats.pendingTasks + stats.completedTasks})
-        </Button>
-
-        {/* Additional Actions */}
-        <div className="pt-4 border-t border-border">
-          <h4 className="text-sm font-medium mb-2">More Actions</h4>
-          <div className="grid grid-cols-2 gap-2">
-            <Button variant="ghost" size="sm" className="justify-start">
-              <Download className="mr-2 h-4 w-4" />
-              Export Data
-            </Button>
-            <Button variant="ghost" size="sm" className="justify-start">
-              <Share2 className="mr-2 h-4 w-4" />
-              Share Progress
-            </Button>
-            <Button variant="ghost" size="sm" className="justify-start">
-              <Bell className="mr-2 h-4 w-4" />
-              Set Reminder
-            </Button>
-            <Button variant="ghost" size="sm" className="justify-start">
-              <TrendingUp className="mr-2 h-4 w-4" />
-              View Analytics
-            </Button>
-          </div>
-        </div>
-      </div>
-    </Card>
+    <ActionSupportPanel
+      title="Quick actions"
+      subtitle="Jump into your next IELTS practice block in one tap."
+      actionsColumns={2}
+      actions={[
+        {
+          id: 'create-task',
+          icon: <Plus className="h-4 w-4" />,
+          label: 'Create New Task',
+          description: 'Add a new goal to your tracker',
+          onClick: onTaskCreate,
+        },
+        {
+          id: 'view-all',
+          icon: <ListChecks className="h-4 w-4" />,
+          label: `View All Tasks (${stats.pendingTasks + stats.completedTasks})`,
+          description: 'Review pending and completed work',
+          onClick: onViewAllTasks,
+        },
+        {
+          id: 'writing',
+          icon: <FileText className="h-4 w-4" />,
+          label: 'Start Writing',
+          description: 'Practice task 2 essay',
+          href: '/writing/practice',
+        },
+        {
+          id: 'speaking',
+          icon: <Mic className="h-4 w-4" />,
+          label: 'Speaking Practice',
+          description: 'Part 2 cue card',
+          href: '/speaking/practice',
+        },
+        {
+          id: 'listening',
+          icon: <Headphones className="h-4 w-4" />,
+          label: 'Listening Exercise',
+          description: 'Section 3 practice',
+          href: '/listening/practice',
+        },
+        {
+          id: 'reading',
+          icon: <BookOpen className="h-4 w-4" />,
+          label: 'Reading Passage',
+          description: 'Academic passage 1',
+          href: '/reading/practice',
+        },
+        {
+          id: 'export',
+          icon: <Download className="h-4 w-4" />,
+          label: 'Export Data',
+          description: 'Download your activity data',
+          href: '/account/activity',
+        },
+        {
+          id: 'share',
+          icon: <Share2 className="h-4 w-4" />,
+          label: 'Share Progress',
+          description: 'Share your latest milestones',
+          href: '/progress',
+        },
+        {
+          id: 'reminder',
+          icon: <Bell className="h-4 w-4" />,
+          label: 'Set Reminder',
+          description: 'Stay consistent every day',
+          href: '/account/notifications',
+        },
+        {
+          id: 'analytics',
+          icon: <TrendingUp className="h-4 w-4" />,
+          label: 'View Analytics',
+          description: 'Track growth over time',
+          href: '/progress',
+        },
+      ]}
+      supportTitle="Need help?"
+      supportDescription="Get support from the team if something blocks your progress."
+      supportPrimaryCta={{ label: 'Contact support', href: '/help', variant: 'secondary' }}
+      supportSecondaryCta={{ label: 'Open AI assistant', href: '/ai', variant: 'ghost' }}
+    />
   );
 }

--- a/components/shared/ActionSupportPanel.tsx
+++ b/components/shared/ActionSupportPanel.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { Card } from '@/components/design-system/Card';
+import { Button } from '@/components/design-system/Button';
+import { ArrowRight } from 'lucide-react';
+
+type ActionItem = {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: React.ReactNode;
+  href?: string;
+  onClick?: () => void;
+  badge?: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+};
+
+type SupportCta = {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  variant?: 'primary' | 'secondary' | 'ghost' | 'outline' | 'accent';
+  ariaLabel?: string;
+};
+
+interface ActionSupportPanelProps {
+  title?: string;
+  subtitle?: string;
+  actions?: ActionItem[];
+  supportTitle?: string;
+  supportDescription?: string;
+  supportPrimaryCta?: SupportCta;
+  supportSecondaryCta?: SupportCta;
+  className?: string;
+  actionsColumns?: 1 | 2 | 3;
+}
+
+function gridCols(actionsColumns: 1 | 2 | 3 = 2) {
+  if (actionsColumns === 1) return 'grid-cols-1';
+  if (actionsColumns === 3) return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3';
+  return 'grid-cols-1 sm:grid-cols-2';
+}
+
+function ActionLinkOrButton({ action }: { action: ActionItem }) {
+  const commonClass =
+    'group flex min-h-[52px] items-start gap-3 rounded-xl border border-border/70 bg-card px-3 py-3 text-left transition hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40';
+
+  const content = (
+    <>
+      {action.icon ? <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center text-primary">{action.icon}</span> : null}
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-semibold text-foreground">{action.label}</span>
+        {action.description ? <span className="mt-0.5 block text-xs text-muted-foreground">{action.description}</span> : null}
+      </span>
+      {action.badge ? (
+        <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          {action.badge}
+        </span>
+      ) : (
+        <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:translate-x-0.5" aria-hidden="true" />
+      )}
+    </>
+  );
+
+  if (action.href) {
+    return (
+      <a href={action.href} aria-label={action.ariaLabel} className={commonClass} aria-disabled={action.disabled ? 'true' : undefined}>
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" onClick={action.onClick} disabled={action.disabled} aria-label={action.ariaLabel} className={commonClass}>
+      {content}
+    </button>
+  );
+}
+
+export default function ActionSupportPanel({
+  title = 'Quick actions',
+  subtitle,
+  actions = [],
+  supportTitle = 'Need help?',
+  supportDescription,
+  supportPrimaryCta,
+  supportSecondaryCta,
+  className,
+  actionsColumns = 2,
+}: ActionSupportPanelProps) {
+  return (
+    <Card className={`rounded-ds-2xl p-5 sm:p-6 ${className ?? ''}`}>
+      {(title || subtitle) && (
+        <div className="mb-4">
+          {title ? <h3 className="font-slab text-h3">{title}</h3> : null}
+          {subtitle ? <p className="mt-1 text-small text-muted-foreground">{subtitle}</p> : null}
+        </div>
+      )}
+
+      {actions.length > 0 ? (
+        <div className={`grid gap-3 ${gridCols(actionsColumns)}`}>
+          {actions.map((action) => (
+            <ActionLinkOrButton key={action.id} action={action} />
+          ))}
+        </div>
+      ) : null}
+
+      {(supportPrimaryCta || supportSecondaryCta || supportDescription) && (
+        <div className={`mt-5 rounded-xl border border-border/70 bg-muted/30 p-4 ${actions.length > 0 ? 'border-t' : ''}`}>
+          <h4 className="text-sm font-semibold">{supportTitle}</h4>
+          {supportDescription ? <p className="mt-1 text-xs text-muted-foreground">{supportDescription}</p> : null}
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+            {supportPrimaryCta ? (
+              <Button
+                variant={supportPrimaryCta.variant ?? 'secondary'}
+                href={supportPrimaryCta.href}
+                onClick={supportPrimaryCta.onClick}
+                className="w-full sm:w-auto"
+                aria-label={supportPrimaryCta.ariaLabel}
+              >
+                {supportPrimaryCta.label}
+              </Button>
+            ) : null}
+            {supportSecondaryCta ? (
+              <Button
+                variant={supportSecondaryCta.variant ?? 'ghost'}
+                href={supportSecondaryCta.href}
+                onClick={supportSecondaryCta.onClick}
+                className="w-full sm:w-auto"
+                aria-label={supportSecondaryCta.ariaLabel}
+              >
+                {supportSecondaryCta.label}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/docs/quick-actions-need-help-audit.md
+++ b/docs/quick-actions-need-help-audit.md
@@ -1,0 +1,242 @@
+# Quick Actions + Need Help Audit & Refactor Plan
+
+## Scope and method
+- Repository-wide text scan for case-insensitive variants of `quick action(s)` and `need help` across components, pages, layouts, and emails.
+- Command used:
+  - `rg -n --hidden -i --glob '!node_modules' --glob '!.next' --glob '!dist' "quick actions?|need help\??" .`
+- Follow-up file inspection was used to classify each hit as:
+  - **Direct UI instance** (heading/button/link/card shown to users),
+  - **Wrapper/context instance** (container or parent page wiring),
+  - **Non-target copy/comment** (not part of the requested UI standardization).
+
+---
+
+## 1) Inventory: “Quick Actions” occurrences
+
+### A. Core reusable components (highest refactor priority)
+1. `components/activity/QuickActions.tsx:71` — card heading “Quick Actions”; multi-action grid + CTA buttons.
+2. `components/dashboard/QuickActions.tsx:16` — dashboard card titled “Quick actions” with responsive action tiles.
+3. `components/dashboard/sections/QuickActionsSection.tsx:20` — section heading “Quick actions” + wrap of multiple buttons.
+4. `components/navigation/QuickAccessWidget.tsx:53` — floating quick-actions menu label.
+
+### B. Page-level implementations (likely consumers of unified component)
+5. `pages/learning/skills/[skill].tsx:149` — “Quick Actions” heading and action links.
+6. `pages/profile/account/index.tsx:450` — “Quick actions” subsection in account activity card.
+7. `pages/account/index.tsx:438` — translated “Quick actions” subsection in account activity card.
+8. `pages/data-deletion.tsx:90` — “2) Quick Actions” section with support/privacy CTAs.
+
+### C. Wrapper/related references (not a direct standalone component)
+9. `pages/dashboard/activity/index.tsx:469` — page column comment and inclusion of activity quick-actions component.
+10. `components/layouts/ResourcesLayout.tsx:52` — comment label “Quick actions”; UI text is “Quick Access.”
+11. `pages/mock/writing/index.tsx:250` — comment only (`/* QUICK ACTIONS */`).
+12. `pages/mock/listening/index.tsx:25` and `:249` — comment/static marker only.
+13. `pages/mock/reading/review/[attemptId].tsx:387` — comment only.
+14. `pages/data-deletion.tsx:11` — TOC title string “Quick Actions” (navigation label).
+
+---
+
+## 2) Inventory: “Need Help?” occurrences
+
+### A. Interactive product UI (highest refactor priority)
+1. `components/writing/RightRailCoach.tsx:79` — ghost button `Need help?`.
+2. `components/auth/AuthAssistant.tsx:236` — floating launcher button `Need help?`.
+3. `pages/onboarding/welcome/index.tsx:505` — help CTA card heading `Need help?` with two support actions.
+4. `pages/checkout/index.tsx:520` — checkout footer support link `Need help?`.
+5. `pages/checkout/crypto.tsx:189` — support link `Need help? Contact support`.
+6. `pages/teacher/pending.tsx:28` — info alert `Need help? Contact support...`.
+7. `pages/teacher/Welcome.tsx:236` — help copy in FAQ tab linking support center.
+8. `components/premium/UpgradeModal.tsx:178` — modal support copy with email CTA.
+
+### B. Contextual “Need help…” variants (same intent, not always exact label)
+9. `components/auth/AuthAssistant.tsx:49`, `:61`, `:73` — seeded assistant prompts “Need help signing in/creating account/...”.
+10. `pages/challenge/[cohort].tsx:170` — in-line motivational help tip.
+11. `pages/data-deletion.tsx:196` — support appeal copy “Need help, or want to appeal...”.
+12. `pages/account/subscription.tsx:401` — i18n/help copy string for subscription support.
+
+### C. Email templates (shared language, separate UI system)
+13. `emails/PaymentFailedEmail.tsx:37` — `Need help? Contact support` line.
+14. `emails/SignupEmail.tsx:31` — `Need help? Contact our support team` line.
+
+### D. Non-target language (exclude from component migration)
+15. `data/roleplay/scenarios.ts:39` — sample sentence “Do you need help...”; not product UI.
+
+---
+
+## 3) Pattern analysis (what to keep vs. what to fix)
+
+## Strong patterns worth reusing
+- **Tile-style quick action cards with compact hierarchy** from `components/dashboard/QuickActions.tsx`:
+  - clear title/description split,
+  - hover/focus affordance,
+  - responsive grid from 1 → 2 → 3 columns.
+- **Touch-friendly floating affordance** from `components/navigation/QuickAccessWidget.tsx`:
+  - mobile-first fixed bottom positioning,
+  - larger tap targets,
+  - explicit open/close states and `aria-controls`.
+- **Action density with wrapped buttons** from `components/dashboard/sections/QuickActionsSection.tsx`:
+  - supports many actions without overflow,
+  - easy to compose with existing Button variants.
+- **Simple, prominent support CTA language** from onboarding/checkout flows:
+  - short “Need help?” heading,
+  - direct action labels (“Contact support”, “Open AI assistant”).
+
+## Inconsistencies to eliminate
+- **Naming drift**: “Quick Actions”, “Quick actions”, “Quick Access”, “Quick Access widget”.
+- **CTA style drift**: support appears as ghost button, text link, alert text, modal paragraph, or floating launcher.
+- **Token drift**: mixed Tailwind palette usage (`slate-*`, `gray-*`, custom tokens) and mixed border radius scales.
+- **Spacing drift**: vertical rhythm varies (`p-3`, `p-4`, `p-5`, `p-6`) with no component-level contract.
+- **A11y gaps**:
+  - not all support CTAs carry explicit `aria-label` when context could be ambiguous,
+  - keyboard focus style consistency is uneven,
+  - some CTA links are low-emphasis in dense footer text.
+
+---
+
+## 4) Unification recommendation
+
+Create **one shared component**:
+
+## `ActionSupportPanel` (single source of truth)
+A composable, responsive panel that includes:
+1. **Quick Actions zone** (icon + label + optional description for each action).
+2. **Need Help zone** (single prominent support CTA + optional secondary CTA).
+
+This component should replace most direct implementations above, with context-specific wrappers only when needed.
+
+---
+
+## 5) Deprecation / merge plan
+
+## Migrate into `ActionSupportPanel` (directly)
+- `components/activity/QuickActions.tsx`
+- `components/dashboard/QuickActions.tsx`
+- `components/dashboard/sections/QuickActionsSection.tsx`
+- `pages/learning/skills/[skill].tsx` quick-actions block
+- `pages/profile/account/index.tsx` quick-actions subsection
+- `pages/account/index.tsx` quick-actions subsection
+- Need-help blocks in:
+  - `components/writing/RightRailCoach.tsx`
+  - `pages/onboarding/welcome/index.tsx`
+  - `pages/checkout/index.tsx`
+  - `pages/checkout/crypto.tsx`
+  - `pages/teacher/pending.tsx`
+  - `pages/teacher/Welcome.tsx`
+  - `components/premium/UpgradeModal.tsx`
+
+## Keep as specialized wrappers, but back them with shared primitives
+- `components/navigation/QuickAccessWidget.tsx` (floating behavior is unique).
+- `components/auth/AuthAssistant.tsx` (chat launcher/assistant UX is unique).
+- Email templates (`emails/*`) should reuse copy conventions, not web UI component code.
+
+## Do not migrate (out of scope)
+- Comment-only markers and non-UI text occurrences.
+
+---
+
+## 6) Best-in-class component blueprint (pseudo-code)
+
+```txt
+Component: ActionSupportPanel
+
+Props:
+- title?: string = "Quick actions"
+- subtitle?: string
+- actions: Array<{
+    id: string
+    label: string
+    href?: string
+    onClick?: () => void
+    icon?: ReactNode
+    description?: string
+    badge?: string
+    disabled?: boolean
+    analyticsId?: string
+  }>
+- support: {
+    label?: string = "Need help?"
+    description?: string
+    primaryCta: {
+      label: string
+      href?: string
+      onClick?: () => void
+      icon?: ReactNode
+    }
+    secondaryCta?: {
+      label: string
+      href?: string
+      onClick?: () => void
+    }
+  }
+- layout?: "stack" | "split" | "floating"
+- density?: "comfortable" | "compact"
+- maxActionsVisible?: number
+- className?: string
+- actionClassName?: string
+- supportClassName?: string
+
+Rendering rules:
+1) Outer container
+   - semantic <section aria-labelledby>
+   - tokenized surface: rounded, border, background, shadow
+   - spacing scale via density tokens
+
+2) Header
+   - title + optional subtitle
+   - optional trailing slot (e.g., "View all")
+
+3) Actions grid
+   - mobile: 1 column, min tap target 44px height
+   - >=sm: 2 columns
+   - >=lg: 3 columns (or configured)
+   - each item: icon | text stack | trailing affordance
+   - focus ring always visible on keyboard focus
+   - disabled items use aria-disabled + muted tokens
+
+4) Support block
+   - visually separated (top border or tinted inset panel)
+   - heading "Need help?" + short helper copy
+   - primary CTA button full-width on mobile, auto-width on >=sm
+   - optional secondary CTA as text/ghost button
+
+5) Accessibility
+   - action buttons/links get explicit labels if text is ambiguous
+   - support CTA uses `aria-label="Contact support"` (or context label)
+   - color contrast AA minimum
+   - keyboard order: header -> actions -> support CTA(s)
+
+6) Responsive behavior
+   - stack layout default mobile-first
+   - split layout on large screens (actions left, support right)
+   - floating variant allowed only in wrapper with motion/reduced-motion guard
+
+7) Theming/design tokens
+   - rely on design-system tokens (`bg-card`, `border-border`, `text-muted-foreground`, radius tokens)
+   - avoid raw palette one-offs unless tokenized alias exists
+
+8) Telemetry hooks
+   - emit action click events with `analyticsId`
+   - emit support CTA click event with context (page + variant)
+```
+
+---
+
+## 7) Suggested rollout sequence
+1. Build `ActionSupportPanel` in `components/shared` with Storybook/visual states (if available).
+2. Migrate dashboard/activity/account implementations first (highest duplication).
+3. Migrate onboarding/checkout/teacher help CTAs to shared support block variant.
+4. Keep auth assistant + floating widget as wrappers around shared action item/support CTA primitives.
+5. Standardize copy casing to:
+   - Heading: **Quick actions**
+   - Support heading: **Need help?**
+6. Add regression checks:
+   - keyboard tab/focus order,
+   - mobile viewport tap targets,
+   - dark mode contrast.
+
+---
+
+## 8) Definition of done for refactor
+- One canonical component used by all web app “Quick actions + Need help” blocks except explicitly specialized wrappers.
+- Legacy duplicated sections removed.
+- Copy and casing consistent across migrated screens.
+- All migrated instances meet accessibility and responsive acceptance criteria.

--- a/pages/onboarding/welcome/index.tsx
+++ b/pages/onboarding/welcome/index.tsx
@@ -13,6 +13,7 @@ import { useLocale } from '@/lib/locale';
 import { useStreak } from '@/hooks/useStreak'; // Added for streak data
 import DailyWeeklyChallenges from '@/components/dashboard/DailyWeeklyChallenges';
 import { Icon } from '@/components/design-system/Icon';
+import ActionSupportPanel from '@/components/shared/ActionSupportPanel';
 
 type WordOfDay = { word: string; meaning?: string; example?: string };
 
@@ -499,22 +500,15 @@ export default function WelcomePage() {
           </div>
         </div>
 
-        {/* HELP CTA */}
-        <div className="mt-10 flex items-center justify-between rounded-ds-2xl border border-border bg-card p-6">
-          <div>
-            <h4 className="font-semibold mb-1">Need help?</h4>
-            <p className="text-small text-mutedText">
-              Ask the community or talk to our AI assistant.
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <Button asChild variant="secondary" className="rounded-ds-xl">
-              <Link href="/community">Visit Community</Link>
-            </Button>
-            <Button asChild variant="ghost" className="rounded-ds-xl">
-              <Link href="/ai">Open AI Assistant</Link>
-            </Button>
-          </div>
+        <div className="mt-10">
+          <ActionSupportPanel
+            title=""
+            actions={[]}
+            supportTitle="Need help?"
+            supportDescription="Ask the community or talk to our AI assistant."
+            supportPrimaryCta={{ label: 'Visit Community', href: '/community', variant: 'secondary' }}
+            supportSecondaryCta={{ label: 'Open AI Assistant', href: '/ai', variant: 'ghost' }}
+          />
         </div>
       </Container>
     </section>


### PR DESCRIPTION
### Motivation
- Create a single reusable panel for compact action tiles plus an integrated support/"Need help?" area to standardize UI and copy across the app.
- Replace duplicated QuickActions markup with a composable component to reduce layout and style drift.
- Document inventory and migration plan for existing "Quick actions" and "Need help?" occurrences.

### Description
- Add `components/shared/ActionSupportPanel.tsx`, a reusable `ActionSupportPanel` component that renders an actions grid and a support block with primary/secondary CTAs and supports buttons or links.
- Refactor `components/activity/QuickActions.tsx` to use `ActionSupportPanel` and wire existing actions into the new panel, replacing bespoke card/button markup and color logic.
- Update `pages/onboarding/welcome/index.tsx` to replace the previous help CTA block with `ActionSupportPanel` usage.
- Add `docs/quick-actions-need-help-audit.md` containing a repository-wide audit, refactor recommendations, and a rollout plan for unifying quick actions and support CTAs.
- Adjust imports and icon usage (`lucide-react`) in affected files to match the new component surface.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` and there were no type errors.
- Ran the project's lint/type validation (`yarn lint`) with no new lint failures.
- Ran the existing unit test suite with `yarn test` and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0af2b8c083288d815466eb80fd88)