### PR TITLE
Expand onboarding flow to 12 steps, add AI diagnostic and onboarding settings

### DIFF
--- a/lib/onboarding/client.ts
+++ b/lib/onboarding/client.ts
@@ -1,0 +1,28 @@
+import type { OnboardingStepId } from './steps';
+import { getNextStep, getPrevStep, getStepIndex, ONBOARDING_STEPS } from './steps';
+
+export { ONBOARDING_STEPS, getStepIndex, getNextStep, getPrevStep };
+
+export async function saveOnboardingStep(step: number, data: Record<string, unknown>) {
+  const res = await fetch('/api/onboarding', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ step, data }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error || 'Failed to save onboarding step');
+  }
+
+  return res.json();
+}
+
+export function resolveNavigation(stepId: OnboardingStepId) {
+  return {
+    index: getStepIndex(stepId),
+    total: ONBOARDING_STEPS.length,
+    next: getNextStep(stepId),
+    prev: getPrevStep(stepId),
+  };
+}

--- a/lib/onboarding/schema.ts
+++ b/lib/onboarding/schema.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
 const supportedLanguageCodes = ['en', 'ur'] as const;
+const cefrLevels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const;
+const learningStyles = ['visual', 'auditory', 'reading_writing', 'kinesthetic', 'mixed'] as const;
+const weaknesses = ['listening', 'reading', 'writing', 'speaking', 'grammar', 'vocabulary'] as const;
 
 export const languageOptions = [
   { value: 'en', label: 'English' },
@@ -9,7 +12,40 @@ export const languageOptions = [
 
 const LanguageEnum = z.enum(supportedLanguageCodes);
 const StudyDayEnum = z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const);
+const CEFRLevelEnum = z.enum(cefrLevels);
+const LearningStyleEnum = z.enum(learningStyles);
+const WeaknessEnum = z.enum(weaknesses);
+export const NotificationChannelEnum = z.enum(['in_app', 'whatsapp', 'email'] as const);
 const PhoneSchema = z.union([z.string().min(6).max(32), z.literal('')]);
+
+export const LanguageBody = z.object({
+  language: LanguageEnum,
+});
+
+export const TargetBandBody = z.object({
+  targetBand: z.number().min(4).max(9),
+});
+
+export const ExamDateBody = z.object({
+  timeframe: z.string().trim().min(1),
+  examDate: z.string().trim().min(1).optional().nullable(),
+});
+
+export const StudyRhythmBody = z.object({
+  rhythm: z.string().trim().min(1),
+});
+
+export const NotificationsBody = z.object({
+  channels: z.array(NotificationChannelEnum).min(1),
+  preferredTime: z.string().trim().min(1).optional().nullable(),
+});
+
+const DiagnosticResultSchema = z.object({
+  grammar: z.string().min(1),
+  coherence: z.string().min(1),
+  vocabulary: z.string().min(1),
+  estimated_band: z.number().min(0).max(9),
+});
 
 export const onboardingStateSchema = z.object({
   preferredLanguage: LanguageEnum.nullable(),
@@ -19,45 +55,84 @@ export const onboardingStateSchema = z.object({
   studyMinutesPerDay: z.number().int().min(10).max(360).nullable(),
   whatsappOptIn: z.boolean().nullable(),
   phone: PhoneSchema.nullable(),
+  currentLevel: CEFRLevelEnum.nullable().optional(),
+  previousIelts: z
+    .object({
+      taken: z.boolean(),
+      overallBand: z.number().min(0).max(9).nullable().optional(),
+      testDate: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+  examTimeline: z
+    .object({
+      timeframe: z.string(),
+      examDate: z.string().nullable(),
+    })
+    .nullable()
+    .optional(),
+  studyCommitment: z
+    .object({
+      daysPerWeek: z.number().int().min(1).max(7),
+      minutesPerDay: z.number().int().min(10).max(360),
+    })
+    .nullable()
+    .optional(),
+  learningStyle: LearningStyleEnum.nullable().optional(),
+  weaknesses: z.array(WeaknessEnum).max(3).nullable().optional(),
+  confidence: z
+    .object({
+      writing: z.number().int().min(1).max(5),
+      speaking: z.number().int().min(1).max(5),
+    })
+    .nullable()
+    .optional(),
+  diagnostic: DiagnosticResultSchema.nullable().optional(),
   onboardingStep: z.number().int().min(0),
   onboardingComplete: z.boolean(),
 });
 
 export type OnboardingState = z.infer<typeof onboardingStateSchema>;
 
-const StepOneSchema = z.object({
-  step: z.literal(1),
+const StepOneSchema = z.object({ step: z.literal(1), data: z.object({}) });
+const StepTwoSchema = z.object({ step: z.literal(2), data: z.object({ preferredLanguage: LanguageEnum }) });
+const StepThreeSchema = z.object({ step: z.literal(3), data: z.object({ currentLevel: CEFRLevelEnum }) });
+const StepFourSchema = z.object({
+  step: z.literal(4),
   data: z.object({
-    preferredLanguage: LanguageEnum,
+    taken: z.boolean(),
+    overallBand: z.number().min(0).max(9).optional().nullable(),
+    testDate: z.string().optional().nullable(),
   }),
 });
-
-const StepTwoSchema = z.object({
-  step: z.literal(2),
+const StepFiveSchema = z.object({ step: z.literal(5), data: z.object({ goalBand: z.number().min(4).max(9) }) });
+const StepSixSchema = z.object({
+  step: z.literal(6),
   data: z.object({
-    goalBand: z.number().min(4).max(9),
-  }),
-});
-
-const StepThreeSchema = z.object({
-  step: z.literal(3),
-  data: z.object({
+    timeframe: z.string().min(1),
     examDate: z.union([z.string(), z.null()]).optional().nullable(),
   }),
 });
-
-const StepFourSchema = z.object({
-  step: z.literal(4),
+const StepSevenSchema = z.object({
+  step: z.literal(7),
   data: z.object({
     studyDays: z.array(StudyDayEnum).min(1),
     minutesPerDay: z.number().int().min(10).max(360),
   }),
 });
-
-const StepFiveSchema = z.object({
-  step: z.literal(5),
+const StepEightSchema = z.object({ step: z.literal(8), data: z.object({ learningStyle: LearningStyleEnum }) });
+const StepNineSchema = z.object({ step: z.literal(9), data: z.object({ weaknesses: z.array(WeaknessEnum).min(1).max(3) }) });
+const StepTenSchema = z.object({
+  step: z.literal(10),
+  data: z.object({ writing: z.number().int().min(1).max(5), speaking: z.number().int().min(1).max(5) }),
+});
+const StepElevenSchema = z.object({ step: z.literal(11), data: z.object({ response: z.string().min(20), result: DiagnosticResultSchema.optional() }) });
+const StepTwelveSchema = z.object({
+  step: z.literal(12),
   data: z.object({
-    whatsappOptIn: z.boolean(),
+    channels: z.array(NotificationChannelEnum).min(1),
+    preferredTime: z.string().trim().min(1).optional().nullable(),
+    whatsappOptIn: z.boolean().optional(),
     phone: z.string().trim().optional().nullable(),
   }),
 });
@@ -68,11 +143,18 @@ export const onboardingStepPayloadSchema = z.discriminatedUnion('step', [
   StepThreeSchema,
   StepFourSchema,
   StepFiveSchema,
+  StepSixSchema,
+  StepSevenSchema,
+  StepEightSchema,
+  StepNineSchema,
+  StepTenSchema,
+  StepElevenSchema,
+  StepTwelveSchema,
 ]);
 
 export type OnboardingStepPayload = z.infer<typeof onboardingStepPayloadSchema>;
 
-export const TOTAL_ONBOARDING_STEPS = 5;
+export const TOTAL_ONBOARDING_STEPS = 12;
 
 export const languageOptionsEnum = LanguageEnum;
 export const studyDayOptionsEnum = StudyDayEnum;

--- a/lib/onboarding/steps.ts
+++ b/lib/onboarding/steps.ts
@@ -1,0 +1,55 @@
+export type OnboardingStepId =
+  | 'welcome'
+  | 'language'
+  | 'current-level'
+  | 'previous-ielts'
+  | 'target-band'
+  | 'exam-timeline'
+  | 'study-commitment'
+  | 'learning-style'
+  | 'weakness'
+  | 'confidence'
+  | 'diagnostic'
+  | 'notifications';
+
+export type OnboardingStepDef = {
+  id: OnboardingStepId;
+  step: number;
+  label: string;
+  path: string;
+};
+
+export const ONBOARDING_STEPS: OnboardingStepDef[] = [
+  { id: 'welcome', step: 1, label: 'Welcome', path: '/onboarding/welcome' },
+  { id: 'language', step: 2, label: 'Language', path: '/onboarding' },
+  { id: 'current-level', step: 3, label: 'Current level', path: '/onboarding/current-level' },
+  { id: 'previous-ielts', step: 4, label: 'Previous IELTS', path: '/onboarding/previous-ielts' },
+  { id: 'target-band', step: 5, label: 'Target band', path: '/onboarding/target-band' },
+  { id: 'exam-timeline', step: 6, label: 'Exam timeline', path: '/onboarding/exam-timeline' },
+  { id: 'study-commitment', step: 7, label: 'Study commitment', path: '/onboarding/study-commitment' },
+  { id: 'learning-style', step: 8, label: 'Learning style', path: '/onboarding/learning-style' },
+  { id: 'weakness', step: 9, label: 'Weakness', path: '/onboarding/weakness' },
+  { id: 'confidence', step: 10, label: 'Confidence', path: '/onboarding/confidence' },
+  { id: 'diagnostic', step: 11, label: 'Diagnostic', path: '/onboarding/diagnostic' },
+  { id: 'notifications', step: 12, label: 'Notifications', path: '/onboarding/notifications' },
+];
+
+const byId = new Map(ONBOARDING_STEPS.map((s) => [s.id, s] as const));
+
+export function getStepById(id: OnboardingStepId): OnboardingStepDef {
+  return byId.get(id)!;
+}
+
+export function getStepIndex(id: OnboardingStepId): number {
+  return ONBOARDING_STEPS.findIndex((s) => s.id === id);
+}
+
+export function getNextStep(id: OnboardingStepId): OnboardingStepDef | null {
+  const index = getStepIndex(id);
+  return index >= 0 && index < ONBOARDING_STEPS.length - 1 ? ONBOARDING_STEPS[index + 1] : null;
+}
+
+export function getPrevStep(id: OnboardingStepId): OnboardingStepDef | null {
+  const index = getStepIndex(id);
+  return index > 0 ? ONBOARDING_STEPS[index - 1] : null;
+}

--- a/lib/studyPlan.ts
+++ b/lib/studyPlan.ts
@@ -72,6 +72,25 @@ export const PlanGenOptionsSchema = z
         { message: 'duplicate_day' },
       ),
     weaknesses: z.array(z.string().min(1)).max(16).optional(),
+    currentLevel: z.string().optional(),
+    previousIelts: z
+      .object({
+        taken: z.boolean(),
+        overallBand: z.number().min(0).max(9).nullable().optional(),
+        testDate: z.string().nullable().optional(),
+      })
+      .optional(),
+    confidence: z.object({ writing: z.number().min(1).max(5), speaking: z.number().min(1).max(5) }).optional(),
+    diagnostic: z
+      .object({
+        grammar: z.string(),
+        coherence: z.string(),
+        vocabulary: z.string(),
+        estimated_band: z.number().min(0).max(9),
+      })
+      .optional(),
+    minutesPerDay: z.number().int().min(10).max(360).optional(),
+    daysPerWeek: z.number().int().min(1).max(7).optional(),
   })
   .strict();
 
@@ -149,9 +168,9 @@ function defaultMinutes(type: TaskType): number {
   }
 }
 
-function computeIntensity(targetBand: number): number {
-  // Around band 6 => neutral. Above => slightly more volume, below => gentler pace.
-  const delta = targetBand - 6;
+function computeIntensity(targetBand: number, baselineBand?: number): number {
+  const anchor = typeof baselineBand === 'number' ? baselineBand : 6;
+  const delta = targetBand - anchor;
   return clamp(1 + delta * 0.15, 0.85, 1.35);
 }
 

--- a/pages/api/ai/diagnostic.ts
+++ b/pages/api/ai/diagnostic.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+import { ai, AI_MODEL } from '@/lib/ai';
+
+const BodySchema = z.object({ response: z.string().min(20).max(4000) });
+const DiagnosticSchema = z.object({
+  grammar: z.string().min(1),
+  coherence: z.string().min(1),
+  vocabulary: z.string().min(1),
+  estimated_band: z.number().min(0).max(9),
+});
+
+type Ok = z.infer<typeof DiagnosticSchema>;
+type Err = { error: string; details?: unknown };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Ok | Err>) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const parsed = BodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid body', details: parsed.error.flatten() });
+  }
+
+  try {
+    const completion = await ai.chat.completions.create({
+      model: AI_MODEL,
+      temperature: 0.2,
+      response_format: { type: 'json_object' },
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are an IELTS diagnostic grader. Return strict JSON with keys: grammar, coherence, vocabulary, estimated_band. Keep each text brief. estimated_band must be a number 0-9.',
+        },
+        { role: 'user', content: parsed.data.response },
+      ],
+    });
+
+    const raw = completion.choices?.[0]?.message?.content;
+    if (!raw) {
+      return res.status(502).json({ error: 'Provider returned empty response' });
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw);
+    } catch (error) {
+      return res.status(502).json({ error: 'Provider response was not valid JSON', details: String(error) });
+    }
+
+    const result = DiagnosticSchema.safeParse(payload);
+    if (!result.success) {
+      return res.status(502).json({ error: 'Provider response failed validation', details: result.error.flatten() });
+    }
+
+    return res.status(200).json(result.data);
+  } catch (error: any) {
+    return res.status(500).json({ error: 'Failed to run diagnostic', details: error?.message ?? String(error) });
+  }
+}

--- a/pages/api/onboarding/complete.ts
+++ b/pages/api/onboarding/complete.ts
@@ -10,12 +10,12 @@ const Body = z.object({
       z.number().int(),
       z.string().transform((v) => {
         const n = Number.parseInt(v, 10);
-        return Number.isNaN(n) ? 5 : n;
+        return Number.isNaN(n) ? 12 : n;
       }),
     ])
     .optional(),
   channels: z
-    .array(z.enum(['email', 'whatsapp', 'in-app']))
+    .array(z.enum(['email', 'whatsapp', 'in_app']))
     .min(1)
     .optional(),
 });
@@ -53,11 +53,11 @@ export default async function handler(
   const body = normalizeBody(req);
   const parse = Body.safeParse(body);
 
-  let step = 5;
-  let channels: ('email' | 'whatsapp' | 'in-app')[] | undefined;
+  let step = 12;
+  let channels: ('email' | 'whatsapp' | 'in_app')[] | undefined;
 
   if (parse.success) {
-    step = parse.data.step ?? 5;
+    step = parse.data.step ?? 12;
     channels = parse.data.channels;
   } else {
     console.warn(

--- a/pages/api/onboarding/index.ts
+++ b/pages/api/onboarding/index.ts
@@ -12,7 +12,7 @@ import {
 
 const SELECT_COLUMNS =
   // Alias DB "id" -> JSON "user_id" so your existing types continue to work
-  'user_id:id,preferred_language,locale,goal_band,exam_date,study_days,study_minutes_per_day,whatsapp_opt_in,phone,notification_channels,onboarding_step,onboarding_complete';
+  'user_id:id,preferred_language,locale,goal_band,exam_date,study_days,study_minutes_per_day,whatsapp_opt_in,phone,notification_channels,onboarding_step,onboarding_complete,settings';
 
 type ErrorResponse = { error: string };
 
@@ -29,6 +29,7 @@ type ProfileRow = {
   notification_channels: string[] | null;
   onboarding_step: number | null;
   onboarding_complete: boolean | null;
+  settings: Record<string, unknown> | null;
 } | null;
 
 const defaultState: OnboardingState = {
@@ -39,6 +40,14 @@ const defaultState: OnboardingState = {
   studyMinutesPerDay: null,
   whatsappOptIn: null,
   phone: null,
+  currentLevel: null,
+  previousIelts: null,
+  examTimeline: null,
+  studyCommitment: null,
+  learningStyle: null,
+  weaknesses: null,
+  confidence: null,
+  diagnostic: null,
   onboardingStep: 0,
   onboardingComplete: false,
 };
@@ -47,6 +56,9 @@ function normalizeState(row: ProfileRow): OnboardingState {
   if (!row) return defaultState;
 
   const studyDays = Array.isArray(row.study_days) ? row.study_days.filter(Boolean) : [];
+
+  const settings = (row.settings ?? {}) as Record<string, unknown>;
+  const onboarding = (settings.onboarding ?? {}) as Record<string, unknown>;
 
   return onboardingStateSchema.parse({
     preferredLanguage: row.preferred_language ?? row.locale ?? null,
@@ -59,6 +71,14 @@ function normalizeState(row: ProfileRow): OnboardingState {
         : null,
     whatsappOptIn: typeof row.whatsapp_opt_in === 'boolean' ? row.whatsapp_opt_in : null,
     phone: row.phone ?? null,
+    currentLevel: typeof onboarding.currentLevel === 'string' ? onboarding.currentLevel : null,
+    previousIelts: onboarding.previousIelts ?? null,
+    examTimeline: onboarding.examTimeline ?? null,
+    studyCommitment: onboarding.studyCommitment ?? null,
+    learningStyle: typeof onboarding.learningStyle === 'string' ? onboarding.learningStyle : null,
+    weaknesses: Array.isArray(onboarding.weaknesses) ? onboarding.weaknesses : null,
+    confidence: onboarding.confidence ?? null,
+    diagnostic: onboarding.diagnostic ?? null,
     onboardingStep: typeof row.onboarding_step === 'number' ? row.onboarding_step : 0,
     onboardingComplete: row.onboarding_complete === true,
   });
@@ -163,48 +183,68 @@ async function applyStep(
   row: ProfileRow,
 ): Promise<ProfileRow> {
   const updates: Record<string, unknown> = {};
+  const settings = (row?.settings ?? {}) as Record<string, unknown>;
+  const onboardingSettings = ((settings.onboarding as Record<string, unknown> | undefined) ?? {}) as Record<string, unknown>;
+
   let nextStep = Math.max(current.onboardingStep ?? 0, payload.step);
   let nextComplete = current.onboardingComplete;
 
   if (payload.step === 1) {
+    onboardingSettings.welcomeSeenAt = new Date().toISOString();
+  }
+
+  if (payload.step === 2) {
     updates.preferred_language = payload.data.preferredLanguage;
     updates.locale = payload.data.preferredLanguage;
   }
 
-  if (payload.step === 2) {
-    updates.goal_band = payload.data.goalBand;
-  }
-
-  if (payload.step === 3) {
-    const examDate = payload.data.examDate?.trim() ? payload.data.examDate : null;
-    updates.exam_date = examDate;
-  }
+  if (payload.step === 3) onboardingSettings.currentLevel = payload.data.currentLevel;
 
   if (payload.step === 4) {
-    updates.study_days = payload.data.studyDays;
-    updates.study_minutes_per_day = payload.data.minutesPerDay;
+    onboardingSettings.previousIelts = {
+      taken: payload.data.taken,
+      overallBand: payload.data.overallBand ?? null,
+      testDate: payload.data.testDate ?? null,
+    };
   }
 
-  if (payload.step === 5) {
+  if (payload.step === 5) updates.goal_band = payload.data.goalBand;
+
+  if (payload.step === 6) {
+    const examDate = payload.data.examDate?.trim() ? payload.data.examDate : null;
+    updates.exam_date = examDate;
+    onboardingSettings.examTimeline = { timeframe: payload.data.timeframe, examDate };
+  }
+
+  if (payload.step === 7) {
+    updates.study_days = payload.data.studyDays;
+    updates.study_minutes_per_day = payload.data.minutesPerDay;
+    onboardingSettings.studyCommitment = {
+      daysPerWeek: payload.data.studyDays.length,
+      minutesPerDay: payload.data.minutesPerDay,
+    };
+  }
+
+  if (payload.step === 8) onboardingSettings.learningStyle = payload.data.learningStyle;
+  if (payload.step === 9) onboardingSettings.weaknesses = payload.data.weaknesses;
+  if (payload.step === 10) onboardingSettings.confidence = payload.data;
+
+  if (payload.step === 11) {
+    onboardingSettings.diagnosticInput = payload.data.response;
+    if (payload.data.result) onboardingSettings.diagnostic = payload.data.result;
+  }
+
+  if (payload.step === 12) {
     const phone = payload.data.phone?.trim() ? payload.data.phone.trim() : null;
-    updates.whatsapp_opt_in = payload.data.whatsappOptIn;
+    const whatsappOptIn =
+      typeof payload.data.whatsappOptIn === 'boolean'
+        ? payload.data.whatsappOptIn
+        : payload.data.channels.includes('whatsapp');
+
+    updates.whatsapp_opt_in = whatsappOptIn;
     updates.phone = phone;
-
-    if (current.phone && !phone) {
-      updates.phone = null;
-    }
-
-    const existingChannels = Array.isArray(row?.notification_channels)
-      ? new Set<string>(row?.notification_channels ?? [])
-      : new Set<string>();
-
-    if (payload.data.whatsappOptIn) {
-      existingChannels.add('whatsapp');
-    } else {
-      existingChannels.delete('whatsapp');
-    }
-
-    updates.notification_channels = Array.from(existingChannels);
+    updates.notification_channels = Array.from(new Set(payload.data.channels));
+    onboardingSettings.notificationTime = payload.data.preferredTime ?? null;
 
     nextStep = TOTAL_ONBOARDING_STEPS;
     nextComplete = true;
@@ -214,6 +254,7 @@ async function applyStep(
     nextComplete = false;
   }
 
+  updates.settings = { ...settings, onboarding: onboardingSettings };
   updates.onboarding_step = nextStep;
   updates.onboarding_complete = nextComplete;
 
@@ -226,17 +267,7 @@ async function applyStep(
     await trackor.log('onboarding_start', { user_id: userId, step: payload.step });
   }
 
-  const trackPayload: Record<string, unknown> = { user_id: userId, step: payload.step };
-  if (payload.step === 1) trackPayload.preferred_language = payload.data.preferredLanguage;
-  if (payload.step === 2) trackPayload.goal_band = payload.data.goalBand;
-  if (payload.step === 3) trackPayload.exam_date = updates.exam_date ?? null;
-  if (payload.step === 4) {
-    trackPayload.study_days = payload.data.studyDays;
-    trackPayload.minutes_per_day = payload.data.minutesPerDay;
-  }
-  if (payload.step === 5) trackPayload.whatsapp_opt_in = payload.data.whatsappOptIn;
-
-  await trackor.log('onboarding_step_complete', trackPayload);
+  await trackor.log('onboarding_step_complete', { user_id: userId, step: payload.step });
 
   if (becameComplete) {
     await trackor.log('onboarding_done', { user_id: userId });

--- a/pages/onboarding/confidence.tsx
+++ b/pages/onboarding/confidence.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+export default function ConfidencePage() {
+  const router = useRouter();
+  const nav = resolveNavigation('confidence');
+  const [writing, setWriting] = useState(3);
+  const [speaking, setSpeaking] = useState(3);
+
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Confidence</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><label className="block mt-4">Writing confidence (1-5)<input className="ml-2 rounded border p-1" type="number" min={1} max={5} value={writing} onChange={(e)=>setWriting(Number(e.target.value))} /></label><label className="block mt-3">Speaking confidence (1-5)<input className="ml-2 rounded border p-1" type="number" min={1} max={5} value={speaking} onChange={(e)=>setSpeaking(Number(e.target.value))} /></label><div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button onClick={async()=>{await saveOnboardingStep(10,{ writing, speaking }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button></div></Container></main>;
+}

--- a/pages/onboarding/current-level.tsx
+++ b/pages/onboarding/current-level.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+const levels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const;
+
+export default function CurrentLevelPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('current-level');
+  const [currentLevel, setLevel] = useState<(typeof levels)[number]>('B1');
+
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Current level</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><select className="mt-4 rounded border p-2" value={currentLevel} onChange={(e)=>setLevel(e.target.value as any)}>{levels.map((l)=><option key={l}>{l}</option>)}</select><div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button onClick={async()=>{await saveOnboardingStep(3,{ currentLevel }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button></div></Container></main>;
+}

--- a/pages/onboarding/diagnostic.tsx
+++ b/pages/onboarding/diagnostic.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+type DiagnosticResult = {
+  grammar: string;
+  coherence: string;
+  vocabulary: string;
+  estimated_band: number;
+};
+
+export default function DiagnosticPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('diagnostic');
+  const [response, setResponse] = useState('');
+  const [result, setResult] = useState<DiagnosticResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/ai/diagnostic', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ response }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || 'Diagnostic failed');
+      setResult(body as DiagnosticResult);
+      await saveOnboardingStep(11, { response, result: body });
+    } catch (e: any) {
+      setError(e?.message || 'Could not run diagnostic');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Diagnostic</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><textarea className="mt-4 w-full rounded border p-3" rows={7} value={response} onChange={(e)=>setResponse(e.target.value)} placeholder="Write a short response about your IELTS goals..." />{error && <p className="mt-2 text-sm text-destructive">{error}</p>}{result && <div className="mt-4 rounded border p-3"><p><strong>Estimated band:</strong> {result.estimated_band.toFixed(1)}</p><p><strong>Grammar:</strong> {result.grammar}</p><p><strong>Coherence:</strong> {result.coherence}</p><p><strong>Vocabulary:</strong> {result.vocabulary}</p></div>}<div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button disabled={loading || response.length < 20} onClick={()=>void runDiagnostic()}>{loading ? 'Analyzing…' : result ? 'Re-run diagnostic' : 'Run diagnostic'}</Button>{result && <Button onClick={()=>nav.next && router.push(nav.next.path)}>Continue</Button>}</div></Container></main>;
+}

--- a/pages/onboarding/exam-timeline.tsx
+++ b/pages/onboarding/exam-timeline.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+export default function ExamTimelinePage() {
+  const router = useRouter();
+  const nav = resolveNavigation('exam-timeline');
+  const [timeframe, setTimeframe] = useState('within_3_months');
+  const [examDate, setExamDate] = useState('');
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Exam timeline</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><select className="mt-4 rounded border p-2" value={timeframe} onChange={(e)=>setTimeframe(e.target.value)}><option value="within_1_month">Within 1 month</option><option value="within_3_months">Within 3 months</option><option value="within_6_months">Within 6 months</option><option value="not_scheduled">Not scheduled</option></select><input type="date" className="mt-3 rounded border p-2" value={examDate} onChange={(e)=>setExamDate(e.target.value)} /><div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button onClick={async()=>{await saveOnboardingStep(6,{ timeframe, examDate: examDate || null }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button></div></Container></main>;
+}

--- a/pages/onboarding/learning-style.tsx
+++ b/pages/onboarding/learning-style.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+const styles = ['visual', 'auditory', 'reading_writing', 'kinesthetic', 'mixed'] as const;
+
+export default function LearningStylePage() {
+  const router = useRouter();
+  const nav = resolveNavigation('learning-style');
+  const [learningStyle, setLearningStyle] = useState<(typeof styles)[number]>('mixed');
+
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Learning style</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><select className="mt-4 rounded border p-2" value={learningStyle} onChange={(e)=>setLearningStyle(e.target.value as any)}>{styles.map((s)=><option key={s} value={s}>{s}</option>)}</select><div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button onClick={async()=>{await saveOnboardingStep(8,{ learningStyle }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button></div></Container></main>;
+}

--- a/pages/onboarding/previous-ielts.tsx
+++ b/pages/onboarding/previous-ielts.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+export default function PreviousIeltsPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('previous-ielts');
+  const [taken, setTaken] = useState(false);
+  const [overallBand, setBand] = useState('6.0');
+  const [testDate, setDate] = useState('');
+
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Previous IELTS</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><label className="mt-4 block"><input type="checkbox" checked={taken} onChange={(e)=>setTaken(e.target.checked)} /> I have taken IELTS before</label>{taken && <div className="mt-4 space-y-3"><input className="rounded border p-2" value={overallBand} onChange={(e)=>setBand(e.target.value)} placeholder="Overall band" /><input type="date" className="rounded border p-2" value={testDate} onChange={(e)=>setDate(e.target.value)} /></div>}<div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button onClick={async()=>{await saveOnboardingStep(4,{ taken, overallBand: taken ? Number(overallBand) : null, testDate: taken ? testDate || null : null }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button></div></Container></main>;
+}

--- a/pages/onboarding/study-commitment.tsx
+++ b/pages/onboarding/study-commitment.tsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+const days = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
+
+export default function StudyCommitmentPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('study-commitment');
+  const [studyDays, setStudyDays] = useState<string[]>(['mon', 'wed', 'fri']);
+  const [minutesPerDay, setMinutes] = useState(45);
+
+  const toggle = (d: string) => setStudyDays((prev) => prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]);
+
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Study commitment</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><div className="mt-4 flex flex-wrap gap-2">{days.map((d)=><button key={d} onClick={()=>toggle(d)} className={`rounded border px-3 py-1 ${studyDays.includes(d)?'bg-primary text-primary-foreground':''}`}>{d}</button>)}</div><input type="number" min={10} max={360} value={minutesPerDay} onChange={(e)=>setMinutes(Number(e.target.value))} className="mt-4 rounded border p-2" /><div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button onClick={async()=>{await saveOnboardingStep(7,{ studyDays, minutesPerDay }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button></div></Container></main>;
+}

--- a/pages/onboarding/weakness.tsx
+++ b/pages/onboarding/weakness.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+
+const options = ['listening', 'reading', 'writing', 'speaking', 'grammar', 'vocabulary'];
+
+export default function WeaknessPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('weakness');
+  const [weaknesses, setWeaknesses] = useState<string[]>(['writing']);
+
+  const toggle = (v: string) => setWeaknesses((prev) => prev.includes(v) ? prev.filter((x) => x !== v) : prev.length < 3 ? [...prev, v] : prev);
+
+  return <main className="min-h-screen bg-background"><Container className="py-10"><h1 className="text-2xl font-semibold">Weaknesses</h1><p className="text-muted-foreground">Step {nav.index + 1} of {nav.total}</p><div className="mt-4 grid grid-cols-2 gap-2">{options.map((o)=><button key={o} className={`rounded border p-2 ${weaknesses.includes(o)?'bg-primary text-primary-foreground':''}`} onClick={()=>toggle(o)}>{o}</button>)}</div><div className="mt-6 flex gap-3"><Button variant="ghost" onClick={()=>nav.prev && router.push(nav.prev.path)}>Back</Button><Button disabled={!weaknesses.length} onClick={async()=>{await saveOnboardingStep(9,{ weaknesses }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button></div></Container></main>;
+}


### PR DESCRIPTION
### Motivation

- Expand the onboarding flow to capture richer learner data (current CEFR level, previous IELTS, exam timeline, study commitment, learning style, weaknesses, confidence and an AI diagnostic) to improve study plan personalization.
- Persist the expanded onboarding payload in a structured `settings.onboarding` object rather than only top-level profile columns.
- Provide a server-side AI diagnostic endpoint to auto-evaluate free-text responses and wire up frontend pages for the new steps.

### Description

- Added a new `lib/onboarding/steps.ts` with a typed list of 12 onboarding step definitions and helpers `getStepIndex`, `getNextStep`, `getPrevStep` and exported `ONBOARDING_STEPS`.
- Introduced `lib/onboarding/client.ts` to expose `saveOnboardingStep` and `resolveNavigation` plus re-exports of the steps utilities.
- Extended `lib/onboarding/schema.ts` with many new Zod schemas and enums (CEFR levels, learning styles, weaknesses, notification channels), expanded `onboardingStateSchema` and `onboardingStepPayloadSchema` to 12 steps and updated `TOTAL_ONBOARDING_STEPS` to `12`.
- Modified `lib/studyPlan.ts` to accept an optional `baselineBand` in `computeIntensity` and added optional fields to `PlanGenOptionsSchema` to carry onboarding-derived inputs (current level, previous IELTS, confidence, diagnostic, minutes/days overrides).
- Added server API `pages/api/ai/diagnostic.ts` which calls the AI service to grade a free-text response and returns a validated JSON diagnostic result.
- Reworked onboarding API `pages/api/onboarding/index.ts` and `pages/api/onboarding/complete.ts` to read/write a `settings.onboarding` object, map new step payloads into profile updates, and mark completion at step `12`; consolidated notification channel naming to `in_app` and `whatsapp` handling.
- Added multiple new onboarding pages under `pages/onboarding/*` for the new steps: `current-level`, `previous-ielts`, `exam-timeline`, `study-commitment`, `learning-style`, `weakness`, `confidence`, and `diagnostic`, and the client-side UI uses `saveOnboardingStep` and `resolveNavigation`.

### Testing

- Ran TypeScript build (`npm run build`) and lint (`npm run lint`) locally and they completed successfully.
- Exercised the onboarding API flow by posting step payloads against the updated `POST /api/onboarding` handler in development and verified responses matched `onboardingStateSchema` parsing (no automated unit tests were added for the new handlers in this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec402c4a88328bd9f1250143fbb28)