### PR TITLE
Add multi-step onboarding flow, draft storage, AI diagnostic, and API support

### DIFF
--- a/components/onboarding/StepLayout.tsx
+++ b/components/onboarding/StepLayout.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Container } from '@/components/design-system/Container';
+import { Button } from '@/components/design-system/Button';
+import { cn } from '@/lib/utils';
+
+export function StepLayout({
+  title,
+  subtitle,
+  step,
+  total,
+  onBack,
+  children,
+  footer,
+}: {
+  title: string;
+  subtitle?: string;
+  step: number;
+  total: number;
+  onBack?: () => void;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  const pct = Math.round((step / total) * 100);
+  return (
+    <main className="min-h-screen bg-background">
+      <Container className="mx-auto flex min-h-screen w-full max-w-4xl flex-col justify-center py-6 sm:py-10">
+        <div className="mb-4 sm:mb-6">
+          <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
+            <span>Step {step} of {total}</span>
+            <span>{pct}% complete</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+
+        <section className="rounded-2xl border border-border bg-card p-4 shadow-sm sm:p-8">
+          <header className="mb-5 sm:mb-6">
+            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{title}</h1>
+            {subtitle && <p className="mt-2 text-sm text-muted-foreground sm:text-base">{subtitle}</p>}
+          </header>
+
+          <div>{children}</div>
+
+          <footer className={cn('mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4')}>
+            <div>{onBack ? <Button variant="ghost" onClick={onBack}>Back</Button> : <span />}</div>
+            <div>{footer}</div>
+          </footer>
+        </section>
+      </Container>
+    </main>
+  );
+}

--- a/lib/onboarding/client.ts
+++ b/lib/onboarding/client.ts
@@ -1,0 +1,28 @@
+import type { OnboardingStepId } from './steps';
+import { getNextStep, getPrevStep, getStepIndex, ONBOARDING_STEPS } from './steps';
+
+export { ONBOARDING_STEPS, getStepIndex, getNextStep, getPrevStep };
+
+export async function saveOnboardingStep(step: number, data: Record<string, unknown>) {
+  const res = await fetch('/api/onboarding', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ step, data }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error || 'Failed to save onboarding step');
+  }
+
+  return res.json();
+}
+
+export function resolveNavigation(stepId: OnboardingStepId) {
+  return {
+    index: getStepIndex(stepId),
+    total: ONBOARDING_STEPS.length,
+    next: getNextStep(stepId),
+    prev: getPrevStep(stepId),
+  };
+}

--- a/lib/onboarding/draft.ts
+++ b/lib/onboarding/draft.ts
@@ -1,0 +1,22 @@
+import type { OnboardingStepId } from './steps';
+
+const keyFor = (stepId: OnboardingStepId) => `onboarding:draft:${stepId}`;
+
+export function loadDraft<T>(stepId: OnboardingStepId, fallback: T): T {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(keyFor(stepId));
+    return raw ? ({ ...fallback, ...JSON.parse(raw) } as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveDraft(stepId: OnboardingStepId, data: unknown) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(keyFor(stepId), JSON.stringify(data));
+  } catch {
+    // noop
+  }
+}

--- a/lib/onboarding/schema.ts
+++ b/lib/onboarding/schema.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
 const supportedLanguageCodes = ['en', 'ur'] as const;
