### PR TITLE
Add centralized subscription service, APIs, and hooks

### DIFF
--- a/components/sections/Pricing.tsx
+++ b/components/sections/Pricing.tsx
@@ -5,8 +5,9 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import Icon from '@/components/design-system/Icon';
 import { Badge } from '@/components/design-system/Badge';
+import { getStandardPlanName } from '@/lib/subscription';
 
-type PlanId = 'free' | 'rocket' | 'institution';
+type PlanId = 'free' | 'booster' | 'institution';
 
 type Plan = {
   id: PlanId;
@@ -24,12 +25,12 @@ type Plan = {
 const plans: Plan[] = [
   {
     id: 'free',
-    name: 'Free',
+    name: getStandardPlanName('free'),
     tagline: 'Start IELTS prep without friction.',
     priceLine: '$0 — no card required',
     note: 'Best for testing the platform and light weekly use.',
     href: '/signup',
-    ctaLabel: 'Start on Free',
+    ctaLabel: `Start on ${getStandardPlanName('free')}`,
     features: [
       'Access to all four modules in limited mode',
       'A few AI writing / speaking checks each month',
@@ -39,17 +40,17 @@ const plans: Plan[] = [
     ]
   },
   {
-    id: 'rocket',
-    name: 'Rocket',
+    id: 'booster',
+    name: getStandardPlanName('booster'),
     tagline: 'Serious prep for 6.0 → 7.0+ journeys.',
     highlight: true,
     badge: 'Most popular (planned)',
     priceLine: 'Intro pricing will launch with the next cohort',
     note: 'For learners who want consistent AI feedback and deeper analytics.',
     href: '#waitlist',
-    ctaLabel: 'Join Rocket waitlist',
+    ctaLabel: `Join ${getStandardPlanName('booster')} waitlist`,
     features: [
-      'Everything in Free, plus higher AI usage limits',
+      `Everything in ${getStandardPlanName('free')}, plus higher AI usage limits`,
       'Deeper band-style feedback for Writing & Speaking',
       'More full mock attempts per month',
       'Access to AI Lab and “Before / After” comparisons',
@@ -95,10 +96,10 @@ const Pricing: React.FC = () => {
           Pricing & plans
         </p>
         <h2 className="mt-2 font-slab text-2xl md:text-3xl text-foreground">
-          Start free. Upgrade to Rocket when you&apos;re serious.
+          Start free. Upgrade to Booster when you&apos;re serious.
         </h2>
         <p className="mt-3 text-xs md:text-sm text-muted-foreground">
-          Free gives you enough to get a feel for the platform. Rocket is where we unlock
+          Free gives you enough to get a feel for the platform. Booster is where we unlock
           higher AI limits, more mocks, and deeper analytics. Institutional plans are for
           teachers and academies who need cohort-level visibility.
         </p>
@@ -151,7 +152,7 @@ const Pricing: React.FC = () => {
               <Button
                 as="a"
                 href={plan.href}
-                variant={plan.id === 'rocket' ? 'primary' : 'secondary'}
+                variant={plan.id === 'booster' ? 'primary' : 'secondary'}
                 size="sm"
                 className="w-full rounded-ds-xl"
               >
@@ -167,7 +168,7 @@ const Pricing: React.FC = () => {
         <div className="inline-flex items-center gap-2">
           <Icon name="Info" size={14} />
           <span>
-            We&apos;re finalizing exact Rocket pricing with early cohorts. Joining the
+            We&apos;re finalizing exact Booster pricing with early cohorts. Joining the
             waitlist means we&apos;ll email you before anything gets charged.
           </span>
         </div>

--- a/components/sections/Pricing.tsx
+++ b/components/sections/Pricing.tsx
@@ -5,7 +5,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import Icon from '@/components/design-system/Icon';
 import { Badge } from '@/components/design-system/Badge';
-import { getStandardPlanName } from '@/lib/subscription';
+import { getPlanPricing, getStandardPlanName } from '@/lib/subscription';
 
 type PlanId = 'free' | 'booster' | 'institution';
 
@@ -22,12 +22,12 @@ type Plan = {
   features: string[];
 };
 
-const plans: Plan[] = [
+export const PRICING_SECTION_PLANS: Plan[] = [
   {
     id: 'free',
     name: getStandardPlanName('free'),
     tagline: 'Start IELTS prep without friction.',
-    priceLine: '$0 — no card required',
+    priceLine: `$${getPlanPricing('free').monthly} — no card required`,
     note: 'Best for testing the platform and light weekly use.',
     href: '/signup',
     ctaLabel: `Start on ${getStandardPlanName('free')}`,
@@ -45,8 +45,8 @@ const plans: Plan[] = [
     tagline: 'Serious prep for 6.0 → 7.0+ journeys.',
     highlight: true,
     badge: 'Most popular (planned)',
-    priceLine: 'Intro pricing will launch with the next cohort',
-    note: 'For learners who want consistent AI feedback and deeper analytics.',
+    priceLine: `$${getPlanPricing('booster').monthly}/month (or $${getPlanPricing('booster').monthlyDisplayFromAnnual}/mo annual)`,
+    note: `Billed $${getPlanPricing('booster').annual}/year on annual plan.`,
     href: '#waitlist',
     ctaLabel: `Join ${getStandardPlanName('booster')} waitlist`,
     features: [
@@ -107,7 +107,7 @@ const Pricing: React.FC = () => {
 
       {/* Plans grid */}
       <div className="grid gap-6 md:grid-cols-3 mb-10">
-        {plans.map((plan) => (
+        {PRICING_SECTION_PLANS.map((plan) => (
           <Card
             key={plan.id}
             interactive

--- a/hooks/useFeatureAccess.ts
+++ b/hooks/useFeatureAccess.ts
@@ -1,0 +1,22 @@
+import useSWR from 'swr';
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(`Failed: ${res.status}`);
+  return (await res.json()) as { ok: boolean; access: boolean };
+};
+
+export function useFeatureAccess(feature: string) {
+  const key = feature ? `/api/subscription/feature-access?feature=${encodeURIComponent(feature)}` : null;
+  const state = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  });
+
+  return {
+    access: state.data?.access ?? false,
+    loading: (!!key && !state.data && !state.error) || state.isLoading,
+    error: state.error,
+    refresh: state.mutate,
+  };
+}

--- a/hooks/useIsActive.ts
+++ b/hooks/useIsActive.ts
@@ -1,0 +1,6 @@
+import { useSubscription } from '@/hooks/useSubscription';
+
+export function useIsActive() {
+  const { active, loading, error, refresh } = useSubscription();
+  return { isActive: active, loading, error, refresh };
+}

--- a/hooks/usePlan.ts
+++ b/hooks/usePlan.ts
@@ -18,7 +18,7 @@ async function fetchPlan(url: string): Promise<PlanResponse> {
 
 export function usePlan(initialPlan?: PlanId) {
   const { data, error, isLoading, mutate, isValidating } = useSWR<PlanResponse>(
-    '/api/me/plan',
+    '/api/subscription/plan',
     fetchPlan,
     {
       revalidateOnFocus: false,

--- a/hooks/useSubscription.ts
+++ b/hooks/useSubscription.ts
@@ -1,0 +1,30 @@
+import useSWR from 'swr';
+
+import type { ActiveSubscription } from '@/lib/subscription';
+
+type SubscriptionResponse = {
+  ok: boolean;
+  active: boolean;
+  subscription: ActiveSubscription | null;
+};
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(`Failed: ${res.status}`);
+  return (await res.json()) as SubscriptionResponse;
+};
+
+export function useSubscription() {
+  const state = useSWR('/api/subscription/active', fetcher, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  });
+
+  return {
+    subscription: state.data?.subscription ?? null,
+    active: state.data?.active ?? false,
+    loading: (!state.data && !state.error) || state.isLoading,
+    error: state.error,
+    refresh: state.mutate,
+  };
+}

--- a/lib/api/withPlan.ts
+++ b/lib/api/withPlan.ts
@@ -6,9 +6,16 @@ import type { User } from '@supabase/supabase-js';
 
 import { getServerClient } from '@/lib/supabaseServer';
 import { hasPlan } from '@/lib/planAccess';
-import { normalizePlan } from '@/lib/subscription';
+import {
+  getUserPlan,
+  getActiveSubscription,
+  requireActiveSubscription,
+  InactiveSubscriptionError,
+  inactiveSubscriptionResponse,
+  type SubscriptionStatus,
+} from '@/lib/subscription';
 import type { PlanId } from '@/types/pricing';
-import { flags, resolveFlags, serverEnabled, type FlagAudience, type FeatureFlagKey } from '@/lib/flags';
+import { resolveFlags, serverEnabled, type FlagAudience, type FeatureFlagKey } from '@/lib/flags';
 
 export type PlanGuardAudience = FlagAudience & {
   plan: PlanId;
@@ -20,6 +27,7 @@ export type PlanGuardContext = {
   user: User;
   plan: PlanId;
   role: string | null;
+  subscriptionStatus: SubscriptionStatus;
   supabase: ReturnType<typeof getServerClient>;
   audience: PlanGuardAudience;
   flags: Record<string, boolean>;
@@ -43,20 +51,23 @@ function buildAudience(user: User, plan: PlanId, role: string | null): PlanGuard
 async function loadProfilePlan(
   supabase: ReturnType<typeof getServerClient>,
   userId: string,
-): Promise<{ plan: PlanId; role: string | null }> {
-  const { data, error } = await supabase
-    .from('profiles')
-    .select('plan, role')
-    .eq('id', userId)
-    .maybeSingle();
+): Promise<{ plan: PlanId; role: string | null; status: SubscriptionStatus }> {
+  const [{ data, error }, sub] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', userId)
+      .maybeSingle(),
+    getActiveSubscription(userId),
+  ]);
 
+  const plan = await getUserPlan(userId);
   if (error || !data) {
-    return { plan: 'free', role: null };
+    return { plan, role: null, status: sub.status };
   }
 
-  const plan = normalizePlan((data as { plan?: string | null }).plan ?? null);
   const role = ((data as { role?: string | null }).role ?? null) as string | null;
-  return { plan, role };
+  return { plan, role, status: sub.status };
 }
 
 async function checkKillSwitch(
@@ -102,11 +113,11 @@ export function withPlan(
         return null;
       }
 
-      const { plan, role } = await loadProfilePlan(supabase, user.id);
+      const { plan, role, status } = await loadProfilePlan(supabase, user.id);
       const audience = buildAudience(user, plan, role);
       const flagsSnapshot = await resolveFlags(audience);
 
-      return { supabase, user, plan, role, audience, flags: flagsSnapshot };
+      return { supabase, user, plan, role, subscriptionStatus: status, audience, flags: flagsSnapshot };
     };
 
     const allowRoles = new Set<AllowedRole>([...(options.allowRoles ?? []), 'admin']);
@@ -135,14 +146,22 @@ export function withPlan(
       return;
     }
 
+    try {
+      await requireActiveSubscription(context.user.id);
+    } catch (error) {
+      if (error instanceof InactiveSubscriptionError) {
+        res.setHeader('X-Required-Plan', required);
+        const inactive = inactiveSubscriptionResponse({ plan: context.plan, status: context.subscriptionStatus }, required);
+        deny(res, inactive.statusCode, inactive.payload);
+        return;
+      }
+      throw error;
+    }
+
     if (!hasPlan(context.plan, required)) {
       res.setHeader('X-Required-Plan', required);
-      deny(res, 402, {
-        error: 'Upgrade required',
-        requiredPlan: required,
-        currentPlan: context.plan,
-        upgradeUrl: `/pricing?required=${required}`,
-      });
+      const inactive = inactiveSubscriptionResponse({ plan: context.plan, status: context.subscriptionStatus }, required);
+      deny(res, inactive.statusCode, inactive.payload);
       return;
     }
 

--- a/lib/api/withPlan.ts
+++ b/lib/api/withPlan.ts
@@ -6,6 +6,7 @@ import type { User } from '@supabase/supabase-js';
 
 import { getServerClient } from '@/lib/supabaseServer';
 import { hasPlan } from '@/lib/planAccess';
+import { normalizePlan } from '@/lib/subscription';
 import type { PlanId } from '@/types/pricing';
 import { flags, resolveFlags, serverEnabled, type FlagAudience, type FeatureFlagKey } from '@/lib/flags';
 
@@ -31,13 +32,6 @@ export type PlanGuardOptions = {
   killSwitchFlag?: FeatureFlagKey;
 };
 
-function normalisePlan(raw?: string | null): PlanId {
-  if (!raw) return 'free';
-  const value = raw.toLowerCase();
-  if (value === 'starter' || value === 'booster' || value === 'master') return value;
-  return 'free';
-}
-
 function buildAudience(user: User, plan: PlanId, role: string | null): PlanGuardAudience {
   return {
     plan,
@@ -60,7 +54,7 @@ async function loadProfilePlan(
     return { plan: 'free', role: null };
   }
 
-  const plan = normalisePlan((data as { plan?: string | null }).plan ?? null);
+  const plan = normalizePlan((data as { plan?: string | null }).plan ?? null);
   const role = ((data as { role?: string | null }).role ?? null) as string | null;
   return { plan, role };
 }

--- a/lib/apiGuard.ts
+++ b/lib/apiGuard.ts
@@ -2,7 +2,7 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 
 import { getServerClient } from '@/lib/supabaseServer';
-import { normalizePlan } from '@/lib/subscription';
+import { getUserPlan, getActiveSubscription, requireActiveSubscription, inactiveSubscriptionResponse, InactiveSubscriptionError } from '@/lib/subscription';
 import { PLAN_RANK, type PlanId } from '@/types/pricing';
 
 type Role = 'user' | 'admin' | 'teacher' | 'org' | null;
@@ -41,10 +41,10 @@ export function withPlan(
     }
 
     // Read profile (RLS should allow user to read own profile)
-    type ProfileRow = { id: string; plan: PlanId | null; role: Role };
+    type ProfileRow = { id: string; role: Role };
     const { data: profile, error: profileErr } = await supabase
       .from('profiles')
-      .select('id, plan, role')
+      .select('id, role')
       .eq('id', user.id)
       .single<ProfileRow>();
 
@@ -66,18 +66,25 @@ export function withPlan(
     }
 
     // Compare plans
-    const currentPlan: PlanId = normalizePlan(profile.plan);
-    if (PLAN_RANK[currentPlan] >= PLAN_RANK[required]) {
-      return handler(req, res);
+    const currentSubscription = await getActiveSubscription(user.id);
+    try {
+      const active = await requireActiveSubscription(user.id);
+      if (PLAN_RANK[active.plan] >= PLAN_RANK[required]) {
+        return handler(req, res);
+      }
+    } catch (error) {
+      if (error instanceof InactiveSubscriptionError) {
+        res.setHeader('X-Required-Plan', required);
+        const inactive = inactiveSubscriptionResponse(currentSubscription, required);
+        return res.status(inactive.statusCode).json(inactive.payload);
+      }
+      throw error;
     }
 
     res.setHeader('X-Required-Plan', required);
-    res.status(402).json({
-      error: 'Upgrade required',
-      requiredPlan: required,
-      currentPlan,
-      upgradeUrl: `/pricing?required=${required}`,
-    });
+    const currentPlan: PlanId = await getUserPlan(user.id);
+    const inactive = inactiveSubscriptionResponse({ plan: currentPlan, status: currentSubscription.status }, required);
+    res.status(inactive.statusCode).json(inactive.payload);
   };
 }
 

--- a/lib/apiGuard.ts
+++ b/lib/apiGuard.ts
@@ -2,16 +2,10 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 
 import { getServerClient } from '@/lib/supabaseServer';
+import { normalizePlan } from '@/lib/subscription';
+import { PLAN_RANK, type PlanId } from '@/types/pricing';
 
-type PlanId = 'free' | 'starter' | 'booster' | 'master';
 type Role = 'user' | 'admin' | 'teacher' | 'org' | null;
-
-const PLAN_ORDER: Record<PlanId, number> = {
-  free: 0,
-  starter: 1,
-  booster: 2,
-  master: 3,
-};
 
 type GuardOptions = {
   /** Additional roles that should bypass the plan check */
@@ -73,7 +67,7 @@ export function withPlan(
 
     // Compare plans
     const currentPlan: PlanId = normalizePlan(profile.plan);
-    if (PLAN_ORDER[currentPlan] >= PLAN_ORDER[required]) {
+    if (PLAN_RANK[currentPlan] >= PLAN_RANK[required]) {
       return handler(req, res);
     }
 
@@ -87,7 +81,3 @@ export function withPlan(
   };
 }
 
-function normalizePlan(plan: PlanId | string | null | undefined): PlanId {
-  const p = (plan ?? 'free').toLowerCase();
-  return p === 'starter' || p === 'booster' || p === 'master' ? p : 'free';
-}

--- a/lib/billing/manual.ts
+++ b/lib/billing/manual.ts
@@ -1,10 +1,9 @@
-import { PLANS, getPlanBillingAmount, type PlanKey, type Cycle } from '@/lib/pricing';
-import { applyPinOrManualProvisioning } from '@/lib/subscription';
+import { PLANS, type PlanKey, type Cycle } from '@/lib/pricing';
+import { applyPinOrManualProvisioning, getPlanPricing } from '@/lib/subscription';
 
 export function priceCents(plan: PlanKey, cycle: Cycle): number {
-  const major = getPlanBillingAmount(plan, cycle);
-  // Stripe will also use 2dp for USD; if you ever support JPY, handle 0dp separately.
-  return Math.round(major * 100);
+  const pricing = getPlanPricing(plan);
+  return cycle === 'monthly' ? pricing.monthlyCents : pricing.annualCents;
 }
 
 export async function createPendingPayment(opts: {

--- a/lib/billing/manual.ts
+++ b/lib/billing/manual.ts
@@ -1,5 +1,5 @@
-import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { PLANS, getPlanBillingAmount, type PlanKey, type Cycle } from '@/lib/pricing';
+import { applyPinOrManualProvisioning } from '@/lib/subscription';
 
 export function priceCents(plan: PlanKey, cycle: Cycle): number {
   const major = getPlanBillingAmount(plan, cycle);
@@ -19,29 +19,16 @@ export async function createPendingPayment(opts: {
   const amount_cents = priceCents(opts.plan, opts.cycle);
   const currency = (PLANS[opts.plan].currency || 'USD').toUpperCase();
 
-  // 1) Add a pending due
-  const { error: insErr } = await supabaseAdmin
-    .from('pending_payments')
-    .insert({
-      user_id: opts.userId,
-      plan_key: opts.plan,
-      cycle: opts.cycle,
-      currency,
-      amount_cents,
-      status: 'due',
-      note: opts.note ?? null,
-      contact_name: opts.name ?? null,
-      contact_phone: opts.phone ?? null,
-      email: opts.email ?? null,
-    });
-  if (insErr) throw insErr;
-
-  // 2) Provision plan immediately
-  const { error: updErr } = await supabaseAdmin
-    .from('profiles')
-    .update({ plan_id: opts.plan })
-    .eq('id', opts.userId);
-  if (updErr) throw updErr;
+  await applyPinOrManualProvisioning({
+    userId: opts.userId,
+    plan: opts.plan,
+    provider: 'manual',
+    eventId: `pending-payment:${opts.userId}:${opts.plan}:${opts.cycle}:${amount_cents}`,
+    cycle: opts.cycle,
+    amountCents: amount_cents,
+    email: opts.email ?? null,
+    note: opts.note,
+  });
 
   return { amount_cents, currency };
 }

--- a/lib/payments/gateway.ts
+++ b/lib/payments/gateway.ts
@@ -1,6 +1,7 @@
 // lib/payments/gateway.ts
 import { env } from '@/lib/env';
-import { getPlanBillingAmount, type Cycle, type PlanKey } from '@/lib/pricing';
+import { getPlanPricing } from '@/lib/subscription';
+import { type Cycle, type PlanKey } from '@/lib/pricing';
 import { initiateEasypaisa } from '@/lib/payments/easypaisa';
 import { initiateJazzCash } from '@/lib/payments/jazzcash';
 import { initiateSafepay } from '@/lib/payments/safepay';
@@ -29,8 +30,8 @@ export type CreateGatewayIntentInput = Readonly<{
 }>;
 
 export function amountInCents(plan: PlanKey, cycle: Cycle): number {
-  const major = getPlanBillingAmount(plan, cycle);
-  return Math.round(major * 100);
+  const pricing = getPlanPricing(plan);
+  return cycle === 'monthly' ? pricing.monthlyCents : pricing.annualCents;
 }
 
 const stripePriceMap: Record<PlanKey, Record<Cycle, string | undefined>> = {

--- a/lib/payments/localWebhook.ts
+++ b/lib/payments/localWebhook.ts
@@ -1,4 +1,5 @@
 import { supabaseService } from '@/lib/supabaseService';
+import { applySubscriptionActivation } from '@/lib/subscription';
 import { trackor } from '@/lib/analytics/trackor.server';
 import { queueNotificationEvent, getNotificationContact } from '@/lib/notify';
 import { getBaseUrl } from '@/lib/url';
@@ -55,7 +56,13 @@ export async function finalizeLocalPayment(
   });
 
   if (intent.user_id) {
-    await supabaseService.from('profiles').update({ plan_id: intent.plan_id }).eq('id', intent.user_id);
+    await applySubscriptionActivation({
+      userId: intent.user_id,
+      plan: intent.plan_id as any,
+      provider,
+      eventId: `local:${provider}:${sessionId}`,
+      subscriptionId: sessionId,
+    });
   }
 
   await trackor.log('payments.intent.success', {

--- a/lib/plan/featureMap.ts
+++ b/lib/plan/featureMap.ts
@@ -7,12 +7,3 @@ export const FEATURE_PLAN: Record<string, PlanId> = {
   'ai.listening.accent': 'starter',
   'mock.listening': 'booster',
 };
-// lib/plan/featureMap.ts
-import type { PlanId } from '@/types/pricing';
-
-export const FEATURE_PLAN: Record<string, PlanId> = {
-  // existing feature keys...
-  'ai.listening.dictation': 'starter',
-  'ai.listening.accent': 'starter',
-  'mock.listening': 'booster',
-};

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -1,5 +1,5 @@
 import { FEATURE_PLAN } from '@/lib/plan/featureMap';
-import { PLAN_LABEL, USD_PLAN_PRICES, type Cycle } from '@/lib/pricing';
+import { PLAN_LABEL, USD_PLAN_PRICES, type Cycle, type PlanKey } from '@/lib/pricing';
 import { supabaseService } from '@/lib/supabaseServer';
 import { coercePlanId, PLAN_RANK, type PlanId } from '@/types/pricing';
 
@@ -46,6 +46,8 @@ export type CanonicalSubscription = ActiveSubscription & {
   source: 'subscriptions' | 'legacy_profile' | 'none';
 };
 
+type TransitionStatusInput = SubscriptionStatus | 'unpaid';
+
 const ACTIVE_STATUSES = new Set<SubscriptionStatus>(['active', 'trialing']);
 const STATUS_VALUES = new Set<SubscriptionStatus>(['active', 'trialing', 'canceled', 'incomplete', 'past_due']);
 
@@ -56,6 +58,11 @@ export function normalizePlan(plan?: string | null): PlanId {
 export function normalizeSubscriptionStatus(status?: string | null): SubscriptionStatus {
   const value = (status ?? 'canceled').toLowerCase();
   return STATUS_VALUES.has(value as SubscriptionStatus) ? (value as SubscriptionStatus) : 'canceled';
+}
+
+function normalizeTransitionStatus(status: TransitionStatusInput): SubscriptionStatus {
+  if (status === 'unpaid') return 'past_due';
+  return normalizeSubscriptionStatus(status);
 }
 
 export function getStandardPlanName(planId: string): PlanId {
@@ -134,6 +141,81 @@ function mapSubscriptionRowToCanonical(
     customerId,
     source: 'subscriptions',
   };
+}
+
+async function wasTransitionApplied(provider: string, eventId: string, action: string): Promise<boolean> {
+  const supabase = supabaseService();
+  const { data } = await supabase
+    .from('payment_events')
+    .select('id')
+    .eq('provider', provider)
+    .eq('external_id', eventId)
+    .eq('status', `subscription:${action}`)
+    .maybeSingle();
+
+  return !!data;
+}
+
+async function markTransitionApplied(provider: string, eventId: string, action: string, userId?: string | null, metadata: Record<string, unknown> = {}) {
+  const supabase = supabaseService();
+  await supabase.from('payment_events').insert([
+    {
+      provider,
+      status: `subscription:${action}`,
+      external_id: eventId,
+      user_id: userId ?? null,
+      metadata,
+    },
+  ]);
+}
+
+async function mirrorProfileSubscriptionState(input: {
+  userId: string;
+  plan: PlanId;
+  status: SubscriptionStatus;
+  renewsAt?: string | null;
+  trialEndsAt?: string | null;
+  premiumUntil?: string | null;
+  customerId?: string | null;
+}) {
+  const supabase = supabaseService();
+  await supabase
+    .from('profiles')
+    .update({
+      plan_id: input.plan,
+      membership: input.plan,
+      subscription_status: input.status,
+      subscription_renews_at: input.renewsAt ?? null,
+      trial_ends_at: input.trialEndsAt ?? null,
+      premium_until: input.premiumUntil ?? null,
+      stripe_customer_id: input.customerId ?? undefined,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', input.userId);
+}
+
+async function upsertCanonicalSubscriptionRow(input: {
+  userId: string;
+  subscriptionId?: string | null;
+  plan: PlanId;
+  status: SubscriptionStatus;
+  renewsAt?: string | null;
+  trialEndsAt?: string | null;
+}) {
+  const supabase = supabaseService();
+  const row = {
+    id: input.subscriptionId ?? undefined,
+    user_id: input.userId,
+    plan_id: input.plan,
+    status: input.status,
+    current_period_end: input.renewsAt ?? null,
+    trial_end: input.trialEndsAt ?? null,
+    updated_at: new Date().toISOString(),
+  };
+
+  await supabase
+    .from('subscriptions')
+    .upsert(row, input.subscriptionId ? { onConflict: 'id' } : undefined);
 }
 
 export async function getLatestSubscriptionRow(userId: string): Promise<RawSubscriptionRow | null> {
@@ -232,34 +314,206 @@ export async function getFeatureAccess(userId: string, feature: string): Promise
   return PLAN_RANK[userPlan] >= PLAN_RANK[requiredPlan];
 }
 
+export async function applySubscriptionActivation(input: {
+  userId: string;
+  plan: PlanId | PlanKey;
+  provider: string;
+  eventId: string;
+  subscriptionId?: string | null;
+  renewsAt?: string | null;
+  trialEndsAt?: string | null;
+  customerId?: string | null;
+}) {
+  if (await wasTransitionApplied(input.provider, input.eventId, 'activation')) return { duplicate: true as const };
+
+  const plan = normalizePlan(input.plan);
+  await upsertCanonicalSubscriptionRow({
+    userId: input.userId,
+    subscriptionId: input.subscriptionId,
+    plan,
+    status: 'active',
+    renewsAt: input.renewsAt,
+    trialEndsAt: input.trialEndsAt,
+  });
+
+  await mirrorProfileSubscriptionState({
+    userId: input.userId,
+    plan,
+    status: 'active',
+    renewsAt: input.renewsAt,
+    trialEndsAt: input.trialEndsAt,
+    premiumUntil: null,
+    customerId: input.customerId,
+  });
+
+  await markTransitionApplied(input.provider, input.eventId, 'activation', input.userId, {
+    subscriptionId: input.subscriptionId,
+    plan,
+  });
+
+  return { duplicate: false as const };
+}
+
+export async function applySubscriptionRenewal(input: {
+  userId: string;
+  provider: string;
+  eventId: string;
+  subscriptionId?: string | null;
+  renewsAt?: string | null;
+}) {
+  if (await wasTransitionApplied(input.provider, input.eventId, 'renewal')) return { duplicate: true as const };
+
+  const current = await getCanonicalSubscription(input.userId);
+  await upsertCanonicalSubscriptionRow({
+    userId: input.userId,
+    subscriptionId: input.subscriptionId ?? current.subscriptionId,
+    plan: current.plan,
+    status: 'active',
+    renewsAt: input.renewsAt ?? current.renewsAt ?? null,
+    trialEndsAt: current.trialEndsAt ?? null,
+  });
+
+  await mirrorProfileSubscriptionState({
+    userId: input.userId,
+    plan: current.plan,
+    status: 'active',
+    renewsAt: input.renewsAt ?? current.renewsAt ?? null,
+    trialEndsAt: current.trialEndsAt ?? null,
+    premiumUntil: null,
+    customerId: current.customerId,
+  });
+
+  await markTransitionApplied(input.provider, input.eventId, 'renewal', input.userId, {
+    subscriptionId: input.subscriptionId,
+  });
+
+  return { duplicate: false as const };
+}
+
+export async function applySubscriptionTransition(input: {
+  userId: string;
+  provider: string;
+  eventId: string;
+  status: TransitionStatusInput;
+  subscriptionId?: string | null;
+  renewsAt?: string | null;
+  trialEndsAt?: string | null;
+}) {
+  if (await wasTransitionApplied(input.provider, input.eventId, 'transition')) return { duplicate: true as const };
+
+  const current = await getCanonicalSubscription(input.userId);
+  const status = normalizeTransitionStatus(input.status);
+  const shouldDowngrade = status === 'canceled' || status === 'past_due';
+  const nextPlan: PlanId = shouldDowngrade ? 'free' : current.plan;
+
+  await upsertCanonicalSubscriptionRow({
+    userId: input.userId,
+    subscriptionId: input.subscriptionId ?? current.subscriptionId,
+    plan: nextPlan,
+    status,
+    renewsAt: input.renewsAt ?? current.renewsAt ?? null,
+    trialEndsAt: input.trialEndsAt ?? current.trialEndsAt ?? null,
+  });
+
+  await mirrorProfileSubscriptionState({
+    userId: input.userId,
+    plan: nextPlan,
+    status,
+    renewsAt: input.renewsAt ?? current.renewsAt ?? null,
+    trialEndsAt: input.trialEndsAt ?? current.trialEndsAt ?? null,
+    premiumUntil: shouldDowngrade ? null : current.renewsAt ?? null,
+    customerId: current.customerId,
+  });
+
+  await markTransitionApplied(input.provider, input.eventId, 'transition', input.userId, {
+    status,
+    subscriptionId: input.subscriptionId,
+  });
+
+  return { duplicate: false as const };
+}
+
+export async function applyPinOrManualProvisioning(input: {
+  userId: string;
+  plan: PlanKey;
+  provider: string;
+  eventId: string;
+  premiumUntil?: string | null;
+  note?: string;
+  amountCents?: number;
+  cycle?: Cycle;
+  email?: string | null;
+}) {
+  if (await wasTransitionApplied(input.provider, input.eventId, 'manual_provision')) return { duplicate: true as const };
+
+  const premiumUntilIso = toIso(input.premiumUntil) ?? null;
+
+  await upsertCanonicalSubscriptionRow({
+    userId: input.userId,
+    plan: input.plan,
+    status: 'active',
+    renewsAt: premiumUntilIso,
+    trialEndsAt: null,
+  });
+
+  await mirrorProfileSubscriptionState({
+    userId: input.userId,
+    plan: input.plan,
+    status: 'active',
+    renewsAt: premiumUntilIso,
+    trialEndsAt: null,
+    premiumUntil: premiumUntilIso,
+  });
+
+  if (typeof input.amountCents === 'number' && input.cycle) {
+    const supabase = supabaseService();
+    await supabase.from('pending_payments').insert({
+      user_id: input.userId,
+      plan_key: input.plan,
+      cycle: input.cycle,
+      currency: 'USD',
+      amount_cents: input.amountCents,
+      status: 'due',
+      note: input.note ?? null,
+      email: input.email ?? null,
+    });
+  }
+
+  await markTransitionApplied(input.provider, input.eventId, 'manual_provision', input.userId, {
+    plan: input.plan,
+    premiumUntil: premiumUntilIso,
+  });
+
+  return { duplicate: false as const };
+}
+
 export async function upsertSubscriptionStateFromWebhook(input: {
   userId: string;
   subscriptionId?: string | null;
   paymentId?: string | null;
   provider: string;
 }) {
-  const supabase = supabaseService();
-  const now = new Date().toISOString();
+  const eventId = input.paymentId ?? input.subscriptionId ?? `${input.userId}:${input.provider}`;
+  if (await wasTransitionApplied(input.provider, eventId, 'activation')) return;
+
+  const current = await getCanonicalSubscription(input.userId);
+  await applySubscriptionActivation({
+    userId: input.userId,
+    plan: current.plan === 'free' ? 'booster' : current.plan,
+    provider: input.provider,
+    eventId,
+    subscriptionId: input.subscriptionId,
+    renewsAt: current.renewsAt ?? null,
+    trialEndsAt: current.trialEndsAt ?? null,
+    customerId: current.customerId,
+  });
 
   if (input.paymentId) {
+    const supabase = supabaseService();
     await supabase
       .from('payments')
-      .update({ status: 'paid', provider: input.provider, provider_payment_id: input.paymentId, updated_at: now })
+      .update({ status: 'paid', provider: input.provider, provider_payment_id: input.paymentId, updated_at: new Date().toISOString() })
       .eq('id', input.paymentId);
-  }
-
-  if (input.subscriptionId) {
-    await supabase
-      .from('subscriptions')
-      .upsert(
-        {
-          id: input.subscriptionId,
-          user_id: input.userId,
-          status: 'active',
-          updated_at: now,
-        },
-        { onConflict: 'id' },
-      );
   }
 }
 

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -5,6 +5,9 @@ import { coercePlanId, PLAN_RANK, type PlanId } from '@/types/pricing';
 
 export type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
 
+export const CANONICAL_PLAN_IDS = ['free', 'starter', 'booster', 'master'] as const;
+export type CanonicalPlanId = (typeof CANONICAL_PLAN_IDS)[number];
+
 export type ActiveSubscription = Readonly<{
   userId: string;
   plan: PlanId;
@@ -50,9 +53,23 @@ type TransitionStatusInput = SubscriptionStatus | 'unpaid';
 
 const ACTIVE_STATUSES = new Set<SubscriptionStatus>(['active', 'trialing']);
 const STATUS_VALUES = new Set<SubscriptionStatus>(['active', 'trialing', 'canceled', 'incomplete', 'past_due']);
+const STANDARD_PLAN_NAMES: Record<CanonicalPlanId, string> = {
+  free: 'Free',
+  starter: 'Starter',
+  booster: 'Booster',
+  master: 'Master',
+};
 
 export function normalizePlan(plan?: string | null): PlanId {
-  return coercePlanId(plan ?? 'free');
+  const raw = (plan ?? 'free').trim().toLowerCase();
+  const aliases: Record<string, PlanId> = {
+    premium: 'master',
+    pro: 'master',
+    rocket: 'booster',
+    seedling: 'starter',
+    owl: 'master',
+  };
+  return aliases[raw] ?? coercePlanId(raw);
 }
 
 export function normalizeSubscriptionStatus(status?: string | null): SubscriptionStatus {
@@ -65,8 +82,9 @@ function normalizeTransitionStatus(status: TransitionStatusInput): SubscriptionS
   return normalizeSubscriptionStatus(status);
 }
 
-export function getStandardPlanName(planId: string): PlanId {
-  return normalizePlan(planId);
+export function getStandardPlanName(planId: string): string {
+  const canonical = normalizePlan(planId) as CanonicalPlanId;
+  return STANDARD_PLAN_NAMES[canonical] ?? STANDARD_PLAN_NAMES.free;
 }
 
 export function getPlanTiers(): Array<{ id: PlanId; rank: number; label: string }> {

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -97,16 +97,15 @@ export function getPlanTiers(): Array<{ id: PlanId; rank: number; label: string 
 
 export function getPlanPricing(planId: string) {
   const id = normalizePlan(planId);
-  if (id === 'free') {
-    return { planId: id, monthly: 0, annual: 0, monthlyDisplayFromAnnual: 0 };
-  }
-
-  const row = USD_PLAN_PRICES[id];
+  const annual = id === 'free' ? 0 : USD_PLAN_PRICES[id].annual;
+  const monthly = id === 'free' ? 0 : USD_PLAN_PRICES[id].monthly;
   return {
     planId: id,
-    monthly: row.monthly,
-    annual: row.annual,
-    monthlyDisplayFromAnnual: row.annual / 12,
+    monthly, // major units per month
+    annual, // major units billed yearly
+    monthlyDisplayFromAnnual: annual / 12,
+    monthlyCents: Math.round(monthly * 100),
+    annualCents: Math.round(annual * 100),
   };
 }
 

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -13,6 +13,22 @@ export type ActiveSubscription = Readonly<{
   trialEndsAt?: string;
 }>;
 
+type RawSubscriptionRow = {
+  id?: string | null;
+  user_id?: string | null;
+  plan_id?: string | null;
+  status?: string | null;
+  current_period_end?: string | null;
+};
+
+export type SubscriptionSnapshot = Readonly<{
+  userId: string;
+  plan: PlanId;
+  status: SubscriptionStatus;
+  currentPeriodEnd: string | null;
+  subscriptionId: string | null;
+}>;
+
 const ACTIVE_STATUSES = new Set<SubscriptionStatus>(['active', 'trialing']);
 const STATUS_VALUES = new Set<SubscriptionStatus>(['active', 'trialing', 'canceled', 'incomplete', 'past_due']);
 
@@ -40,12 +56,7 @@ export function getPlanTiers(): Array<{ id: PlanId; rank: number; label: string 
 export function getPlanPricing(planId: string) {
   const id = normalizePlan(planId);
   if (id === 'free') {
-    return {
-      planId: id,
-      monthly: 0,
-      annual: 0,
-      monthlyDisplayFromAnnual: 0,
-    };
+    return { planId: id, monthly: 0, annual: 0, monthlyDisplayFromAnnual: 0 };
   }
 
   const row = USD_PLAN_PRICES[id];
@@ -61,6 +72,56 @@ function toIso(value?: string | null) {
   if (!value) return undefined;
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+function normalizeSubscriptionSnapshot(row: RawSubscriptionRow | null | undefined, userId: string): SubscriptionSnapshot {
+  return {
+    userId,
+    plan: normalizePlan(row?.plan_id ?? 'free'),
+    status: normalizeSubscriptionStatus(row?.status ?? 'canceled'),
+    currentPeriodEnd: row?.current_period_end ?? null,
+    subscriptionId: row?.id ?? null,
+  };
+}
+
+export async function getLatestSubscriptionRow(userId: string): Promise<RawSubscriptionRow | null> {
+  const supabase = supabaseService();
+  const { data } = await supabase
+    .from('subscriptions')
+    .select('id, user_id, plan_id, status, current_period_end')
+    .eq('user_id', userId)
+    .order('current_period_end', { ascending: false, nullsFirst: false })
+    .limit(1)
+    .maybeSingle();
+
+  return (data ?? null) as RawSubscriptionRow | null;
+}
+
+export async function getLatestSubscriptionSnapshotsForUsers(userIds: string[]): Promise<Record<string, SubscriptionSnapshot>> {
+  if (userIds.length === 0) return {};
+
+  const supabase = supabaseService();
+  const { data } = await supabase
+    .from('subscriptions')
+    .select('id, user_id, plan_id, status, current_period_end')
+    .in('user_id', userIds)
+    .order('current_period_end', { ascending: false, nullsFirst: false });
+
+  const rows = (data ?? []) as RawSubscriptionRow[];
+  const latestByUser: Record<string, RawSubscriptionRow> = {};
+
+  for (const row of rows) {
+    const rowUserId = row.user_id;
+    if (!rowUserId || latestByUser[rowUserId]) continue;
+    latestByUser[rowUserId] = row;
+  }
+
+  const snapshots: Record<string, SubscriptionSnapshot> = {};
+  for (const userId of userIds) {
+    snapshots[userId] = normalizeSubscriptionSnapshot(latestByUser[userId], userId);
+  }
+
+  return snapshots;
 }
 
 export async function getActiveSubscription(userId: string): Promise<ActiveSubscription> {
@@ -83,12 +144,12 @@ export async function getActiveSubscription(userId: string): Promise<ActiveSubsc
   const plan = normalizePlan(row?.plan_id ?? row?.membership ?? 'free');
   const normalizedStatus = normalizeSubscriptionStatus(row?.subscription_status);
   const premiumUntil = toIso(row?.premium_until);
-  const fallbackStatus: SubscriptionStatus = premiumUntil && new Date(premiumUntil) > new Date() ? 'active' : normalizedStatus;
+  const status: SubscriptionStatus = premiumUntil && new Date(premiumUntil) > new Date() ? 'active' : normalizedStatus;
 
   return {
     userId,
     plan,
-    status: fallbackStatus,
+    status,
     renewsAt: toIso(row?.subscription_renews_at) ?? premiumUntil,
     trialEndsAt: toIso(row?.trial_ends_at),
   };
@@ -116,6 +177,37 @@ export async function getFeatureAccess(userId: string, feature: string): Promise
   const requiredPlan = FEATURE_PLAN[feature] ?? 'free';
   const userPlan = await getUserPlan(userId);
   return PLAN_RANK[userPlan] >= PLAN_RANK[requiredPlan];
+}
+
+export async function upsertSubscriptionStateFromWebhook(input: {
+  userId: string;
+  subscriptionId?: string | null;
+  paymentId?: string | null;
+  provider: string;
+}) {
+  const supabase = supabaseService();
+  const now = new Date().toISOString();
+
+  if (input.paymentId) {
+    await supabase
+      .from('payments')
+      .update({ status: 'paid', provider: input.provider, provider_payment_id: input.paymentId, updated_at: now })
+      .eq('id', input.paymentId);
+  }
+
+  if (input.subscriptionId) {
+    await supabase
+      .from('subscriptions')
+      .upsert(
+        {
+          id: input.subscriptionId,
+          user_id: input.userId,
+          status: 'active',
+          updated_at: now,
+        },
+        { onConflict: 'id' },
+      );
+  }
 }
 
 export function getCyclePricing(planId: string, cycle: Cycle) {

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -1,0 +1,124 @@
+import { FEATURE_PLAN } from '@/lib/plan/featureMap';
+import { PLAN_LABEL, USD_PLAN_PRICES, type Cycle } from '@/lib/pricing';
+import { supabaseService } from '@/lib/supabaseServer';
+import { coercePlanId, PLAN_RANK, type PlanId } from '@/types/pricing';
+
+export type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
+
+export type ActiveSubscription = Readonly<{
+  userId: string;
+  plan: PlanId;
+  status: SubscriptionStatus;
+  renewsAt?: string;
+  trialEndsAt?: string;
+}>;
+
+const ACTIVE_STATUSES = new Set<SubscriptionStatus>(['active', 'trialing']);
+const STATUS_VALUES = new Set<SubscriptionStatus>(['active', 'trialing', 'canceled', 'incomplete', 'past_due']);
+
+export function normalizePlan(plan?: string | null): PlanId {
+  return coercePlanId(plan ?? 'free');
+}
+
+export function normalizeSubscriptionStatus(status?: string | null): SubscriptionStatus {
+  const value = (status ?? 'canceled').toLowerCase();
+  return STATUS_VALUES.has(value as SubscriptionStatus) ? (value as SubscriptionStatus) : 'canceled';
+}
+
+export function getStandardPlanName(planId: string): PlanId {
+  return normalizePlan(planId);
+}
+
+export function getPlanTiers(): Array<{ id: PlanId; rank: number; label: string }> {
+  return (['free', 'starter', 'booster', 'master'] as PlanId[]).map((id) => ({
+    id,
+    rank: PLAN_RANK[id],
+    label: id === 'free' ? 'Free' : PLAN_LABEL[id],
+  }));
+}
+
+export function getPlanPricing(planId: string) {
+  const id = normalizePlan(planId);
+  if (id === 'free') {
+    return {
+      planId: id,
+      monthly: 0,
+      annual: 0,
+      monthlyDisplayFromAnnual: 0,
+    };
+  }
+
+  const row = USD_PLAN_PRICES[id];
+  return {
+    planId: id,
+    monthly: row.monthly,
+    annual: row.annual,
+    monthlyDisplayFromAnnual: row.annual / 12,
+  };
+}
+
+function toIso(value?: string | null) {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+export async function getActiveSubscription(userId: string): Promise<ActiveSubscription> {
+  const supabase = supabaseService();
+  const { data } = await supabase
+    .from('profiles')
+    .select('plan_id, membership, subscription_status, subscription_renews_at, trial_ends_at, premium_until')
+    .eq('id', userId)
+    .maybeSingle();
+
+  const row = (data ?? null) as {
+    plan_id?: string | null;
+    membership?: string | null;
+    subscription_status?: string | null;
+    subscription_renews_at?: string | null;
+    trial_ends_at?: string | null;
+    premium_until?: string | null;
+  } | null;
+
+  const plan = normalizePlan(row?.plan_id ?? row?.membership ?? 'free');
+  const normalizedStatus = normalizeSubscriptionStatus(row?.subscription_status);
+  const premiumUntil = toIso(row?.premium_until);
+  const fallbackStatus: SubscriptionStatus = premiumUntil && new Date(premiumUntil) > new Date() ? 'active' : normalizedStatus;
+
+  return {
+    userId,
+    plan,
+    status: fallbackStatus,
+    renewsAt: toIso(row?.subscription_renews_at) ?? premiumUntil,
+    trialEndsAt: toIso(row?.trial_ends_at),
+  };
+}
+
+export async function isSubscriptionActive(userId: string): Promise<boolean> {
+  const sub = await getActiveSubscription(userId);
+  return ACTIVE_STATUSES.has(sub.status) && sub.plan !== 'free';
+}
+
+export async function requireActiveSubscription(userId: string): Promise<ActiveSubscription> {
+  const sub = await getActiveSubscription(userId);
+  if (!ACTIVE_STATUSES.has(sub.status) || sub.plan === 'free') {
+    throw new Error('Active subscription required');
+  }
+  return sub;
+}
+
+export async function getUserPlan(userId: string): Promise<PlanId> {
+  const sub = await getActiveSubscription(userId);
+  return sub.plan;
+}
+
+export async function getFeatureAccess(userId: string, feature: string): Promise<boolean> {
+  const requiredPlan = FEATURE_PLAN[feature] ?? 'free';
+  const userPlan = await getUserPlan(userId);
+  return PLAN_RANK[userPlan] >= PLAN_RANK[requiredPlan];
+}
+
+export function getCyclePricing(planId: string, cycle: Cycle) {
+  const pricing = getPlanPricing(planId);
+  return cycle === 'monthly' ? pricing.monthly : pricing.annual;
+}

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -16,6 +16,28 @@ export type ActiveSubscription = Readonly<{
   trialEndsAt?: string;
 }>;
 
+export type InactiveSubscriptionErrorPayload = {
+  error: 'subscription_inactive';
+  message: string;
+  code: 'SUBSCRIPTION_INACTIVE';
+  requiredPlan: Exclude<PlanId, 'free'>;
+  currentPlan: PlanId;
+  status: SubscriptionStatus;
+  upgradeUrl: string;
+};
+
+export class InactiveSubscriptionError extends Error {
+  statusCode: number;
+  payload: InactiveSubscriptionErrorPayload;
+
+  constructor(payload: InactiveSubscriptionErrorPayload, statusCode = 402) {
+    super(payload.message);
+    this.name = 'InactiveSubscriptionError';
+    this.statusCode = statusCode;
+    this.payload = payload;
+  }
+}
+
 type RawSubscriptionRow = {
   id?: string | null;
   user_id?: string | null;
@@ -315,9 +337,36 @@ export async function isSubscriptionActive(userId: string): Promise<boolean> {
 export async function requireActiveSubscription(userId: string): Promise<ActiveSubscription> {
   const sub = await getActiveSubscription(userId);
   if (!ACTIVE_STATUSES.has(sub.status) || sub.plan === 'free') {
-    throw new Error('Active subscription required');
+    throw new InactiveSubscriptionError({
+      error: 'subscription_inactive',
+      message: 'An active paid subscription is required',
+      code: 'SUBSCRIPTION_INACTIVE',
+      requiredPlan: 'starter',
+      currentPlan: sub.plan,
+      status: sub.status,
+      upgradeUrl: '/pricing?required=starter',
+    });
   }
   return sub;
+}
+
+export function inactiveSubscriptionResponse(
+  current: Pick<ActiveSubscription, 'plan' | 'status'>,
+  requiredPlan: Exclude<PlanId, 'free'>,
+  statusCode = 402,
+): InactiveSubscriptionError {
+  return new InactiveSubscriptionError(
+    {
+      error: 'subscription_inactive',
+      message: 'Upgrade required',
+      code: 'SUBSCRIPTION_INACTIVE',
+      requiredPlan,
+      currentPlan: current.plan,
+      status: current.status,
+      upgradeUrl: `/pricing?required=${requiredPlan}`,
+    },
+    statusCode,
+  );
 }
 
 export async function getUserPlan(userId: string): Promise<PlanId> {

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -19,6 +19,17 @@ type RawSubscriptionRow = {
   plan_id?: string | null;
   status?: string | null;
   current_period_end?: string | null;
+  trial_end?: string | null;
+};
+
+type LegacyProfileSubscription = {
+  plan_id?: string | null;
+  membership?: string | null;
+  subscription_status?: string | null;
+  subscription_renews_at?: string | null;
+  trial_ends_at?: string | null;
+  premium_until?: string | null;
+  stripe_customer_id?: string | null;
 };
 
 export type SubscriptionSnapshot = Readonly<{
@@ -28,6 +39,12 @@ export type SubscriptionSnapshot = Readonly<{
   currentPeriodEnd: string | null;
   subscriptionId: string | null;
 }>;
+
+export type CanonicalSubscription = ActiveSubscription & {
+  subscriptionId: string | null;
+  customerId: string | null;
+  source: 'subscriptions' | 'legacy_profile' | 'none';
+};
 
 const ACTIVE_STATUSES = new Set<SubscriptionStatus>(['active', 'trialing']);
 const STATUS_VALUES = new Set<SubscriptionStatus>(['active', 'trialing', 'canceled', 'incomplete', 'past_due']);
@@ -84,11 +101,46 @@ function normalizeSubscriptionSnapshot(row: RawSubscriptionRow | null | undefine
   };
 }
 
+function mapLegacyProfileToCanonical(userId: string, profile: LegacyProfileSubscription | null | undefined): CanonicalSubscription {
+  const plan = normalizePlan(profile?.plan_id ?? profile?.membership ?? 'free');
+  const normalizedStatus = normalizeSubscriptionStatus(profile?.subscription_status);
+  const premiumUntil = toIso(profile?.premium_until);
+  const status: SubscriptionStatus = premiumUntil && new Date(premiumUntil) > new Date() ? 'active' : normalizedStatus;
+
+  return {
+    userId,
+    plan,
+    status,
+    renewsAt: toIso(profile?.subscription_renews_at) ?? premiumUntil,
+    trialEndsAt: toIso(profile?.trial_ends_at),
+    subscriptionId: null,
+    customerId: profile?.stripe_customer_id ?? null,
+    source: profile ? 'legacy_profile' : 'none',
+  };
+}
+
+function mapSubscriptionRowToCanonical(
+  userId: string,
+  row: RawSubscriptionRow,
+  customerId: string | null,
+): CanonicalSubscription {
+  return {
+    userId,
+    plan: normalizePlan(row.plan_id),
+    status: normalizeSubscriptionStatus(row.status),
+    renewsAt: toIso(row.current_period_end),
+    trialEndsAt: toIso(row.trial_end),
+    subscriptionId: row.id ?? null,
+    customerId,
+    source: 'subscriptions',
+  };
+}
+
 export async function getLatestSubscriptionRow(userId: string): Promise<RawSubscriptionRow | null> {
   const supabase = supabaseService();
   const { data } = await supabase
     .from('subscriptions')
-    .select('id, user_id, plan_id, status, current_period_end')
+    .select('id, user_id, plan_id, status, current_period_end, trial_end')
     .eq('user_id', userId)
     .order('current_period_end', { ascending: false, nullsFirst: false })
     .limit(1)
@@ -124,34 +176,35 @@ export async function getLatestSubscriptionSnapshotsForUsers(userIds: string[]):
   return snapshots;
 }
 
-export async function getActiveSubscription(userId: string): Promise<ActiveSubscription> {
+export async function getCanonicalSubscription(userId: string): Promise<CanonicalSubscription> {
   const supabase = supabaseService();
-  const { data } = await supabase
-    .from('profiles')
-    .select('plan_id, membership, subscription_status, subscription_renews_at, trial_ends_at, premium_until')
-    .eq('id', userId)
-    .maybeSingle();
 
-  const row = (data ?? null) as {
-    plan_id?: string | null;
-    membership?: string | null;
-    subscription_status?: string | null;
-    subscription_renews_at?: string | null;
-    trial_ends_at?: string | null;
-    premium_until?: string | null;
-  } | null;
+  const [latestRow, profileRes] = await Promise.all([
+    getLatestSubscriptionRow(userId),
+    supabase
+      .from('profiles')
+      .select('stripe_customer_id, plan_id, membership, subscription_status, subscription_renews_at, trial_ends_at, premium_until')
+      .eq('id', userId)
+      .maybeSingle(),
+  ]);
 
-  const plan = normalizePlan(row?.plan_id ?? row?.membership ?? 'free');
-  const normalizedStatus = normalizeSubscriptionStatus(row?.subscription_status);
-  const premiumUntil = toIso(row?.premium_until);
-  const status: SubscriptionStatus = premiumUntil && new Date(premiumUntil) > new Date() ? 'active' : normalizedStatus;
+  const profile = (profileRes.data ?? null) as LegacyProfileSubscription | null;
 
+  if (latestRow) {
+    return mapSubscriptionRowToCanonical(userId, latestRow, profile?.stripe_customer_id ?? null);
+  }
+
+  return mapLegacyProfileToCanonical(userId, profile);
+}
+
+export async function getActiveSubscription(userId: string): Promise<ActiveSubscription> {
+  const canonical = await getCanonicalSubscription(userId);
   return {
     userId,
-    plan,
-    status,
-    renewsAt: toIso(row?.subscription_renews_at) ?? premiumUntil,
-    trialEndsAt: toIso(row?.trial_ends_at),
+    plan: canonical.plan,
+    status: canonical.status,
+    renewsAt: canonical.renewsAt,
+    trialEndsAt: canonical.trialEndsAt,
   };
 }
 

--- a/lib/subscriptions.ts
+++ b/lib/subscriptions.ts
@@ -1,8 +1,13 @@
-// lib/subscriptions.ts
 import type Stripe from 'stripe';
 
-export type SubscriptionPlan = 'starter' | 'booster' | 'master' | 'free';
-export type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
+import {
+  normalizePlan,
+  normalizeSubscriptionStatus,
+  type SubscriptionStatus,
+} from '@/lib/subscription';
+import type { PlanId } from '@/types/pricing';
+
+export type SubscriptionPlan = PlanId;
 
 export type Invoice = Readonly<{
   id: string;
@@ -25,12 +30,10 @@ export function summarizeFromStripe(
   fallbackPlan: SubscriptionPlan = 'free'
 ): SubscriptionSummary {
   const nickname = (sub?.items?.data?.[0]?.price?.nickname ?? '').toString().toLowerCase();
-  const plan: SubscriptionPlan =
-    nickname === 'starter' || nickname === 'booster' || nickname === 'master' ? (nickname as SubscriptionPlan) : fallbackPlan;
 
   return {
-    plan,
-    status: ((sub?.status as SubscriptionStatus) ?? 'canceled'),
+    plan: normalizePlan(nickname || fallbackPlan),
+    status: normalizeSubscriptionStatus(sub?.status),
     renewsAt: sub?.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : undefined,
     trialEndsAt: sub?.trial_end ? new Date(sub.trial_end * 1000).toISOString() : undefined,
   };
@@ -47,3 +50,5 @@ export function mapStripeInvoice(i: Stripe.Invoice): Invoice {
     status: (i.status as Invoice['status']) ?? 'open',
   };
 }
+
+export { normalizePlan, normalizeSubscriptionStatus } from '@/lib/subscription';

--- a/lib/usage/checkQuota.ts
+++ b/lib/usage/checkQuota.ts
@@ -2,6 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { PostgrestSingleResponse, SupabaseClient } from '@supabase/supabase-js';
 import { getServerClient } from '@/lib/supabaseServer';
+import { getUserPlan } from '@/lib/subscription';
 
 export type QuotaResult = { ok: true } | { ok: false; reason: string };
 
@@ -12,7 +13,7 @@ const TEACHER_BYPASS =
  * Check per-user quota for a usage `key`, with role bypass (admin, optional teacher).
  * Strategy (in order):
  *  1) Bypass for admin (and teacher if enabled).
- *  2) get_user_plan(user) → plan_limits(plan_id,key) → get_usage_today(user,key) → compare (fail-closed).
+ *  2) getUserPlan(user) → plan_limits(plan_id,key) → get_usage_today(user,key) → compare (fail-closed).
  *  3) Legacy fallback: usage_check(user,key) (fail-open if RPC missing/shape unexpected).
  *  4) Any transport/infra issue: fail-open (ok: true) so APIs don’t 500.
  */
@@ -41,9 +42,7 @@ export async function checkQuota(
     if (TEACHER_BYPASS && role === 'teacher') return { ok: true };
 
     // ---- modern plan/usage path ----
-    // get_user_plan(uuid) → { plan_id text }
-    const planRes = await safeRpcSingle(supabase, 'get_user_plan', { p_user_id: user.id });
-    const planId: string = (planRes?.data as any)?.plan_id ?? 'free';
+    const planId = await getUserPlan(user.id);
 
     // plan_limits(plan_id,key) → per_day, per_month (nullable)
     const limitRes = await supabase

--- a/pages/account/billing-history.tsx
+++ b/pages/account/billing-history.tsx
@@ -13,8 +13,6 @@ import { Badge } from '@/components/design-system/Badge';
 import { Skeleton } from '@/components/design-system/Skeleton';
 import { useToast } from '@/components/design-system/Toaster';
 import { useLocale } from '@/lib/locale';
-import { fetchProfile } from '@/lib/profile';
-import type { Profile } from '@/types/profile';
 import { GlobalPlanGuard } from '@/components/GlobalPlanGuard';
 import type { PlanId } from '@/types/pricing';
 
@@ -39,7 +37,8 @@ export default function BillingHistoryPage() {
   const { t, locale } = useLocale();
   const { error: toastError } = useToast();
 
-  const [profile, setProfile] = useState<Profile | null>(null);
+  const [currentPlan, setCurrentPlan] = useState<PlanId>('free');
+  const [hasSubscription, setHasSubscription] = useState(false);
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -71,27 +70,29 @@ export default function BillingHistoryPage() {
     (async () => {
       setLoading(true);
       try {
-        // First get profile to ensure authenticated and get customer info
-        const fetchedProfile = await fetchProfile();
-        if (cancelled) return;
-        if (!fetchedProfile) {
-          throw new Error('Profile not found');
-        }
-        setProfile(fetchedProfile);
+        const [planRes, summaryRes, historyRes] = await Promise.all([
+          fetch('/api/subscription/plan', { credentials: 'include' }),
+          fetch('/api/billing/summary', { credentials: 'include' }),
+          fetch('/api/billing/history', {
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+          }),
+        ]);
 
-        // Fetch billing history via API route
-        const response = await fetch('/api/billing/history', {
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-        });
-
-        if (!response.ok) {
-          const data = await response.json().catch(() => ({}));
+        if (!planRes.ok || !summaryRes.ok || !historyRes.ok) {
+          const failed = [planRes, summaryRes, historyRes].find((res) => !res.ok) ?? historyRes;
+          const data = await failed.json().catch(() => ({}));
           throw new Error(data.error || t('billingHistory.error.fetch', 'Failed to fetch billing history'));
         }
 
-        const data: InvoicesResponse = await response.json();
+        const planData = (await planRes.json()) as { plan: PlanId };
+        const summaryData = (await summaryRes.json()) as { summary?: { plan?: PlanId; status?: string } };
+        const data: InvoicesResponse = await historyRes.json();
         if (cancelled) return;
+
+        setCurrentPlan(planData.plan ?? summaryData.summary?.plan ?? 'free');
+        const status = summaryData.summary?.status ?? 'canceled';
+        setHasSubscription(status === 'active' || status === 'trialing');
 
         setInvoices(data.invoices || []);
         setHasMore(data.hasMore || false);
@@ -118,9 +119,6 @@ export default function BillingHistoryPage() {
       cancelled = true;
     };
   }, [router, t, toastError]);
-
-  const currentPlan: PlanId = profile?.tier ?? 'free';
-  const hasSubscription = !!profile?.stripe_customer_id && profile.subscription_status === 'active';
 
   // Status badge variant
   const getStatusVariant = (status: Invoice['status']): React.ComponentProps<typeof Badge>['variant'] => {

--- a/pages/account/subscription.tsx
+++ b/pages/account/subscription.tsx
@@ -12,24 +12,25 @@ import { Alert } from '@/components/design-system/Alert';
 import { Badge } from '@/components/design-system/Badge';
 import { Skeleton } from '@/components/design-system/Skeleton';
 import { useToast } from '@/components/design-system/Toaster';
-import { fetchProfile } from '@/lib/profile';
-import type { Profile } from '@/types/profile';
 import { GlobalPlanGuard } from '@/components/GlobalPlanGuard';
 import { useLocale } from '@/lib/locale';
 import type { PlanId } from '@/types/pricing';
 
-type SubscriptionStatus =
-  | 'active'
-  | 'trialing'
-  | 'canceled'
-  | 'incomplete'
-  | 'past_due'
-  | 'unpaid'
-  | 'paused'
-  | 'inactive'
-  | 'expired';
+type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
 
 type SubscriptionPlanKey = 'free' | 'starter' | 'booster' | 'master';
+
+type PortalSubscription = {
+  plan: PlanId;
+  status: SubscriptionStatus;
+  renewsAt?: string;
+  trialEndsAt?: string;
+};
+
+type PortalResponse = {
+  subscription: PortalSubscription;
+  invoices: Array<unknown>;
+};
 
 type PlanDisplay = {
   name: string;
@@ -73,7 +74,7 @@ export default function SubscriptionPage() {
   const { t, locale } = useLocale();
   const { error: toastError, success: toastSuccess } = useToast();
 
-  const [profile, setProfile] = useState<Profile | null>(null);
+  const [subscription, setSubscription] = useState<PortalSubscription | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [cancelling, setCancelling] = useState(false);
@@ -98,15 +99,17 @@ export default function SubscriptionPage() {
   useEffect(() => {
     let cancelled = false;
 
-    const loadProfile = async () => {
+    const loadSubscription = async () => {
       setLoading(true);
       try {
-        const fetchedProfile = await fetchProfile();
-        if (cancelled) return;
-        if (!fetchedProfile) {
-          throw new Error('Profile not found');
+        const response = await fetch('/api/subscriptions/portal', { credentials: 'include' });
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || 'Failed to load subscription');
         }
-        setProfile(fetchedProfile);
+        const data = (await response.json()) as PortalResponse;
+        if (cancelled) return;
+        setSubscription(data.subscription);
         setError(null);
       } catch (err) {
         if (cancelled) return;
@@ -125,21 +128,20 @@ export default function SubscriptionPage() {
       }
     };
 
-    loadProfile();
+    loadSubscription();
 
     return () => {
       cancelled = true;
     };
   }, [router, t, toastError]);
 
-  const currentPlan: PlanId = profile?.tier ?? 'free';
+  const currentPlan: PlanId = subscription?.plan ?? 'free';
   const planKey: SubscriptionPlanKey = (currentPlan as SubscriptionPlanKey) ?? 'free';
 
-  const status: SubscriptionStatus =
-    (profile?.subscription_status as SubscriptionStatus) ?? 'inactive';
+  const status: SubscriptionStatus = subscription?.status ?? 'canceled';
 
-  const expiresAt = profile?.subscription_expires_at ?? profile?.premium_until ?? null;
-  const trialEndsAt = profile?.trial_end ?? null;
+  const expiresAt = subscription?.renewsAt ?? null;
+  const trialEndsAt = subscription?.trialEndsAt ?? null;
 
   const isPremium = currentPlan !== 'free' && (status === 'active' || status === 'trialing');
   const isTrialing = status === 'trialing' && !!trialEndsAt;
@@ -164,9 +166,11 @@ export default function SubscriptionPage() {
       }
 
       toastSuccess(t('subscription.cancel.success', 'Subscription cancelled successfully.'));
-      // Refresh profile
-      const refreshedProfile = await fetchProfile();
-      setProfile(refreshedProfile);
+      const refreshed = await fetch('/api/subscriptions/portal', { credentials: 'include' });
+      if (refreshed.ok) {
+        const data = (await refreshed.json()) as PortalResponse;
+        setSubscription(data.subscription);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : t('subscription.cancel.error', 'Failed to cancel subscription');
       toastError(message);
@@ -184,13 +188,7 @@ export default function SubscriptionPage() {
       case 'past_due':
       case 'incomplete':
         return 'warning';
-      case 'unpaid':
-        return 'danger';
-      case 'paused':
-        return 'secondary';
       case 'canceled':
-      case 'expired':
-      case 'inactive':
       default:
         return 'neutral';
     }
@@ -206,16 +204,9 @@ export default function SubscriptionPage() {
         return t('subscription.status.pastDue', 'Past due');
       case 'incomplete':
         return t('subscription.status.incomplete', 'Incomplete');
-      case 'unpaid':
-        return t('subscription.status.unpaid', 'Unpaid');
-      case 'paused':
-        return t('subscription.status.paused', 'Paused');
       case 'canceled':
-        return t('subscription.status.canceled', 'Canceled');
-      case 'expired':
-        return t('subscription.status.expired', 'Expired');
       default:
-        return t('subscription.status.inactive', 'Inactive');
+        return t('subscription.status.canceled', 'Canceled');
     }
   };
 
@@ -378,7 +369,7 @@ export default function SubscriptionPage() {
                       </Button>
                     )}
 
-                    {profile?.stripe_customer_id && (
+                    {(subscription?.plan !== 'free' || isPremium) && (
                       <Button
                         asChild
                         variant="ghost"

--- a/pages/account/subscription.tsx
+++ b/pages/account/subscription.tsx
@@ -14,7 +14,7 @@ import { Skeleton } from '@/components/design-system/Skeleton';
 import { useToast } from '@/components/design-system/Toaster';
 import { GlobalPlanGuard } from '@/components/GlobalPlanGuard';
 import { useLocale } from '@/lib/locale';
-import { getStandardPlanName } from '@/lib/subscription';
+import { getPlanPricing, getStandardPlanName } from '@/lib/subscription';
 import type { PlanId } from '@/types/pricing';
 
 type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
@@ -41,31 +41,37 @@ type PlanDisplay = {
   currency?: string;
 };
 
-const PLAN_DISPLAY: Record<SubscriptionPlanKey, PlanDisplay> = {
+const priceLine = (plan: SubscriptionPlanKey) => {
+  const pricing = getPlanPricing(plan);
+  if (pricing.monthly === 0) return '$0';
+  return `$${pricing.monthly}/month`;
+};
+
+export const PLAN_DISPLAY: Record<SubscriptionPlanKey, PlanDisplay> = {
   free: {
     name: getStandardPlanName('free'),
     features: ['Basic access', 'Limited mocks', 'Community support'],
-    price: '$0',
+    price: priceLine('free'),
   },
   starter: {
     name: getStandardPlanName('starter'),
     features: ['More mocks', 'Basic analytics', 'Email reminders'],
-    price: '$5.99/month',
-    priceMonthly: 599,
+    price: priceLine('starter'),
+    priceMonthly: getPlanPricing('starter').monthlyCents,
     currency: 'USD',
   },
   booster: {
     name: getStandardPlanName('booster'),
     features: ['Full mocks', 'Band analytics', 'AI feedback'],
-    price: '$9.99/month',
-    priceMonthly: 999,
+    price: priceLine('booster'),
+    priceMonthly: getPlanPricing('booster').monthlyCents,
     currency: 'USD',
   },
   master: {
     name: getStandardPlanName('master'),
     features: ['Everything in Booster', 'Teacher tools', 'Priority support'],
-    price: '$14.99/month',
-    priceMonthly: 1499,
+    price: priceLine('master'),
+    priceMonthly: getPlanPricing('master').monthlyCents,
     currency: 'USD',
   },
 };

--- a/pages/account/subscription.tsx
+++ b/pages/account/subscription.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from '@/components/design-system/Skeleton';
 import { useToast } from '@/components/design-system/Toaster';
 import { GlobalPlanGuard } from '@/components/GlobalPlanGuard';
 import { useLocale } from '@/lib/locale';
+import { getStandardPlanName } from '@/lib/subscription';
 import type { PlanId } from '@/types/pricing';
 
 type SubscriptionStatus = 'active' | 'trialing' | 'canceled' | 'incomplete' | 'past_due';
@@ -42,26 +43,26 @@ type PlanDisplay = {
 
 const PLAN_DISPLAY: Record<SubscriptionPlanKey, PlanDisplay> = {
   free: {
-    name: 'Free',
+    name: getStandardPlanName('free'),
     features: ['Basic access', 'Limited mocks', 'Community support'],
     price: '$0',
   },
   starter: {
-    name: 'Starter',
+    name: getStandardPlanName('starter'),
     features: ['More mocks', 'Basic analytics', 'Email reminders'],
     price: '$5.99/month',
     priceMonthly: 599,
     currency: 'USD',
   },
   booster: {
-    name: 'Booster',
+    name: getStandardPlanName('booster'),
     features: ['Full mocks', 'Band analytics', 'AI feedback'],
     price: '$9.99/month',
     priceMonthly: 999,
     currency: 'USD',
   },
   master: {
-    name: 'Master',
+    name: getStandardPlanName('master'),
     features: ['Everything in Booster', 'Teacher tools', 'Priority support'],
     price: '$14.99/month',
     priceMonthly: 1499,

--- a/pages/api/account/export.ts
+++ b/pages/api/account/export.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { logAccountAudit } from '@/lib/audit';
 import { env } from '@/lib/env';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
+import { getActiveSubscription, getStandardPlanName, isSubscriptionActive } from '@/lib/subscription';
 import { sendTransactionalEmail } from '@/lib/email';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -27,13 +28,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const userAgentHeader = req.headers['user-agent'];
     const userAgent = Array.isArray(userAgentHeader) ? userAgentHeader[0] : userAgentHeader ?? null;
 
-    const [profileRes, bookmarksRes, subscriptionsRes, studyPlansRes, attemptsRes, invoicesRes] = await Promise.all([
+    const [profileRes, bookmarksRes, subscriptionsRes, studyPlansRes, attemptsRes, invoicesRes, activeSubscription, subscriptionActive] = await Promise.all([
       supabase.from('profiles').select('*').eq('user_id', user.id).maybeSingle(),
       supabase.from('user_bookmarks').select('*').eq('user_id', user.id),
       supabase.from('subscriptions').select('*').eq('user_id', user.id),
       supabase.from('study_plans').select('*').eq('user_id', user.id),
       supabase.from('attempts').select('*').eq('user_id', user.id),
       supabase.from('invoices').select('*').eq('user_id', user.id),
+      getActiveSubscription(user.id),
+      isSubscriptionActive(user.id),
     ]);
 
     if (profileRes.error && profileRes.error.code !== 'PGRST116') {
@@ -50,6 +53,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       profile: profileRes.data ?? null,
       bookmarks: bookmarksRes.data ?? [],
       subscriptions: subscriptionsRes.data ?? [],
+      subscriptionSummary: {
+        plan: activeSubscription.plan,
+        standardPlanName: getStandardPlanName(activeSubscription.plan),
+        status: activeSubscription.status,
+        isActive: subscriptionActive,
+        renewsAt: activeSubscription.renewsAt ?? null,
+        trialEndsAt: activeSubscription.trialEndsAt ?? null,
+      },
       studyPlans: studyPlansRes.data ?? [],
       attempts: attemptsRes.data ?? [],
       invoices: invoicesRes.data ?? [],

--- a/pages/api/account/export.ts
+++ b/pages/api/account/export.ts
@@ -28,10 +28,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const userAgentHeader = req.headers['user-agent'];
     const userAgent = Array.isArray(userAgentHeader) ? userAgentHeader[0] : userAgentHeader ?? null;
 
-    const [profileRes, bookmarksRes, subscriptionsRes, studyPlansRes, attemptsRes, invoicesRes, activeSubscription, subscriptionActive] = await Promise.all([
+    const [profileRes, bookmarksRes, studyPlansRes, attemptsRes, invoicesRes, activeSubscription, subscriptionActive] = await Promise.all([
       supabase.from('profiles').select('*').eq('user_id', user.id).maybeSingle(),
       supabase.from('user_bookmarks').select('*').eq('user_id', user.id),
-      supabase.from('subscriptions').select('*').eq('user_id', user.id),
       supabase.from('study_plans').select('*').eq('user_id', user.id),
       supabase.from('attempts').select('*').eq('user_id', user.id),
       supabase.from('invoices').select('*').eq('user_id', user.id),
@@ -43,7 +42,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       throw profileRes.error;
     }
 
-    for (const response of [bookmarksRes, subscriptionsRes, studyPlansRes, attemptsRes, invoicesRes]) {
+    for (const response of [bookmarksRes, studyPlansRes, attemptsRes, invoicesRes]) {
       if (response.error) {
         throw response.error;
       }
@@ -52,7 +51,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const exportData = {
       profile: profileRes.data ?? null,
       bookmarks: bookmarksRes.data ?? [],
-      subscriptions: subscriptionsRes.data ?? [],
+      subscriptions: [],
       subscriptionSummary: {
         plan: activeSubscription.plan,
         standardPlanName: getStandardPlanName(activeSubscription.plan),

--- a/pages/api/account/redeem-pin.ts
+++ b/pages/api/account/redeem-pin.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { env } from '@/lib/env';
 import { getServerClient } from '@/lib/supabaseServer';
 import { getAdminClient } from '@/lib/supabaseAdmin';
+import { applyPinOrManualProvisioning } from '@/lib/subscription';
 
 type Plan = 'starter' | 'booster' | 'master';
 
@@ -190,16 +191,13 @@ export default async function handler(
   const premiumUntil = new Date();
   premiumUntil.setUTCDate(premiumUntil.getUTCDate() + grantDays);
 
-  // Update user profile (uses admin client to avoid RLS snags)
-  await admin
-    .from('user_profiles') // NOTE: your schema predominantly references `user_profiles`
-    .update({
-      membership: plan,
-      premium_until: premiumUntil.toISOString(),
-      subscription_status: 'active',
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', user.id);
+  await applyPinOrManualProvisioning({
+    userId: user.id,
+    plan,
+    provider: 'pin',
+    eventId: `premium-pin:${(pinRow as any).id ?? user.id}:${plan}`,
+    premiumUntil: premiumUntil.toISOString(),
+  });
 
   // Invalidate the PIN so it can't be reused
   await admin.from('premium_pins').delete().eq('user_id', user.id);

--- a/pages/api/admin/users.ts
+++ b/pages/api/admin/users.ts
@@ -1,16 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import { getServerClient } from '@/lib/supabaseServer';
+import { getLatestSubscriptionSnapshotsForUsers } from '@/lib/subscription';
 
 // ---------- Types ----------
-const SubscriptionRow = z.object({
-  user_id: z.string(),
-  plan_id: z.string().nullable().optional(),
-  status: z.string().nullable().optional(),
-  current_period_end: z.string().datetime().nullable().optional(),
-});
-type SubscriptionRow = z.infer<typeof SubscriptionRow>;
-
 const ProfileRow = z.object({
   id: z.string(),
   full_name: z.string().nullable().optional(),
@@ -64,38 +57,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(500).json({ error: 'Profiles shape invalid', details: profilesParsed.error.flatten() });
   }
 
-  // Fetch all subscriptions (map latest per user)
-  const { data: subs, error: sErr } = await supabase
-    .from('subscriptions')
-    .select('user_id, plan_id, status, current_period_end');
-  if (sErr) return res.status(500).json({ error: sErr.message });
-
-  const subsParsed = z.array(SubscriptionRow).safeParse(subs ?? []);
-  if (!subsParsed.success) {
-    return res.status(500).json({ error: 'Subscriptions shape invalid', details: subsParsed.error.flatten() });
-  }
-
-  // Pick the latest subscription per user_id (by current_period_end desc; nulls last)
-  const latestByUser: Record<string, SubscriptionRow> = {};
-  for (const row of subsParsed.data) {
-    const curr = latestByUser[row.user_id];
-    const currEnd = curr?.current_period_end ? Date.parse(curr.current_period_end) : -1;
-    const nextEnd = row.current_period_end ? Date.parse(row.current_period_end) : -1;
-    if (!curr || nextEnd >= currEnd) latestByUser[row.user_id] = row;
-  }
+  const userIds = profilesParsed.data.map((profile) => profile.id);
+  const snapshots = await getLatestSubscriptionSnapshotsForUsers(userIds);
 
   // Compose payload
   const payload: AdminUsersResponse = profilesParsed.data.map((p) => {
-    const s = latestByUser[p.id];
+    const s = snapshots[p.id];
     return {
       id: p.id,
       email: p.email ?? null,        // will be null if your profiles table doesn’t store email
       full_name: p.full_name ?? null,
       role: p.role,
       subscription: s ? {
-        plan_id: s.plan_id ?? null,
-        status: s.status ?? null,
-        current_period_end: s.current_period_end ?? null,
+        plan_id: s.plan,
+        status: s.status,
+        current_period_end: s.currentPeriodEnd,
       } : null,
     };
   });

--- a/pages/api/billing/summary.ts
+++ b/pages/api/billing/summary.ts
@@ -2,6 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { stripe } from '@/lib/stripe';
 import { summarizeFromStripe, mapStripeInvoice, type SubscriptionSummary } from '@/lib/subscriptions';
+import { getCanonicalSubscription } from '@/lib/subscription';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 
 type DueRow = Readonly<{
@@ -57,7 +58,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   try {
     const { data: profileData, error: pErr } = await supabase
       .from('profiles')
-      .select('id, email, stripe_customer_id, plan_id, premium_until')
+      .select('id, email, stripe_customer_id')
       .eq('id', user.id)
       .single();
     profile = profileData;
@@ -83,11 +84,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   // Return mock response if Stripe is not configured
   if (!stripe) {
+    const canonical = await getCanonicalSubscription(user.id);
     return res.status(200).json({
       ok: true,
       summary: {
-        plan: (profile?.plan_id as SubscriptionSummary['plan']) ?? 'free',
-        status: 'canceled',
+        plan: canonical.plan,
+        status: canonical.status,
+        renewsAt: canonical.renewsAt,
+        trialEndsAt: canonical.trialEndsAt,
       },
       invoices: [],
       dues,
@@ -124,7 +128,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     subs.data.find(s => s.status === 'active' || s.status === 'trialing') ??
     subs.data.sort((a, b) => (b.created ?? 0) - (a.created ?? 0))[0];
 
-  const summary = summarizeFromStripe(sub, (profile?.plan_id as SubscriptionSummary['plan']) ?? 'free');
+  const canonical = await getCanonicalSubscription(user.id);
+  const summary = summarizeFromStripe(sub, canonical.plan);
 
   let invs;
   try {
@@ -138,5 +143,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
   const invoices = invs.data.map(mapStripeInvoice);
 
-  return res.status(200).json({ ok: true, summary, invoices, customerId, dues });
+  return res.status(200).json({
+    ok: true,
+    summary: {
+      ...summary,
+      plan: canonical.plan,
+      status: canonical.status,
+      renewsAt: canonical.renewsAt ?? summary.renewsAt,
+      trialEndsAt: canonical.trialEndsAt ?? summary.trialEndsAt,
+    },
+    invoices,
+    customerId,
+    dues,
+  });
 }

--- a/pages/api/debug/feature-flags.ts
+++ b/pages/api/debug/feature-flags.ts
@@ -5,14 +5,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { resolveFlags, type FlagAudience } from '@/lib/flags';
 import { getServerClient } from '@/lib/supabaseServer';
-import type { PlanId } from '@/types/pricing';
-
-const normalisePlan = (raw?: string | null): PlanId => {
-  if (!raw) return 'free';
-  const lower = raw.toLowerCase();
-  if (lower === 'starter' || lower === 'booster' || lower === 'master') return lower;
-  return 'free';
-};
+import { normalizePlan } from '@/lib/subscription';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -35,7 +28,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .eq('id', user.id)
       .maybeSingle();
 
-    const plan = normalisePlan((data as { plan?: string | null } | null)?.plan ?? null);
+    const plan = normalizePlan((data as { plan?: string | null } | null)?.plan ?? null);
     const role = ((data as { role?: string | null } | null)?.role ?? null) as string | null;
     audience = { plan, role, userId: user.id };
   }

--- a/pages/api/me/plan.ts
+++ b/pages/api/me/plan.ts
@@ -1,15 +1,10 @@
 // pages/api/me/plan.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { supabaseServer } from '@/lib/supabaseServer';
+import { getUserPlan } from '@/lib/subscription';
 import type { PlanId } from '@/types/pricing';
 
 type Resp = { ok: true; plan: PlanId } | { ok: false; plan: PlanId };
-
-function normalize(s?: string | null): PlanId {
-  const v = (s ?? 'free').toLowerCase();
-  if (v === 'starter' || v === 'booster' || v === 'master' || v === 'free') return v;
-  return 'free';
-}
 
 function isEmailInAdminList(email?: string | null) {
   if (!email) return false;
@@ -47,6 +42,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return res.status(200).json({ ok: true, plan: 'master' });
   }
 
-  const plan = normalize(profile?.plan_id as string | undefined);
+  const plan = await getUserPlan(user.id);
   return res.status(200).json({ ok: true, plan });
 }

--- a/pages/api/payments/create-checkout-session.ts
+++ b/pages/api/payments/create-checkout-session.ts
@@ -2,8 +2,8 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { env } from '@/lib/env';
-import { createClient as createSbClient } from '@supabase/supabase-js';
 import { getPlanBillingAmount, type Cycle, type PlanKey } from '@/lib/pricing';
+import { applyPinOrManualProvisioning } from '@/lib/subscription';
 
 type CreateCheckoutBody = Readonly<{
   plan: PlanKey;
@@ -48,56 +48,6 @@ const methodNotAllowed = (res: NextApiResponse<ResBody>) =>
 const badRequest = (res: NextApiResponse<ResBody>, msg: string) =>
   res.status(400).json({ ok: false, error: msg });
 
-/** Attempt to write a pending due and provision the plan.
- * Uses service role if available; otherwise tries with the user-scoped client.
- * Fails gracefully (returns void).
- */
-async function provisionManually(opts: {
-  userId: string;
-  plan: PlanKey;
-  cycle: Cycle;
-  userEmail?: string | null;
-}) {
-  const amountMajor = getPlanBillingAmount(opts.plan, opts.cycle);
-  const amount_cents = Math.round(amountMajor * 100);
-  const currency = 'USD';
-
-  // Prefer service role for server-side writes
-  const adminKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-  const admin = adminKey ? createSbClient(url, adminKey, { auth: { persistSession: false } }) : null;
-
-  const upsertClient = admin ?? createSupabaseServerClient({} as { req: NextApiRequest });
-
-  // Insert pending due (ignore failure)
-  try {
-    await upsertClient
-      .from('pending_payments')
-      .insert({
-        user_id: opts.userId,
-        plan_key: opts.plan,
-        cycle: opts.cycle,
-        currency,
-        amount_cents,
-        status: 'due',
-        note: 'Manual fallback: gateway unavailable',
-        email: opts.userEmail ?? null,
-      });
-  } catch {
-    // ignore
-  }
-
-  // Provision plan immediately (ignore failure if RLS blocks)
-  try {
-    await upsertClient
-      .from('profiles')
-      .update({ plan_id: opts.plan })
-      .eq('id', opts.userId);
-  } catch {
-    // ignore
-  }
-}
-
 // ---- Handler ----
 const handler: NextApiHandler<ResBody> = async (req, res) => {
   if (req.method !== 'POST') return methodNotAllowed(res);
@@ -124,7 +74,16 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
   // If Stripe is not configured → manual fallback (create pending due + provision plan)
   if (!env.STRIPE_SECRET_KEY || !priceId) {
     try {
-      await provisionManually({ userId, plan, cycle: billingCycle, userEmail });
+      await applyPinOrManualProvisioning({
+        userId,
+        plan,
+        provider: 'manual',
+        eventId: `checkout-manual:${userId}:${plan}:${billingCycle}`,
+        cycle: billingCycle,
+        amountCents: Math.round(getPlanBillingAmount(plan, billingCycle) * 100),
+        email: userEmail,
+        note: 'Manual fallback: gateway unavailable',
+      });
       return res.status(200).json({
         ok: true,
         manual: true,

--- a/pages/api/payments/create-checkout-session.ts
+++ b/pages/api/payments/create-checkout-session.ts
@@ -4,6 +4,7 @@ import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { env } from '@/lib/env';
 import { type Cycle, type PlanKey } from '@/lib/pricing';
 import { applyPinOrManualProvisioning, getPlanPricing } from '@/lib/subscription';
+import { normalizeCycleInput } from '@/types/payments';
 
 type CreateCheckoutBody = Readonly<{
   plan: PlanKey;
@@ -18,8 +19,8 @@ type ResBody = Success | Failure;
 // ---- Helpers ----
 const isPlan = (v: unknown): v is PlanKey =>
   typeof v === 'string' && ['starter', 'booster', 'master'].includes(v);
-const isCycle = (v: unknown): v is Cycle =>
-  typeof v === 'string' && ['monthly', 'annual'].includes(v);
+const isCycle = (v: unknown): v is string =>
+  typeof v === 'string' && ['monthly', 'annual', 'yearly'].includes(v);
 
 const getOrigin = (req: NextApiRequest) => {
   const proto = (req.headers['x-forwarded-proto'] as string) || 'https';
@@ -56,7 +57,7 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
   const body = req.body as Partial<CreateCheckoutBody> | undefined;
   if (!body) return badRequest(res, 'missing_body');
   const plan = isPlan(body.plan) ? body.plan : 'booster';
-  const billingCycle = isCycle(body.billingCycle) ? body.billingCycle : 'monthly';
+  const billingCycle: Cycle = normalizeCycleInput(isCycle(body.billingCycle) ? body.billingCycle : 'monthly');
   const referralCode = typeof body.referralCode === 'string' ? body.referralCode.slice(0, 64) : undefined;
 
   // Auth (user id for metadata / customer lookup)

--- a/pages/api/payments/create-checkout-session.ts
+++ b/pages/api/payments/create-checkout-session.ts
@@ -2,8 +2,8 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { env } from '@/lib/env';
-import { getPlanBillingAmount, type Cycle, type PlanKey } from '@/lib/pricing';
-import { applyPinOrManualProvisioning } from '@/lib/subscription';
+import { type Cycle, type PlanKey } from '@/lib/pricing';
+import { applyPinOrManualProvisioning, getPlanPricing } from '@/lib/subscription';
 
 type CreateCheckoutBody = Readonly<{
   plan: PlanKey;
@@ -80,7 +80,7 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
         provider: 'manual',
         eventId: `checkout-manual:${userId}:${plan}:${billingCycle}`,
         cycle: billingCycle,
-        amountCents: Math.round(getPlanBillingAmount(plan, billingCycle) * 100),
+        amountCents: billingCycle === 'monthly' ? getPlanPricing(plan).monthlyCents : getPlanPricing(plan).annualCents,
         email: userEmail,
         note: 'Manual fallback: gateway unavailable',
       });

--- a/pages/api/payments/create-intent.ts
+++ b/pages/api/payments/create-intent.ts
@@ -10,14 +10,15 @@ import { createPendingPayment } from '@/lib/billing/manual';
 import type { Cycle, PlanKey } from '@/lib/pricing';
 import { queueNotificationEvent, getNotificationContact, type NotificationContact } from '@/lib/notify';
 import { getBaseUrl } from '@/lib/url';
+import { normalizeCycleInput } from '@/types/payments';
 
 const providers: PaymentProvider[] = ['stripe', 'easypaisa', 'jazzcash', 'safepay', 'crypto'];
 
 const Body = z.object({
   plan: z.enum(['starter', 'booster', 'master']).default('booster'),
-  cycle: z.enum(['monthly', 'annual']).optional(),
+  cycle: z.enum(['monthly', 'annual', 'yearly']).optional(),
   // Back-compat for old client param name
-  billingCycle: z.enum(['monthly', 'annual']).optional(),
+  billingCycle: z.enum(['monthly', 'annual', 'yearly']).optional(),
   provider: z.enum(providers as [PaymentProvider, ...PaymentProvider[]]).optional(),
   referralCode: z.string().max(64).optional(),
   promoCode: z.string().max(64).optional(),
@@ -56,7 +57,7 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
 
   const body = parsed.data;
   const plan: PlanKey = body.plan;
-  const cycle: Cycle = (body.cycle ?? body.billingCycle ?? 'monthly') as Cycle;
+  const cycle: Cycle = normalizeCycleInput(body.cycle ?? body.billingCycle ?? 'monthly');
   const provider: PaymentProvider = (body.provider ?? 'stripe') as PaymentProvider;
   const referralCode = body.referralCode;
   const promoCode = body.promoCode;

--- a/pages/api/payments/vault.ts
+++ b/pages/api/payments/vault.ts
@@ -4,11 +4,12 @@ import { z } from 'zod';
 import Stripe from 'stripe';
 import { getServerClient } from '@/lib/supabaseServer';
 import { getPlanPricing } from '@/lib/subscription';
+import { normalizeCycleInput, type Cycle } from '@/types/payments';
 
 const Body = z.object({
   payment_method_id: z.string(),
   plan: z.enum(['free','starter','booster','master']).default('starter'),
-  cycle: z.enum(['monthly','yearly']).default('monthly'),
+  cycle: z.enum(['monthly','annual','yearly']).default('monthly'),
   billing_details: z.object({
     name: z.string().optional(),
     phone: z.string().optional(),
@@ -24,7 +25,7 @@ const Body = z.object({
 const stripeKey = process.env.STRIPE_SECRET_KEY || '';
 const stripe = stripeKey ? new Stripe(stripeKey, { apiVersion: '2024-06-20' }) : null;
 
-function amountFor(plan: 'free'|'starter'|'booster'|'master', cycle: 'monthly'|'yearly') {
+function amountFor(plan: 'free'|'starter'|'booster'|'master', cycle: Cycle) {
   const pricing = getPlanPricing(plan);
   return cycle === 'monthly' ? pricing.monthlyCents : pricing.annualCents;
 }
@@ -40,7 +41,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (!stripe) return res.status(503).json({ error: 'stripe_not_configured' });
 
-  const { payment_method_id, plan, cycle, billing_details } = parse.data;
+  const { payment_method_id, plan, cycle: cycleInput, billing_details } = parse.data;
+  const cycle: Cycle = normalizeCycleInput(cycleInput);
 
   try {
     // Customer (you can optimize by caching customer_id per user)

--- a/pages/api/payments/vault.ts
+++ b/pages/api/payments/vault.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 import Stripe from 'stripe';
 import { getServerClient } from '@/lib/supabaseServer';
+import { getPlanPricing } from '@/lib/subscription';
 
 const Body = z.object({
   payment_method_id: z.string(),
@@ -24,10 +25,8 @@ const stripeKey = process.env.STRIPE_SECRET_KEY || '';
 const stripe = stripeKey ? new Stripe(stripeKey, { apiVersion: '2024-06-20' }) : null;
 
 function amountFor(plan: 'free'|'starter'|'booster'|'master', cycle: 'monthly'|'yearly') {
-  if (plan === 'starter') return cycle === 'monthly' ? 900 : 9000;
-  if (plan === 'booster') return cycle === 'monthly' ? 1900 : 19000;
-  if (plan === 'master')  return cycle === 'monthly' ? 3900 : 39000;
-  return 0;
+  const pricing = getPlanPricing(plan);
+  return cycle === 'monthly' ? pricing.monthlyCents : pricing.annualCents;
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/pages/api/payments/webhook.ts
+++ b/pages/api/payments/webhook.ts
@@ -3,7 +3,7 @@ import { verifyJazzCash } from '@/lib/payments/jazzcash';
 import { verifyEasypaisa } from '@/lib/payments/easypaisa';
 import { verifyCard } from '@/lib/payments/card';
 import { verifySafepay } from '@/lib/payments/safepay';
-import { supabaseService } from '@/lib/supabaseService';
+import { upsertSubscriptionStateFromWebhook } from '@/lib/subscription';
 
 type Provider = 'jazzcash' | 'easypaisa' | 'card' | 'safepay';
 
@@ -31,18 +31,13 @@ export default async function webhook(req: NextApiRequest, res: NextApiResponse)
   if (!valid) return res.status(400).json({ error: 'Invalid signature' });
 
   const { paymentId, subscriptionId, userId } = req.body;
-  if (paymentId) {
-    await supabaseService
-      .from('payments')
-      .update({ status: 'paid', provider, provider_payment_id: paymentId })
-      .eq('id', paymentId);
-  }
-  if (subscriptionId && userId) {
-    await supabaseService
-      .from('subscriptions')
-      .update({ status: 'active' })
-      .eq('id', subscriptionId)
-      .eq('user_id', userId);
+  if (userId) {
+    await upsertSubscriptionStateFromWebhook({
+      userId,
+      subscriptionId: subscriptionId ?? null,
+      paymentId: paymentId ?? null,
+      provider,
+    });
   }
   return res.json({ ok: true });
 }

--- a/pages/api/payments/webhook.ts
+++ b/pages/api/payments/webhook.ts
@@ -3,7 +3,7 @@ import { verifyJazzCash } from '@/lib/payments/jazzcash';
 import { verifyEasypaisa } from '@/lib/payments/easypaisa';
 import { verifyCard } from '@/lib/payments/card';
 import { verifySafepay } from '@/lib/payments/safepay';
-import { upsertSubscriptionStateFromWebhook } from '@/lib/subscription';
+import { applySubscriptionActivation } from '@/lib/subscription';
 
 type Provider = 'jazzcash' | 'easypaisa' | 'card' | 'safepay';
 
@@ -30,13 +30,14 @@ export default async function webhook(req: NextApiRequest, res: NextApiResponse)
   }
   if (!valid) return res.status(400).json({ error: 'Invalid signature' });
 
-  const { paymentId, subscriptionId, userId } = req.body;
+  const { paymentId, subscriptionId, userId, plan } = req.body;
   if (userId) {
-    await upsertSubscriptionStateFromWebhook({
+    await applySubscriptionActivation({
       userId,
-      subscriptionId: subscriptionId ?? null,
-      paymentId: paymentId ?? null,
+      plan: typeof plan === 'string' ? plan : 'booster',
       provider,
+      eventId: String(paymentId ?? subscriptionId ?? `${provider}:${userId}`),
+      subscriptionId: subscriptionId ?? null,
     });
   }
   return res.json({ ok: true });

--- a/pages/api/premium/eligibility.ts
+++ b/pages/api/premium/eligibility.ts
@@ -1,6 +1,7 @@
 // pages/api/premium/eligibility.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { normalizePlan } from '@/lib/subscription';
 
 // Use service role client for token verification (no refresh needed)
 const supabaseAdmin = createClient(
@@ -38,8 +39,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return res.status(200).json({ eligible: false, plan: null, reason: 'no_profile' });
   }
 
-  const plan = profile.plan as string | null;
-  const eligible = plan === 'premium' || plan === 'master';
+  const plan = normalizePlan((profile.plan as string | null) ?? 'free');
+  const eligible = plan === 'master' || plan === 'booster' || plan === 'starter';
 
   return res.status(200).json({ eligible, plan, reason: eligible ? undefined : 'plan_required' });
 }

--- a/pages/api/premium/eligibility.ts
+++ b/pages/api/premium/eligibility.ts
@@ -1,18 +1,13 @@
 // pages/api/premium/eligibility.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
-import { normalizePlan } from '@/lib/subscription';
+import { requireActiveSubscription, InactiveSubscriptionError } from '@/lib/subscription';
 
-// Use service role client for token verification (no refresh needed)
-const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+const supabaseAdmin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
 
-type Resp = { eligible: boolean; plan: string | null; reason?: string };
+type Resp = { eligible: boolean; plan: string | null; reason?: string; upgrade?: Record<string, unknown> } | Record<string, unknown>;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Resp>) {
-  // Validate environment
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
     return res.status(500).json({ eligible: false, plan: null, reason: 'server_config_error' });
   }
@@ -22,25 +17,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return res.status(200).json({ eligible: false, plan: null, reason: 'unauthenticated' });
   }
 
-  // Verify token using service role
-  const { data: { user }, error } = await supabaseAdmin.auth.getUser(token);
+  const {
+    data: { user },
+    error,
+  } = await supabaseAdmin.auth.getUser(token);
   if (error || !user) {
     return res.status(200).json({ eligible: false, plan: null, reason: 'unauthenticated' });
   }
 
-  // Fetch user's plan
-  const { data: profile, error: profileError } = await supabaseAdmin
-    .from('profiles')
-    .select('plan')
-    .eq('id', user.id)
-    .single();
-
-  if (profileError || !profile) {
-    return res.status(200).json({ eligible: false, plan: null, reason: 'no_profile' });
+  try {
+    const active = await requireActiveSubscription(user.id);
+    return res.status(200).json({ eligible: true, plan: active.plan });
+  } catch (err) {
+    if (err instanceof InactiveSubscriptionError) {
+      return res.status(err.statusCode).json({ ...err.payload, eligible: false, plan: err.payload.currentPlan });
+    }
+    throw err;
   }
-
-  const plan = normalizePlan((profile.plan as string | null) ?? 'free');
-  const eligible = plan === 'master' || plan === 'booster' || plan === 'starter';
-
-  return res.status(200).json({ eligible, plan, reason: eligible ? undefined : 'plan_required' });
 }

--- a/pages/api/premium/status.ts
+++ b/pages/api/premium/status.ts
@@ -1,46 +1,44 @@
 // pages/api/premium/status.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createClient } from '@supabase/supabase-js';
+import { getActiveSubscription, isSubscriptionActive } from '@/lib/subscription';
 
-const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
+const supabaseAdmin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
 
 type Resp = {
   pinOk: boolean;
   loggedIn: boolean;
   userId: string | null;
   plan: string | null;
+  active: boolean;
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Resp>) {
   if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    return res.status(500).json({ pinOk: false, loggedIn: false, userId: null, plan: null });
+    return res.status(500).json({ pinOk: false, loggedIn: false, userId: null, plan: null, active: false });
   }
 
   const pinOk = req.cookies?.pr_pin_ok === '1';
-
   const token = req.headers.authorization?.split(' ')[1];
   if (!token) {
-    return res.status(200).json({ pinOk, loggedIn: false, userId: null, plan: null });
+    return res.status(200).json({ pinOk, loggedIn: false, userId: null, plan: null, active: false });
   }
 
-  const { data: { user }, error } = await supabaseAdmin.auth.getUser(token);
+  const {
+    data: { user },
+    error,
+  } = await supabaseAdmin.auth.getUser(token);
   if (error || !user) {
-    return res.status(200).json({ pinOk, loggedIn: false, userId: null, plan: null });
+    return res.status(200).json({ pinOk, loggedIn: false, userId: null, plan: null, active: false });
   }
 
-  const { data: profile } = await supabaseAdmin
-    .from('profiles')
-    .select('plan')
-    .eq('id', user.id)
-    .single();
+  const [subscription, active] = await Promise.all([getActiveSubscription(user.id), isSubscriptionActive(user.id)]);
 
   return res.status(200).json({
     pinOk,
     loggedIn: true,
     userId: user.id,
-    plan: (profile?.plan ?? null) as string | null,
+    plan: subscription.plan,
+    active,
   });
 }

--- a/pages/api/subscription/active.ts
+++ b/pages/api/subscription/active.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { getServerClient } from '@/lib/supabaseServer';
+import { getActiveSubscription, isSubscriptionActive } from '@/lib/subscription';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ ok: false, error: 'method_not_allowed' });
+
+  const supabase = getServerClient(req, res);
+  const { data: auth } = await supabase.auth.getUser();
+  const userId = auth.user?.id;
+
+  if (!userId) return res.status(200).json({ ok: false, active: false, subscription: null });
+
+  const subscription = await getActiveSubscription(userId);
+  const active = await isSubscriptionActive(userId);
+  return res.status(200).json({ ok: true, active, subscription });
+}

--- a/pages/api/subscription/feature-access.ts
+++ b/pages/api/subscription/feature-access.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { getServerClient } from '@/lib/supabaseServer';
+import { getFeatureAccess } from '@/lib/subscription';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ ok: false, error: 'method_not_allowed', access: false });
+
+  const feature = typeof req.query.feature === 'string' ? req.query.feature : '';
+  if (!feature) return res.status(400).json({ ok: false, error: 'feature_required', access: false });
+
+  const supabase = getServerClient(req, res);
+  const { data: auth } = await supabase.auth.getUser();
+  const userId = auth.user?.id;
+
+  if (!userId) return res.status(200).json({ ok: false, access: false });
+
+  const access = await getFeatureAccess(userId, feature);
+  return res.status(200).json({ ok: true, access, feature });
+}

--- a/pages/api/subscription/plan.ts
+++ b/pages/api/subscription/plan.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { getServerClient } from '@/lib/supabaseServer';
+import { getUserPlan } from '@/lib/subscription';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ ok: false, error: 'method_not_allowed', plan: 'free' });
+
+  const supabase = getServerClient(req, res);
+  const { data: auth } = await supabase.auth.getUser();
+  const userId = auth.user?.id;
+
+  if (!userId) return res.status(200).json({ ok: false, plan: 'free' });
+
+  const plan = await getUserPlan(userId);
+  return res.status(200).json({ ok: true, plan });
+}

--- a/pages/api/subscriptions/portal.ts
+++ b/pages/api/subscriptions/portal.ts
@@ -2,7 +2,7 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { env } from '@/lib/env';
-import { normalizePlan, normalizeSubscriptionStatus } from '@/lib/subscription';
+import { getCanonicalSubscription } from '@/lib/subscription';
 
 type Invoice = Readonly<{
   id: string;
@@ -39,17 +39,9 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
   const userId = userResp.user?.id;
   if (!userId) return res.status(401).json({ ok: false, error: 'Unauthorized' });
 
-  // Look up Stripe customer id from your profiles table
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('stripe_customer_id, membership, subscription_status, subscription_renews_at, trial_ends_at')
-    .eq('id', userId)
-    .maybeSingle();
+  const canonical = await getCanonicalSubscription(userId);
+  const customerId = canonical.customerId ?? undefined;
 
-  const customerId = profile?.stripe_customer_id as string | undefined;
-
-  // If the request is a form POST (no JSON) we assume "Open customer portal" and redirect.
-  // You can also set a header `x-open-portal: 1` to force redirect mode.
   const openPortal =
     req.headers['x-open-portal'] === '1' ||
     (req.headers['content-type']?.includes('application/x-www-form-urlencoded') ?? false);
@@ -75,34 +67,34 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
     return res.status(303).end();
   }
 
-  // JSON summary mode (used by pages/account/billing.tsx)
   if (!stripe || !customerId) {
     const fallback: SummaryResponse = {
       subscription: {
-        plan: normalizePlan((profile?.membership as string | null | undefined) ?? 'free'),
-        status: normalizeSubscriptionStatus(profile?.subscription_status as string | null | undefined),
-        renewsAt: profile?.subscription_renews_at || undefined,
-        trialEndsAt: profile?.trial_ends_at || undefined,
+        plan: canonical.plan,
+        status: canonical.status,
+        renewsAt: canonical.renewsAt,
+        trialEndsAt: canonical.trialEndsAt,
       },
       invoices: [],
     };
     return res.status(200).json(fallback);
   }
 
-  // Pull latest subscription + last few invoices
   const subs = await stripe.subscriptions.list({ customer: customerId, status: 'all', limit: 1 });
   const sub = subs.data[0];
-  const priceNickname =
-    (sub?.items?.data?.[0]?.price?.nickname?.toLowerCase() as SubscriptionSummary['plan']) ||
-    (profile?.membership as any) ||
-    'free';
 
   const summary: SubscriptionSummary = {
-    plan: normalizePlan(priceNickname),
-    status: normalizeSubscriptionStatus(sub?.status),
-    renewsAt: sub?.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : undefined,
-    trialEndsAt: sub?.trial_end ? new Date(sub.trial_end * 1000).toISOString() : undefined,
+    plan: canonical.plan,
+    status: canonical.status,
+    renewsAt: canonical.renewsAt,
+    trialEndsAt: canonical.trialEndsAt,
   };
+
+  if (sub) {
+    summary.status = canonical.status;
+    summary.renewsAt = canonical.renewsAt ?? (sub.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : undefined);
+    summary.trialEndsAt = canonical.trialEndsAt ?? (sub.trial_end ? new Date(sub.trial_end * 1000).toISOString() : undefined);
+  }
 
   const invs = await stripe.invoices.list({ customer: customerId, limit: 12 });
   const invoices: Invoice[] = invs.data.map((i) => ({

--- a/pages/api/subscriptions/portal.ts
+++ b/pages/api/subscriptions/portal.ts
@@ -2,6 +2,7 @@
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { createSupabaseServerClient } from '@/lib/supabaseServer';
 import { env } from '@/lib/env';
+import { normalizePlan, normalizeSubscriptionStatus } from '@/lib/subscription';
 
 type Invoice = Readonly<{
   id: string;
@@ -78,8 +79,8 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
   if (!stripe || !customerId) {
     const fallback: SummaryResponse = {
       subscription: {
-        plan: (profile?.membership as any) || 'free',
-        status: (profile?.subscription_status as any) || 'canceled',
+        plan: normalizePlan((profile?.membership as string | null | undefined) ?? 'free'),
+        status: normalizeSubscriptionStatus(profile?.subscription_status as string | null | undefined),
         renewsAt: profile?.subscription_renews_at || undefined,
         trialEndsAt: profile?.trial_ends_at || undefined,
       },
@@ -97,8 +98,8 @@ const handler: NextApiHandler<ResBody> = async (req, res) => {
     'free';
 
   const summary: SubscriptionSummary = {
-    plan: ['starter', 'booster', 'master'].includes(priceNickname) ? priceNickname : 'free',
-    status: ((sub?.status as SubscriptionSummary['status']) || 'canceled'),
+    plan: normalizePlan(priceNickname),
+    status: normalizeSubscriptionStatus(sub?.status),
     renewsAt: sub?.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : undefined,
     trialEndsAt: sub?.trial_end ? new Date(sub.trial_end * 1000).toISOString() : undefined,
   };

--- a/pages/api/webhooks/payment.ts
+++ b/pages/api/webhooks/payment.ts
@@ -6,6 +6,7 @@ import { env } from '@/lib/env';
 import { trackor } from '@/lib/analytics/trackor.server';
 import { queueNotificationEvent, getNotificationContact } from '@/lib/notify';
 import { getBaseUrl } from '@/lib/url';
+import { applySubscriptionActivation, applySubscriptionRenewal, applySubscriptionTransition } from '@/lib/subscription';
 
 // Important: disable body parsing so we can verify Stripe signatures
 export const config = { api: { bodyParser: false } };
@@ -100,30 +101,16 @@ const handler: NextApiHandler<Ok | Err> = async (req, res) => {
 
         const userId = session.client_reference_id;
         const plan = (session.metadata?.plan as 'starter' | 'booster' | 'master' | undefined) || 'booster';
-
-        if (userId) {
-          // Update profile entitlements
-          await supabase
-            .from('profiles')
-            .update({
-              membership: plan,
-              subscription_status: 'active',
-              stripe_customer_id: session.customer,
-              subscription_renews_at: null,
-              trial_ends_at: null,
-              premium_until: null,
-              updated_at: new Date().toISOString(),
-            })
-            .eq('id', userId);
-        }
+        let intent: { id: string; user_id: string | null; plan_id: string; cycle: string } | null = null;
 
         if (session.id) {
-          const { data: intent } = await supabase
+          const intentRes = await supabase
             .from('payment_intents')
             .select('id, user_id, plan_id, cycle')
             .eq('gateway_session_id', session.id)
             .eq('provider', 'stripe')
             .maybeSingle();
+          intent = (intentRes.data as any) ?? null;
 
           if (intent) {
             const confirmedAt = new Date().toISOString();
@@ -147,6 +134,17 @@ const handler: NextApiHandler<Ok | Err> = async (req, res) => {
               cycle: intent.cycle,
             });
           }
+        }
+
+        if (userId) {
+          await applySubscriptionActivation({
+            userId,
+            plan: (intent?.plan_id as any) ?? plan,
+            provider: 'stripe',
+            eventId: event.id,
+            subscriptionId: session.subscription ?? session.id,
+            customerId: session.customer,
+          });
         }
 
         await supabase.from('payment_events').insert([
@@ -182,11 +180,20 @@ const handler: NextApiHandler<Ok | Err> = async (req, res) => {
         if (invoice.customer) {
           const { data: profile } = await supabase
             .from('profiles')
-            .select('user_id')
+            .select('id')
             .eq('stripe_customer_id', invoice.customer as string)
-            .maybeSingle<{ user_id: string }>();
+            .maybeSingle<{ id: string }>();
 
-          await notifyPayment(profile?.user_id ?? null, 'payment_success', invoice.id, {
+          if (profile?.id) {
+            await applySubscriptionRenewal({
+              userId: profile.id,
+              provider: 'stripe',
+              eventId: event.id,
+              subscriptionId: invoice.subscription as string | undefined,
+            });
+          }
+
+          await notifyPayment(profile?.id ?? null, 'payment_success', invoice.id, {
             provider: 'stripe',
             amount: invoice.amount_paid,
             currency: invoice.currency,
@@ -212,15 +219,25 @@ const handler: NextApiHandler<Ok | Err> = async (req, res) => {
         if (invoice.customer) {
           const { data: profile } = await supabase
             .from('profiles')
-            .select('user_id')
+            .select('id')
             .eq('stripe_customer_id', invoice.customer as string)
-            .maybeSingle<{ user_id: string }>();
+            .maybeSingle<{ id: string }>();
 
           const reason =
             (invoice.last_payment_error?.message as string | undefined) ??
             'Payment failed';
 
-          await notifyPayment(profile?.user_id ?? null, 'payment_failed', invoice.id, {
+          if (profile?.id) {
+            await applySubscriptionTransition({
+              userId: profile.id,
+              provider: 'stripe',
+              eventId: event.id,
+              subscriptionId: invoice.subscription as string | undefined,
+              status: 'past_due',
+            });
+          }
+
+          await notifyPayment(profile?.id ?? null, 'payment_failed', invoice.id, {
             provider: 'stripe',
             amount: invoice.amount_due,
             currency: invoice.currency,
@@ -235,45 +252,48 @@ const handler: NextApiHandler<Ok | Err> = async (req, res) => {
       case 'customer.subscription.updated':
       case 'customer.subscription.deleted': {
         const sub = event.data.object as any;
-        // Best-effort: if you store customer->user mapping, update profile
         try {
           const customerId: string | undefined = sub.customer;
           if (customerId) {
             const { data: prof } = await supabase
               .from('profiles')
-              .select('id, membership')
+              .select('id')
               .eq('stripe_customer_id', customerId)
               .maybeSingle();
+
             if (prof?.id) {
-              const status = (sub.status as string | undefined) || 'canceled';
-              const periodEnd =
+              const renewsAt =
                 typeof sub.current_period_end === 'number'
                   ? new Date(sub.current_period_end * 1000).toISOString()
                   : null;
-              const trialEnd =
+              const trialEndsAt =
                 typeof sub.trial_end === 'number'
                   ? new Date(sub.trial_end * 1000).toISOString()
                   : null;
+              const stripeStatus = (sub.status as string | undefined) ?? 'canceled';
 
-              const shouldDowngrade =
-                status === 'canceled' || status === 'past_due' || status === 'unpaid';
-
-              const updates: Record<string, any> = {
-                subscription_status: status,
-                subscription_renews_at: periodEnd,
-                trial_ends_at: trialEnd,
-                updated_at: new Date().toISOString(),
-              };
-
-              if (shouldDowngrade) {
-                updates.membership = 'free';
-                updates.premium_until = null;
+              if (stripeStatus === 'active' || stripeStatus === 'trialing') {
+                await applySubscriptionActivation({
+                  userId: prof.id,
+                  plan: ((sub.items?.data?.[0]?.price?.nickname as string | undefined) ?? 'booster') as any,
+                  provider: 'stripe',
+                  eventId: event.id,
+                  subscriptionId: sub.id,
+                  renewsAt,
+                  trialEndsAt,
+                  customerId,
+                });
+              } else {
+                await applySubscriptionTransition({
+                  userId: prof.id,
+                  provider: 'stripe',
+                  eventId: event.id,
+                  subscriptionId: sub.id,
+                  renewsAt,
+                  trialEndsAt,
+                  status: stripeStatus === 'unpaid' ? 'unpaid' : stripeStatus === 'past_due' ? 'past_due' : 'canceled',
+                });
               }
-
-              await supabase
-                .from('profiles')
-                .update(updates)
-                .eq('id', prof.id);
             }
           }
         } catch {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import Icon, { type IconName } from '@/components/design-system/Icon';
+import { getStandardPlanName } from '@/lib/subscription';
 
 const modules = [
   {
@@ -130,7 +131,7 @@ const quickLinks = [
   },
   {
     label: 'Check pricing & plans',
-    description: 'Free vs Rocket vs higher tiers.',
+    description: 'Free vs Booster vs higher tiers.',
     href: '/pricing',
     icon: 'CreditCard' as IconName,
   },
@@ -166,7 +167,7 @@ const testimonials = [
 const plans = [
   {
     id: 'free',
-    name: 'Free',
+    name: getStandardPlanName('free'),
     price: '0',
     tag: 'Start here',
     bullets: [
@@ -176,8 +177,8 @@ const plans = [
     ],
   },
   {
-    id: 'rocket',
-    name: 'Rocket',
+    id: 'booster',
+    name: getStandardPlanName('booster'),
     price: 'Best for 6.5 → 7.5+',
     tag: 'Most popular',
     bullets: [
@@ -271,7 +272,7 @@ const LandingPage: React.FC = () => {
                     <Icon name="ShieldCheck" size={14} /> No-card free tier
                   </span>
                   <span>•</span>
-                  <span>AI usage is capped on Free and unlocked on Rocket</span>
+                  <span>AI usage is capped on Free and unlocked on Booster</span>
                 </div>
               </div>
 
@@ -554,7 +555,7 @@ const LandingPage: React.FC = () => {
                   Start free. Upgrade when you’re serious.
                 </h2>
                 <p className="mt-1 text-small text-grayish md:max-w-xl">
-                  Free covers basic practice and a taste of AI. Rocket unlocks deeper
+                  Free covers basic practice and a taste of AI. Booster unlocks deeper
                   feedback and more mocks. Institutional is for teachers and academies.
                 </p>
               </div>
@@ -607,7 +608,7 @@ const LandingPage: React.FC = () => {
                     <Button
                       asChild
                       size="sm"
-                      variant={plan.id === 'rocket' ? 'primary' : 'secondary'}
+                      variant={plan.id === 'booster' ? 'primary' : 'secondary'}
                       className="w-full rounded-ds-xl"
                     >
                       <Link href="/pricing">
@@ -639,7 +640,7 @@ const LandingPage: React.FC = () => {
                     no spam, no fake urgency.
                   </p>
                   <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
-                    <li>• First wave gets discounted Rocket pricing.</li>
+                    <li>• First wave gets discounted Booster pricing.</li>
                     <li>• Teachers / academies can request a separate call.</li>
                   </ul>
                 </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import Icon, { type IconName } from '@/components/design-system/Icon';
-import { getStandardPlanName } from '@/lib/subscription';
+import { getPlanPricing, getStandardPlanName } from '@/lib/subscription';
 
 const modules = [
   {
@@ -164,11 +164,11 @@ const testimonials = [
   },
 ];
 
-const plans = [
+export const LANDING_PLANS = [
   {
     id: 'free',
     name: getStandardPlanName('free'),
-    price: '0',
+    price: `$${getPlanPricing('free').monthly}`,
     tag: 'Start here',
     bullets: [
       'Access to all four modules in limited mode',
@@ -179,7 +179,7 @@ const plans = [
   {
     id: 'booster',
     name: getStandardPlanName('booster'),
-    price: 'Best for 6.5 → 7.5+',
+    price: `$${getPlanPricing('booster').monthly}/mo`,
     tag: 'Most popular',
     bullets: [
       'Deeper AI writing + speaking feedback',
@@ -570,7 +570,7 @@ const LandingPage: React.FC = () => {
             </div>
 
             <div className="grid gap-5 md:grid-cols-3">
-              {plans.map((plan) => (
+              {LANDING_PLANS.map((plan) => (
                 <Card
                   key={plan.id}
                   className={`flex h-full flex-col justify-between rounded-ds-2xl border border-border/70 bg-card/80 p-6 ${

--- a/pages/pricing/overview.tsx
+++ b/pages/pricing/overview.tsx
@@ -12,6 +12,7 @@ import { ProgressBar } from '@/components/design-system/ProgressBar';
 import { Separator } from '@/components/design-system/Separator';
 
 import { usePlan } from '@/hooks/usePlan';
+import { getStandardPlanName, normalizePlan } from '@/lib/subscription';
 
 // Optional: plan selector already in your repo
 import PlanPicker from '@/components/payments/PlanPicker';
@@ -89,7 +90,7 @@ const PricingOverviewPage: React.FC = () => {
   const [counters, setCounters] = useState<CountersResponse>({});
   const [sub, setSub] = useState<SubscriptionSummary | null>(null);
 
-  const planLabel = (hookPlan ?? sub?.plan ?? 'free').toString();
+  const planLabel = getStandardPlanName(normalizePlan((hookPlan ?? sub?.plan ?? 'free').toString()));
 
   // Counters (non-fatal if unauthenticated)
   useEffect(() => {
@@ -154,7 +155,7 @@ const PricingOverviewPage: React.FC = () => {
                 Your current plan, quotas and upgrade options.
               </p>
             </div>
-            <Badge variant="brand">{planLabel.toUpperCase()}</Badge>
+            <Badge variant="brand">{planLabel}</Badge>
           </div>
 
           {/* Your Plan */}

--- a/pages/writing/library.tsx
+++ b/pages/writing/library.tsx
@@ -52,9 +52,9 @@ const planLibraryLimit: Record<PlanId, number> = {
 
 const planLibraryCopy: Record<PlanId, string> = {
   free: 'Preview a handful of prompts and upgrade to unlock full filters and AI tools.',
-  starter: 'Seedling members access the latest 100 prompts with full filtering.',
-  booster: 'Rocket unlocks 500 prompts with detailed outlines and metadata.',
-  master: 'Owl includes the full 500 prompt vault and on-demand AI generation.',
+  starter: 'Starter members access the latest 100 prompts with full filtering.',
+  booster: 'Booster unlocks 500 prompts with detailed outlines and metadata.',
+  master: 'Master includes the full 500 prompt vault and on-demand AI generation.',
 };
 
 interface LibraryPageProps {

--- a/supabase/migrations/20260309193000_deprecate_profile_subscription_columns.sql
+++ b/supabase/migrations/20260309193000_deprecate_profile_subscription_columns.sql
@@ -1,0 +1,16 @@
+-- Stage 1: Mark legacy profile subscription columns as deprecated.
+-- These columns are now served via compatibility mapping in lib/subscription.ts
+-- and should not be used for new reads.
+
+comment on column public.profiles.membership is
+  'DEPRECATED: subscription plan should be read from public.subscriptions latest row.';
+comment on column public.profiles.plan_id is
+  'DEPRECATED: canonical subscription plan is public.subscriptions.plan_id.';
+comment on column public.profiles.subscription_status is
+  'DEPRECATED: canonical status is public.subscriptions.status.';
+comment on column public.profiles.subscription_renews_at is
+  'DEPRECATED: canonical renewal timestamp is public.subscriptions.current_period_end.';
+comment on column public.profiles.trial_ends_at is
+  'DEPRECATED: canonical trial timestamp is public.subscriptions.trial_end.';
+comment on column public.profiles.premium_until is
+  'DEPRECATED: no longer canonical; use subscription lifecycle in public.subscriptions.';

--- a/supabase/migrations/20260309194000_drop_legacy_profile_subscription_columns.sql
+++ b/supabase/migrations/20260309194000_drop_legacy_profile_subscription_columns.sql
@@ -1,0 +1,10 @@
+-- Stage 2: Remove legacy profile subscription columns after migration freeze.
+-- Run only after all application reads/writes are moved to public.subscriptions.
+
+alter table public.profiles
+  drop column if exists membership,
+  drop column if exists plan_id,
+  drop column if exists subscription_status,
+  drop column if exists subscription_renews_at,
+  drop column if exists trial_ends_at,
+  drop column if exists premium_until;

--- a/tests/lib/payments-cycle-normalization.test.ts
+++ b/tests/lib/payments-cycle-normalization.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeCycleInput } from '@/types/payments';
+
+describe('normalizeCycleInput', () => {
+  it('keeps canonical values', () => {
+    expect(normalizeCycleInput('monthly')).toBe('monthly');
+    expect(normalizeCycleInput('annual')).toBe('annual');
+  });
+
+  it('maps yearly alias to annual', () => {
+    expect(normalizeCycleInput('yearly')).toBe('annual');
+  });
+
+  it('defaults unknown/null to monthly', () => {
+    expect(normalizeCycleInput('whatever')).toBe('monthly');
+    expect(normalizeCycleInput(null)).toBe('monthly');
+    expect(normalizeCycleInput(undefined)).toBe('monthly');
+  });
+});

--- a/tests/lib/subscription-pricing-consistency.test.ts
+++ b/tests/lib/subscription-pricing-consistency.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPlanPricing } from '@/lib/subscription';
+import { amountInCents } from '@/lib/payments/gateway';
+import { priceCents } from '@/lib/billing/manual';
+
+describe('subscription pricing consistency', () => {
+  it('keeps monthly/annual major + cents coherent in service', () => {
+    for (const plan of ['free', 'starter', 'booster', 'master'] as const) {
+      const pricing = getPlanPricing(plan);
+      expect(pricing.monthlyCents).toBe(Math.round(pricing.monthly * 100));
+      expect(pricing.annualCents).toBe(Math.round(pricing.annual * 100));
+      expect(pricing.monthlyDisplayFromAnnual).toBe(pricing.annual / 12);
+    }
+  });
+
+  it('matches API/payment helper cents with service source', () => {
+    for (const plan of ['starter', 'booster', 'master'] as const) {
+      const pricing = getPlanPricing(plan);
+      expect(amountInCents(plan, 'monthly')).toBe(pricing.monthlyCents);
+      expect(amountInCents(plan, 'annual')).toBe(pricing.annualCents);
+      expect(priceCents(plan, 'monthly')).toBe(pricing.monthlyCents);
+      expect(priceCents(plan, 'annual')).toBe(pricing.annualCents);
+    }
+  });
+});

--- a/types/payments.ts
+++ b/types/payments.ts
@@ -1,6 +1,14 @@
 // types/payments.ts
 export type PlanKey = 'starter' | 'booster' | 'master';
-export type Cycle = 'monthly' | 'annual';
+export const CANONICAL_CYCLES = ['monthly', 'annual'] as const;
+export type Cycle = (typeof CANONICAL_CYCLES)[number];
+export type CycleInput = Cycle | 'yearly';
+
+export function normalizeCycleInput(input?: string | null): Cycle {
+  const value = (input ?? 'monthly').toLowerCase();
+  if (value === 'annual' || value === 'yearly') return 'annual';
+  return 'monthly';
+}
 export type PaymentMethod = 'stripe' | 'easypaisa' | 'jazzcash' | 'safepay' | 'crypto';
 
 export type CreateCheckoutBody = Readonly<{


### PR DESCRIPTION
### Motivation
- Centralize subscription and plan logic so UI and API layers use a single service for plan normalization, status normalization, tier labels, and price lookup.
- Provide a small server-side API surface for subscription queries and feature-access checks to simplify client hooks and prevent duplicated logic.
- Offer lightweight client hooks to consume the subscription API (`useSubscription`, `useIsActive`, `useFeatureAccess`) and replace scattered plan/status derivations across the codebase.

### Description
- Added `lib/subscription.ts` implementing `getActiveSubscription`, `isSubscriptionActive`, `requireActiveSubscription`, `getUserPlan`, `getFeatureAccess`, `getPlanPricing`, `getPlanTiers`, `getStandardPlanName`, and shared `normalizePlan`/`normalizeSubscriptionStatus` helpers.
- Moved plan normalization, status normalization, tier labels, and pricing lookup into `lib/subscription.ts` and updated `lib/subscriptions.ts` to keep Stripe DTO mapping while delegating normalization and re-exporting helpers.
- Added server endpoints `GET /api/subscription/active`, `GET /api/subscription/plan`, and `GET /api/subscription/feature-access?feature=...` backed by `lib/subscription.ts`.
- Added client hooks `hooks/useSubscription.ts`, `hooks/useIsActive.ts`, and `hooks/useFeatureAccess.ts`, updated `hooks/usePlan.ts` to use `/api/subscription/plan`, and replaced direct plan/status derivations in `pages/api/me/plan.ts`, `pages/api/subscriptions/portal.ts`, `pages/api/debug/feature-flags.ts`, `lib/apiGuard.ts`, and `lib/api/withPlan.ts` to use the new service.

### Testing
- Attempted to run the test suite with `npm run -s test -- --runInBand`, but the job failed in this environment due to missing runtime tooling (`tsx` not available).
- Ran a TypeScript check with `npx tsc --noEmit`, which reported a pre-existing parse error in `pages/writing/index.tsx` unrelated to these changes.
- Ran `npm run lint`, which could not execute here because `next` is not installed in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af1be113508328983d7a0a15ff917d)