+const cefrLevels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const;
+const learningStyles = ['visual', 'auditory', 'reading_writing', 'kinesthetic', 'mixed'] as const;
+const weaknesses = ['listening', 'reading', 'writing', 'speaking', 'grammar', 'vocabulary'] as const;
 
 export const languageOptions = [
   { value: 'en', label: 'English' },
@@ -9,7 +12,40 @@ export const languageOptions = [
 
 const LanguageEnum = z.enum(supportedLanguageCodes);
 const StudyDayEnum = z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const);
+const CEFRLevelEnum = z.enum(cefrLevels);
+const LearningStyleEnum = z.enum(learningStyles);
+const WeaknessEnum = z.enum(weaknesses);
+export const NotificationChannelEnum = z.enum(['in_app', 'whatsapp', 'email'] as const);
 const PhoneSchema = z.union([z.string().min(6).max(32), z.literal('')]);
+
+export const LanguageBody = z.object({
+  language: LanguageEnum,
+});
+
+export const TargetBandBody = z.object({
+  targetBand: z.number().min(4).max(9),
+});
+
+export const ExamDateBody = z.object({
+  timeframe: z.string().trim().min(1),
+  examDate: z.string().trim().min(1).optional().nullable(),
+});
+
+export const StudyRhythmBody = z.object({
+  rhythm: z.string().trim().min(1),
+});
+
+export const NotificationsBody = z.object({
+  channels: z.array(NotificationChannelEnum).min(1),
+  preferredTime: z.string().trim().min(1).optional().nullable(),
+});
+
+const DiagnosticResultSchema = z.object({
+  grammar: z.string().min(1),
+  coherence: z.string().min(1),
+  vocabulary: z.string().min(1),
+  estimated_band: z.number().min(0).max(9),
+});
 
 export const onboardingStateSchema = z.object({
   preferredLanguage: LanguageEnum.nullable(),
@@ -19,45 +55,84 @@ export const onboardingStateSchema = z.object({
   studyMinutesPerDay: z.number().int().min(10).max(360).nullable(),
   whatsappOptIn: z.boolean().nullable(),
   phone: PhoneSchema.nullable(),
+  currentLevel: CEFRLevelEnum.nullable().optional(),
+  previousIelts: z
+    .object({
+      taken: z.boolean(),
+      overallBand: z.number().min(0).max(9).nullable().optional(),
+      testDate: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+  examTimeline: z
+    .object({
+      timeframe: z.string(),
+      examDate: z.string().nullable(),
+    })
+    .nullable()
+    .optional(),
+  studyCommitment: z
+    .object({
+      daysPerWeek: z.number().int().min(1).max(7),
+      minutesPerDay: z.number().int().min(10).max(360),
+    })
+    .nullable()
+    .optional(),
+  learningStyle: LearningStyleEnum.nullable().optional(),
+  weaknesses: z.array(WeaknessEnum).max(3).nullable().optional(),
+  confidence: z
+    .object({
+      writing: z.number().int().min(1).max(5),
+      speaking: z.number().int().min(1).max(5),
+    })
+    .nullable()
+    .optional(),
+  diagnostic: DiagnosticResultSchema.nullable().optional(),
   onboardingStep: z.number().int().min(0),
   onboardingComplete: z.boolean(),
 });
 
 export type OnboardingState = z.infer<typeof onboardingStateSchema>;
 
-const StepOneSchema = z.object({
-  step: z.literal(1),
+const StepOneSchema = z.object({ step: z.literal(1), data: z.object({}) });
+const StepTwoSchema = z.object({ step: z.literal(2), data: z.object({ preferredLanguage: LanguageEnum }) });
+const StepThreeSchema = z.object({ step: z.literal(3), data: z.object({ currentLevel: CEFRLevelEnum }) });
+const StepFourSchema = z.object({
+  step: z.literal(4),
   data: z.object({
-    preferredLanguage: LanguageEnum,
+    taken: z.boolean(),
+    overallBand: z.number().min(0).max(9).optional().nullable(),
+    testDate: z.string().optional().nullable(),
   }),
 });
-
-const StepTwoSchema = z.object({
-  step: z.literal(2),
+const StepFiveSchema = z.object({ step: z.literal(5), data: z.object({ goalBand: z.number().min(4).max(9) }) });
+const StepSixSchema = z.object({
+  step: z.literal(6),
   data: z.object({
-    goalBand: z.number().min(4).max(9),
-  }),
-});
-
-const StepThreeSchema = z.object({
-  step: z.literal(3),
-  data: z.object({
+    timeframe: z.string().min(1),
     examDate: z.union([z.string(), z.null()]).optional().nullable(),
   }),
 });
-
-const StepFourSchema = z.object({
-  step: z.literal(4),
+const StepSevenSchema = z.object({
+  step: z.literal(7),
   data: z.object({
     studyDays: z.array(StudyDayEnum).min(1),
     minutesPerDay: z.number().int().min(10).max(360),
   }),
 });
-
-const StepFiveSchema = z.object({
-  step: z.literal(5),
+const StepEightSchema = z.object({ step: z.literal(8), data: z.object({ learningStyle: LearningStyleEnum }) });
+const StepNineSchema = z.object({ step: z.literal(9), data: z.object({ weaknesses: z.array(WeaknessEnum).min(1).max(3) }) });
+const StepTenSchema = z.object({
+  step: z.literal(10),
+  data: z.object({ writing: z.number().int().min(1).max(5), speaking: z.number().int().min(1).max(5) }),
+});
+const StepElevenSchema = z.object({ step: z.literal(11), data: z.object({ response: z.string().min(20), result: DiagnosticResultSchema.optional() }) });
+const StepTwelveSchema = z.object({
+  step: z.literal(12),
   data: z.object({
-    whatsappOptIn: z.boolean(),
+    channels: z.array(NotificationChannelEnum).min(1),
+    preferredTime: z.string().trim().min(1).optional().nullable(),
+    whatsappOptIn: z.boolean().optional(),
     phone: z.string().trim().optional().nullable(),
   }),
 });
@@ -68,11 +143,18 @@ export const onboardingStepPayloadSchema = z.discriminatedUnion('step', [
   StepThreeSchema,
   StepFourSchema,
   StepFiveSchema,
+  StepSixSchema,
+  StepSevenSchema,
+  StepEightSchema,
+  StepNineSchema,
+  StepTenSchema,
+  StepElevenSchema,
+  StepTwelveSchema,
 ]);
 
 export type OnboardingStepPayload = z.infer<typeof onboardingStepPayloadSchema>;
 
-export const TOTAL_ONBOARDING_STEPS = 5;
+export const TOTAL_ONBOARDING_STEPS = 12;
 
 export const languageOptionsEnum = LanguageEnum;
 export const studyDayOptionsEnum = StudyDayEnum;

--- a/lib/onboarding/steps.ts
+++ b/lib/onboarding/steps.ts
@@ -1,0 +1,55 @@
+export type OnboardingStepId =
+  | 'welcome'
+  | 'language'
+  | 'current-level'
+  | 'previous-ielts'
+  | 'target-band'
+  | 'exam-timeline'
+  | 'study-commitment'
+  | 'learning-style'
+  | 'weakness'
+  | 'confidence'
+  | 'diagnostic'
+  | 'notifications';
+
+export type OnboardingStepDef = {
+  id: OnboardingStepId;
+  step: number;
+  label: string;
+  path: string;
+};
+
+export const ONBOARDING_STEPS: OnboardingStepDef[] = [
+  { id: 'welcome', step: 1, label: 'Welcome', path: '/onboarding/welcome' },
+  { id: 'language', step: 2, label: 'Language', path: '/onboarding' },
+  { id: 'current-level', step: 3, label: 'Current level', path: '/onboarding/current-level' },
+  { id: 'previous-ielts', step: 4, label: 'Previous IELTS', path: '/onboarding/previous-ielts' },
+  { id: 'target-band', step: 5, label: 'Target band', path: '/onboarding/target-band' },
+  { id: 'exam-timeline', step: 6, label: 'Exam timeline', path: '/onboarding/exam-timeline' },
+  { id: 'study-commitment', step: 7, label: 'Study commitment', path: '/onboarding/study-commitment' },
+  { id: 'learning-style', step: 8, label: 'Learning style', path: '/onboarding/learning-style' },
+  { id: 'weakness', step: 9, label: 'Weakness', path: '/onboarding/weakness' },
+  { id: 'confidence', step: 10, label: 'Confidence', path: '/onboarding/confidence' },
+  { id: 'diagnostic', step: 11, label: 'Diagnostic', path: '/onboarding/diagnostic' },
+  { id: 'notifications', step: 12, label: 'Notifications', path: '/onboarding/notifications' },
+];
+
+const byId = new Map(ONBOARDING_STEPS.map((s) => [s.id, s] as const));
+
+export function getStepById(id: OnboardingStepId): OnboardingStepDef {
+  return byId.get(id)!;
+}
+
+export function getStepIndex(id: OnboardingStepId): number {
+  return ONBOARDING_STEPS.findIndex((s) => s.id === id);
+}
+
+export function getNextStep(id: OnboardingStepId): OnboardingStepDef | null {
+  const index = getStepIndex(id);
+  return index >= 0 && index < ONBOARDING_STEPS.length - 1 ? ONBOARDING_STEPS[index + 1] : null;
+}
+
+export function getPrevStep(id: OnboardingStepId): OnboardingStepDef | null {
+  const index = getStepIndex(id);
+  return index > 0 ? ONBOARDING_STEPS[index - 1] : null;
+}

--- a/lib/studyPlan.ts
+++ b/lib/studyPlan.ts
@@ -72,6 +72,25 @@ export const PlanGenOptionsSchema = z
         { message: 'duplicate_day' },
       ),
     weaknesses: z.array(z.string().min(1)).max(16).optional(),
+    currentLevel: z.string().optional(),
+    previousIelts: z
+      .object({
+        taken: z.boolean(),
+        overallBand: z.number().min(0).max(9).nullable().optional(),
+        testDate: z.string().nullable().optional(),
+      })
+      .optional(),
+    confidence: z.object({ writing: z.number().min(1).max(5), speaking: z.number().min(1).max(5) }).optional(),
+    diagnostic: z
+      .object({
+        grammar: z.string(),
+        coherence: z.string(),
+        vocabulary: z.string(),
+        estimated_band: z.number().min(0).max(9),
+      })
+      .optional(),
+    minutesPerDay: z.number().int().min(10).max(360).optional(),
+    daysPerWeek: z.number().int().min(1).max(7).optional(),
   })
   .strict();
 
@@ -149,9 +168,9 @@ function defaultMinutes(type: TaskType): number {
   }
 }
 
-function computeIntensity(targetBand: number): number {
-  // Around band 6 => neutral. Above => slightly more volume, below => gentler pace.
-  const delta = targetBand - 6;
+function computeIntensity(targetBand: number, baselineBand?: number): number {
+  const anchor = typeof baselineBand === 'number' ? baselineBand : 6;
+  const delta = targetBand - anchor;
   return clamp(1 + delta * 0.15, 0.85, 1.35);
 }
 

--- a/pages/api/ai/diagnostic.ts
+++ b/pages/api/ai/diagnostic.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+import { ai, AI_MODEL } from '@/lib/ai';
+
+const BodySchema = z.object({ response: z.string().min(20).max(4000) });
+const DiagnosticSchema = z.object({
+  grammar: z.string().min(1),
+  coherence: z.string().min(1),
+  vocabulary: z.string().min(1),
+  estimated_band: z.number().min(0).max(9),
+});
+
+type Ok = z.infer<typeof DiagnosticSchema>;
+type Err = { error: string; details?: unknown };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Ok | Err>) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const parsed = BodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid body', details: parsed.error.flatten() });
+  }
+
+  try {
+    const completion = await ai.chat.completions.create({
+      model: AI_MODEL,
+      temperature: 0.2,
+      response_format: { type: 'json_object' },
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are an IELTS diagnostic grader. Return strict JSON with keys: grammar, coherence, vocabulary, estimated_band. Keep each text brief. estimated_band must be a number 0-9.',
+        },
+        { role: 'user', content: parsed.data.response },
+      ],
+    });
+
+    const raw = completion.choices?.[0]?.message?.content;
+    if (!raw) {
+      return res.status(502).json({ error: 'Provider returned empty response' });
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw);
+    } catch (error) {
+      return res.status(502).json({ error: 'Provider response was not valid JSON', details: String(error) });
+    }
+
+    const result = DiagnosticSchema.safeParse(payload);
+    if (!result.success) {
+      return res.status(502).json({ error: 'Provider response failed validation', details: result.error.flatten() });
+    }
+
+    return res.status(200).json(result.data);
+  } catch (error: any) {
+    return res.status(500).json({ error: 'Failed to run diagnostic', details: error?.message ?? String(error) });
+  }
+}

--- a/pages/api/onboarding/complete.ts
+++ b/pages/api/onboarding/complete.ts
@@ -10,12 +10,12 @@ const Body = z.object({
       z.number().int(),
       z.string().transform((v) => {
         const n = Number.parseInt(v, 10);
-        return Number.isNaN(n) ? 5 : n;
+        return Number.isNaN(n) ? 12 : n;
       }),
     ])
     .optional(),
   channels: z
-    .array(z.enum(['email', 'whatsapp', 'in-app']))
+    .array(z.enum(['email', 'whatsapp', 'in_app']))
     .min(1)
     .optional(),
 });
@@ -53,11 +53,11 @@ export default async function handler(
   const body = normalizeBody(req);
   const parse = Body.safeParse(body);
 
-  let step = 5;
-  let channels: ('email' | 'whatsapp' | 'in-app')[] | undefined;
+  let step = 12;
+  let channels: ('email' | 'whatsapp' | 'in_app')[] | undefined;
 
   if (parse.success) {
-    step = parse.data.step ?? 5;
+    step = parse.data.step ?? 12;
     channels = parse.data.channels;
   } else {
     console.warn(

--- a/pages/api/onboarding/index.ts
+++ b/pages/api/onboarding/index.ts
@@ -12,7 +12,7 @@ import {
 
 const SELECT_COLUMNS =
   // Alias DB "id" -> JSON "user_id" so your existing types continue to work
-  'user_id:id,preferred_language,locale,goal_band,exam_date,study_days,study_minutes_per_day,whatsapp_opt_in,phone,notification_channels,onboarding_step,onboarding_complete';
+  'user_id:id,preferred_language,locale,goal_band,exam_date,study_days,study_minutes_per_day,whatsapp_opt_in,phone,notification_channels,onboarding_step,onboarding_complete,settings';
 
 type ErrorResponse = { error: string };
 
@@ -29,6 +29,7 @@ type ProfileRow = {
   notification_channels: string[] | null;
   onboarding_step: number | null;
   onboarding_complete: boolean | null;
+  settings: Record<string, unknown> | null;
 } | null;
 
 const defaultState: OnboardingState = {
@@ -39,6 +40,14 @@ const defaultState: OnboardingState = {
   studyMinutesPerDay: null,
   whatsappOptIn: null,
   phone: null,
+  currentLevel: null,
+  previousIelts: null,
+  examTimeline: null,
+  studyCommitment: null,
+  learningStyle: null,
+  weaknesses: null,
+  confidence: null,
+  diagnostic: null,
   onboardingStep: 0,
   onboardingComplete: false,
 };
@@ -47,6 +56,9 @@ function normalizeState(row: ProfileRow): OnboardingState {
   if (!row) return defaultState;
 
   const studyDays = Array.isArray(row.study_days) ? row.study_days.filter(Boolean) : [];
+
+  const settings = (row.settings ?? {}) as Record<string, unknown>;
+  const onboarding = (settings.onboarding ?? {}) as Record<string, unknown>;
 
   return onboardingStateSchema.parse({
     preferredLanguage: row.preferred_language ?? row.locale ?? null,
@@ -59,6 +71,14 @@ function normalizeState(row: ProfileRow): OnboardingState {
         : null,
     whatsappOptIn: typeof row.whatsapp_opt_in === 'boolean' ? row.whatsapp_opt_in : null,
     phone: row.phone ?? null,
+    currentLevel: typeof onboarding.currentLevel === 'string' ? onboarding.currentLevel : null,
+    previousIelts: onboarding.previousIelts ?? null,
+    examTimeline: onboarding.examTimeline ?? null,
+    studyCommitment: onboarding.studyCommitment ?? null,
+    learningStyle: typeof onboarding.learningStyle === 'string' ? onboarding.learningStyle : null,
+    weaknesses: Array.isArray(onboarding.weaknesses) ? onboarding.weaknesses : null,
+    confidence: onboarding.confidence ?? null,
+    diagnostic: onboarding.diagnostic ?? null,
     onboardingStep: typeof row.onboarding_step === 'number' ? row.onboarding_step : 0,
     onboardingComplete: row.onboarding_complete === true,
   });
@@ -163,57 +183,81 @@ async function applyStep(
   row: ProfileRow,
 ): Promise<ProfileRow> {
   const updates: Record<string, unknown> = {};
+  const settings = (row?.settings ?? {}) as Record<string, unknown>;
+  const onboardingSettings = ((settings.onboarding as Record<string, unknown> | undefined) ?? {}) as Record<string, unknown>;
+
   let nextStep = Math.max(current.onboardingStep ?? 0, payload.step);
   let nextComplete = current.onboardingComplete;
 
   if (payload.step === 1) {
+    onboardingSettings.welcomeSeenAt = new Date().toISOString();
+  }
+
+  onboardingSettings.draft = payload.step < TOTAL_ONBOARDING_STEPS;
+
+  if (payload.step === 2) {
     updates.preferred_language = payload.data.preferredLanguage;
     updates.locale = payload.data.preferredLanguage;
   }
 
-  if (payload.step === 2) {
-    updates.goal_band = payload.data.goalBand;
-  }
-
-  if (payload.step === 3) {
-    const examDate = payload.data.examDate?.trim() ? payload.data.examDate : null;
-    updates.exam_date = examDate;
-  }
+  if (payload.step === 3) onboardingSettings.currentLevel = payload.data.currentLevel;
 
   if (payload.step === 4) {
-    updates.study_days = payload.data.studyDays;
-    updates.study_minutes_per_day = payload.data.minutesPerDay;
+    onboardingSettings.previousIelts = {
+      taken: payload.data.taken,
+      overallBand: payload.data.overallBand ?? null,
+      testDate: payload.data.testDate ?? null,
+    };
   }
 
-  if (payload.step === 5) {
+  if (payload.step === 5) updates.goal_band = payload.data.goalBand;
+
+  if (payload.step === 6) {
+    const examDate = payload.data.examDate?.trim() ? payload.data.examDate : null;
+    updates.exam_date = examDate;
+    onboardingSettings.examTimeline = { timeframe: payload.data.timeframe, examDate };
+  }
+
+  if (payload.step === 7) {
+    updates.study_days = payload.data.studyDays;
+    updates.study_minutes_per_day = payload.data.minutesPerDay;
+    onboardingSettings.studyCommitment = {
+      daysPerWeek: payload.data.studyDays.length,
+      minutesPerDay: payload.data.minutesPerDay,
+    };
+  }
+
+  if (payload.step === 8) onboardingSettings.learningStyle = payload.data.learningStyle;
+  if (payload.step === 9) onboardingSettings.weaknesses = payload.data.weaknesses;
+  if (payload.step === 10) onboardingSettings.confidence = payload.data;
+
+  if (payload.step === 11) {
+    onboardingSettings.diagnosticInput = payload.data.response;
+    if (payload.data.result) onboardingSettings.diagnostic = payload.data.result;
+  }
+
+  if (payload.step === 12) {
     const phone = payload.data.phone?.trim() ? payload.data.phone.trim() : null;
-    updates.whatsapp_opt_in = payload.data.whatsappOptIn;
+    const whatsappOptIn =
+      typeof payload.data.whatsappOptIn === 'boolean'
+        ? payload.data.whatsappOptIn
+        : payload.data.channels.includes('whatsapp');
+
+    updates.whatsapp_opt_in = whatsappOptIn;
     updates.phone = phone;
-
-    if (current.phone && !phone) {
-      updates.phone = null;
-    }
-
-    const existingChannels = Array.isArray(row?.notification_channels)
-      ? new Set<string>(row?.notification_channels ?? [])
-      : new Set<string>();
-
-    if (payload.data.whatsappOptIn) {
-      existingChannels.add('whatsapp');
-    } else {
-      existingChannels.delete('whatsapp');
-    }
-
-    updates.notification_channels = Array.from(existingChannels);
+    updates.notification_channels = Array.from(new Set(payload.data.channels));
+    onboardingSettings.notificationTime = payload.data.preferredTime ?? null;
 
     nextStep = TOTAL_ONBOARDING_STEPS;
     nextComplete = true;
+    onboardingSettings.draft = false;
   }
 
   if (payload.step < TOTAL_ONBOARDING_STEPS && !current.onboardingComplete) {
     nextComplete = false;
   }
 
+  updates.settings = { ...settings, onboarding: onboardingSettings };
   updates.onboarding_step = nextStep;
   updates.onboarding_complete = nextComplete;
 
@@ -226,17 +270,7 @@ async function applyStep(
     await trackor.log('onboarding_start', { user_id: userId, step: payload.step });
   }
 
-  const trackPayload: Record<string, unknown> = { user_id: userId, step: payload.step };
-  if (payload.step === 1) trackPayload.preferred_language = payload.data.preferredLanguage;
-  if (payload.step === 2) trackPayload.goal_band = payload.data.goalBand;
-  if (payload.step === 3) trackPayload.exam_date = updates.exam_date ?? null;
-  if (payload.step === 4) {
-    trackPayload.study_days = payload.data.studyDays;
-    trackPayload.minutes_per_day = payload.data.minutesPerDay;
-  }
-  if (payload.step === 5) trackPayload.whatsapp_opt_in = payload.data.whatsappOptIn;
-
-  await trackor.log('onboarding_step_complete', trackPayload);
+  await trackor.log('onboarding_step_complete', { user_id: userId, step: payload.step });
 
   if (becameComplete) {
     await trackor.log('onboarding_done', { user_id: userId });

--- a/pages/onboarding/confidence.tsx
+++ b/pages/onboarding/confidence.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+export default function ConfidencePage() {
+  const router = useRouter();
+  const nav = resolveNavigation('confidence');
+  const [writing, setWriting] = useState(3);
+  const [speaking, setSpeaking] = useState(3);
+
+  useEffect(() => {
+    const d = loadDraft('confidence', { writing: 3, speaking: 3 });
+    setWriting(d.writing); setSpeaking(d.speaking);
+  }, []);
+  useEffect(() => saveDraft('confidence', { writing, speaking }), [writing, speaking]);
+
+  return <StepLayout title="How confident are you today?" subtitle="Rate from 1 (low) to 5 (high)." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<Button onClick={async()=>{await saveOnboardingStep(10,{ writing, speaking }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button>}>
+    <div className="space-y-5">
+      <label className="block"><span className="mb-1 block font-medium">Writing confidence: {writing}/5</span><input className="w-full" type="range" min={1} max={5} value={writing} onChange={(e)=>setWriting(Number(e.target.value))} /></label>
+      <label className="block"><span className="mb-1 block font-medium">Speaking confidence: {speaking}/5</span><input className="w-full" type="range" min={1} max={5} value={speaking} onChange={(e)=>setSpeaking(Number(e.target.value))} /></label>
+    </div>
+  </StepLayout>;
+}

--- a/pages/onboarding/current-level.tsx
+++ b/pages/onboarding/current-level.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+const levels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const;
+
+export default function CurrentLevelPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('current-level');
+  const [currentLevel, setLevel] = useState<(typeof levels)[number]>('B1');
+
+  useEffect(() => {
+    const d = loadDraft('current-level', { currentLevel: 'B1' as const });
+    setLevel(d.currentLevel);
+  }, []);
+  useEffect(() => saveDraft('current-level', { currentLevel }), [currentLevel]);
+
+  return (
+    <StepLayout title="What's your current English level?" subtitle="Choose your best estimate. We'll calibrate plan difficulty from here." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<Button onClick={async()=>{await saveOnboardingStep(3,{ currentLevel }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button>}>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {levels.map((l) => (
+          <button key={l} onClick={() => setLevel(l)} className={`rounded-xl border p-4 text-left transition ${currentLevel===l?'border-primary bg-primary/10':'border-border hover:bg-muted/40'}`}>
+            <p className="text-lg font-semibold">{l}</p>
+            <p className="text-xs text-muted-foreground">CEFR level</p>
+          </button>
+        ))}
+      </div>
+    </StepLayout>
+  );
+}

--- a/pages/onboarding/diagnostic.tsx
+++ b/pages/onboarding/diagnostic.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+type DiagnosticResult = { grammar: string; coherence: string; vocabulary: string; estimated_band: number };
+
+export default function DiagnosticPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('diagnostic');
+  const [response, setResponse] = useState('');
+  const [result, setResult] = useState<DiagnosticResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const d = loadDraft('diagnostic', { response: '' });
+    setResponse(d.response);
+  }, []);
+  useEffect(() => saveDraft('diagnostic', { response, result }), [response, result]);
+
+  const runDiagnostic = async () => {
+    setLoading(true); setError(null);
+    try {
+      const res = await fetch('/api/ai/diagnostic', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ response }) });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || 'Diagnostic failed');
+      setResult(body as DiagnosticResult);
+      await saveOnboardingStep(11, { response, result: body });
+    } catch (e: any) { setError(e?.message || 'Could not run diagnostic'); }
+    finally { setLoading(false); }
+  };
+
+  return <StepLayout title="Quick writing diagnostic" subtitle="Write 80+ words about your IELTS goal. We’ll estimate your current band." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<div className="flex gap-2"><Button variant="secondary" disabled={loading || response.length < 20} onClick={()=>void runDiagnostic()}>{loading ? 'Analyzing…' : 'Run diagnostic'}</Button>{result && <Button onClick={()=>nav.next && router.push(nav.next.path)}>Continue</Button>}</div>}>
+    <textarea className="min-h-40 w-full rounded-xl border p-3" value={response} onChange={(e)=>setResponse(e.target.value)} placeholder="Tell us about your IELTS goal, challenges, and target score..." />
+    {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+    {result && <div className="mt-4 grid gap-2 rounded-xl border border-primary/30 bg-primary/5 p-4 text-sm sm:grid-cols-2"><p><strong>Estimated band:</strong> {result.estimated_band.toFixed(1)}</p><p><strong>Grammar:</strong> {result.grammar}</p><p><strong>Coherence:</strong> {result.coherence}</p><p><strong>Vocabulary:</strong> {result.vocabulary}</p></div>}
+    <p className="mt-3 text-xs text-muted-foreground">Draft saves automatically while typing.</p>
+  </StepLayout>;
+}

--- a/pages/onboarding/exam-timeline.tsx
+++ b/pages/onboarding/exam-timeline.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+const options = [
+  ['within_1_month', 'Within 1 month'],
+  ['within_3_months', 'Within 3 months'],
+  ['within_6_months', 'Within 6 months'],
+  ['not_scheduled', 'Not scheduled yet'],
+] as const;
+
+export default function ExamTimelinePage() {
+  const router = useRouter();
+  const nav = resolveNavigation('exam-timeline');
+  const [timeframe, setTimeframe] = useState('within_3_months');
+  const [examDate, setExamDate] = useState('');
+
+  useEffect(() => {
+    const d = loadDraft('exam-timeline', { timeframe: 'within_3_months', examDate: '' });
+    setTimeframe(d.timeframe); setExamDate(d.examDate);
+  }, []);
+  useEffect(() => saveDraft('exam-timeline', { timeframe, examDate }), [timeframe, examDate]);
+
+  return <StepLayout title="When is your exam?" subtitle="We use this to build a realistic timeline." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<Button onClick={async()=>{await saveOnboardingStep(6,{ timeframe, examDate: examDate || null }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button>}>
+    <div className="grid gap-3 sm:grid-cols-2">{options.map(([v,l]) => <button key={v} onClick={()=>setTimeframe(v)} className={`rounded-xl border p-4 text-left ${timeframe===v?'border-primary bg-primary/10':'border-border'}`}>{l}</button>)}</div>
+    <input type="date" className="mt-4 w-full rounded-xl border p-3 sm:w-auto" value={examDate} onChange={(e)=>setExamDate(e.target.value)} />
+  </StepLayout>;
+}

--- a/pages/onboarding/learning-style.tsx
+++ b/pages/onboarding/learning-style.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+const styles = [
+  ['visual', 'Visual (charts, diagrams)'],
+  ['auditory', 'Auditory (listening & speaking)'],
+  ['reading_writing', 'Reading/Writing'],
+  ['kinesthetic', 'Hands-on practice'],
+  ['mixed', 'Mixed'],
+] as const;
+
+export default function LearningStylePage() {
+  const router = useRouter();
+  const nav = resolveNavigation('learning-style');
+  const [learningStyle, setLearningStyle] = useState<(typeof styles)[number][0]>('mixed');
+
+  useEffect(() => {
+    const d = loadDraft('learning-style', { learningStyle: 'mixed' as const });
+    setLearningStyle(d.learningStyle);
+  }, []);
+  useEffect(() => saveDraft('learning-style', { learningStyle }), [learningStyle]);
+
+  return <StepLayout title="What learning style suits you?" subtitle="We'll tune exercises and explanations to your preference." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<Button onClick={async()=>{await saveOnboardingStep(8,{ learningStyle }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button>}>
+    <div className="grid gap-3 sm:grid-cols-2">{styles.map(([value,label])=><button key={value} onClick={()=>setLearningStyle(value)} className={`rounded-xl border p-4 text-left ${learningStyle===value?'border-primary bg-primary/10':'border-border'}`}>{label}</button>)}</div>
+  </StepLayout>;
+}

--- a/pages/onboarding/previous-ielts.tsx
+++ b/pages/onboarding/previous-ielts.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+export default function PreviousIeltsPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('previous-ielts');
+  const [taken, setTaken] = useState(false);
+  const [overallBand, setBand] = useState('6.0');
+  const [testDate, setDate] = useState('');
+
+  useEffect(() => {
+    const d = loadDraft('previous-ielts', { taken: false, overallBand: '6.0', testDate: '' });
+    setTaken(d.taken); setBand(d.overallBand); setDate(d.testDate);
+  }, []);
+  useEffect(() => saveDraft('previous-ielts', { taken, overallBand, testDate }), [taken, overallBand, testDate]);
+
+  return (
+    <StepLayout title="Have you taken IELTS before?" subtitle="Past attempts help us estimate your starting point." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<Button onClick={async()=>{await saveOnboardingStep(4,{ taken, overallBand: taken ? Number(overallBand) : null, testDate: taken ? testDate || null : null }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button>}>
+      <label className="flex items-center gap-2 rounded-xl border border-border p-4"><input type="checkbox" checked={taken} onChange={(e)=>setTaken(e.target.checked)} /> Yes, I've taken IELTS</label>
+      {taken && <div className="mt-4 grid gap-3 sm:grid-cols-2"><input className="rounded-xl border p-3" value={overallBand} onChange={(e)=>setBand(e.target.value)} placeholder="Overall band (e.g. 6.0)" /><input type="date" className="rounded-xl border p-3" value={testDate} onChange={(e)=>setDate(e.target.value)} /></div>}
+      <p className="mt-3 text-xs text-muted-foreground">Draft saved automatically on this device.</p>
+    </StepLayout>
+  );
+}

--- a/pages/onboarding/study-commitment.tsx
+++ b/pages/onboarding/study-commitment.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+const days = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const;
+
+export default function StudyCommitmentPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('study-commitment');
+  const [studyDays, setStudyDays] = useState<string[]>(['mon', 'wed', 'fri']);
+  const [minutesPerDay, setMinutes] = useState(45);
+
+  useEffect(() => {
+    const d = loadDraft('study-commitment', { studyDays: ['mon', 'wed', 'fri'], minutesPerDay: 45 });
+    setStudyDays(d.studyDays); setMinutes(d.minutesPerDay);
+  }, []);
+  useEffect(() => saveDraft('study-commitment', { studyDays, minutesPerDay }), [studyDays, minutesPerDay]);
+
+  const toggle = (d: string) => setStudyDays((prev) => prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d]);
+
+  return <StepLayout title="How much can you study?" subtitle="Pick your weekly days and average minutes per day." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<Button disabled={!studyDays.length} onClick={async()=>{await saveOnboardingStep(7,{ studyDays, minutesPerDay }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button>}>
+    <div className="mb-4 grid grid-cols-4 gap-2 sm:grid-cols-7">{days.map((d)=><button key={d} onClick={()=>toggle(d)} className={`rounded-lg border px-2 py-2 text-sm uppercase ${studyDays.includes(d)?'border-primary bg-primary/10':'border-border'}`}>{d}</button>)}</div>
+    <label className="text-sm font-medium">Minutes per day</label>
+    <input type="range" min={10} max={180} step={5} value={minutesPerDay} onChange={(e)=>setMinutes(Number(e.target.value))} className="mt-2 w-full"/>
+    <p className="mt-1 text-sm text-muted-foreground">{minutesPerDay} minutes/day</p>
+  </StepLayout>;
+}

--- a/pages/onboarding/weakness.tsx
+++ b/pages/onboarding/weakness.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Button } from '@/components/design-system/Button';
+import { StepLayout } from '@/components/onboarding/StepLayout';
+import { resolveNavigation, saveOnboardingStep } from '@/lib/onboarding/client';
+import { loadDraft, saveDraft } from '@/lib/onboarding/draft';
+
+const options = ['listening', 'reading', 'writing', 'speaking', 'grammar', 'vocabulary'];
+
+export default function WeaknessPage() {
+  const router = useRouter();
+  const nav = resolveNavigation('weakness');
+  const [weaknesses, setWeaknesses] = useState<string[]>(['writing']);
+
+  useEffect(() => {
+    const d = loadDraft('weakness', { weaknesses: ['writing'] });
+    setWeaknesses(d.weaknesses);
+  }, []);
+  useEffect(() => saveDraft('weakness', { weaknesses }), [weaknesses]);
+
+  const toggle = (v: string) => setWeaknesses((prev) => prev.includes(v) ? prev.filter((x) => x !== v) : prev.length < 3 ? [...prev, v] : prev);
+
+  return <StepLayout title="Where do you struggle most?" subtitle="Pick up to 3 areas. We'll prioritize them in your daily plan." step={nav.index + 1} total={nav.total} onBack={() => nav.prev && router.push(nav.prev.path)} footer={<Button disabled={!weaknesses.length} onClick={async()=>{await saveOnboardingStep(9,{ weaknesses }); if (nav.next) await router.push(nav.next.path);}}>Continue</Button>}>
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">{options.map((o)=><button key={o} className={`rounded-xl border p-3 text-left capitalize ${weaknesses.includes(o)?'border-primary bg-primary/10':'border-border'}`} onClick={()=>toggle(o)}>{o}</button>)}</div>
+    <p className="mt-3 text-xs text-muted-foreground">Selected: {weaknesses.length}/3</p>
+  </StepLayout>;
+}


### PR DESCRIPTION
### Motivation
- Expand the onboarding flow from a few steps to a full 12-step experience that captures richer user data (CEFR level, previous IELTS, exam timeline, study commitment, learning style, weaknesses, confidence, diagnostic, notifications). 
- Persist incomplete drafts locally during onboarding and consolidate onboarding data into profile `settings.onboarding` on the server. 
- Provide an automated writing diagnostic powered by the AI service to estimate current band and strengths/weaknesses. 

### Description
- Add a reusable `StepLayout` UI component for consistent onboarding pages and many new onboarding pages under `pages/onboarding/*` implementing steps 3–12 (current-level, previous-ielts, exam-timeline, study-commitment, learning-style, weakness, confidence, diagnostic). 
- Add onboarding client utilities (`lib/onboarding/client.ts`, `lib/onboarding/draft.ts`, `lib/onboarding/steps.ts`) to resolve navigation, save steps, and load/save drafts to `localStorage`. 
- Expand and reorganize the onboarding schema in `lib/onboarding/schema.ts` to a 12-step discriminated union plus new payload types and exported enums; bump `TOTAL_ONBOARDING_STEPS` to 12. 
- Update server APIs to support the new flow and settings: change `pages/api/onboarding/index.ts` to read/write `settings.onboarding`, persist intermediate drafts and rich fields, and adjust `pages/api/onboarding/complete.ts` to accept the updated final step and notification channel naming. 
- Add an AI diagnostic endpoint at `pages/api/ai/diagnostic.ts` that validates request/response with `zod` and uses the AI chat completion to return `grammar`, `coherence`, `vocabulary`, and `estimated_band`. 
- Update study plan generation (`lib/studyPlan.ts`) to accept additional onboarding inputs (current level, previous IELTS, confidence, diagnostic) and change `computeIntensity` to accept a `baselineBand`. 

### Testing
- Ran local TypeScript type checking (`yarn tsc`) and a Next.js build (`next build`) against the updated codebase and they completed successfully. }

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec402c4a88328bd9f1250143fbb28)