### PR TITLE
Fix placement entry links to point to runnable route

### DIFF
--- a/pages/onboarding/welcome/index.tsx
+++ b/pages/onboarding/welcome/index.tsx
@@ -266,7 +266,7 @@ export default function WelcomePage() {
                   <Link href="/dashboard">Skip for now · Go to dashboard</Link>
                 </Button>
                 <Button asChild variant="ghost" className="rounded-ds-xl">
-                  <Link href="/band-predictor">Try Band Predictor</Link>
+                  <Link href="/placement/run">Try Band Predictor</Link>
                 </Button>
               </div>
             </div>
@@ -318,7 +318,7 @@ export default function WelcomePage() {
               variant="secondary"
               className="rounded-ds-xl"
             >
-              <Link href="/band-predictor">Start test</Link>
+              <Link href="/placement/run">Start test</Link>
             </Button>
           </div>
           <div className="rounded-ds-2xl border border-border bg-card p-5">
@@ -495,7 +495,7 @@ export default function WelcomePage() {
               </p>
             </div>
             <Button asChild className="rounded-ds-xl">
-              <Link href="/band-predictor">Start now</Link>
+              <Link href="/placement/run">Start now</Link>
             </Button>
           </div>
         </div>

--- a/pages/placement/start.tsx
+++ b/pages/placement/start.tsx
@@ -23,7 +23,7 @@ export default function PlacementStartPage() {
           </ul>
 
           <div className="flex gap-3">
-            <Button as="a" href="/placement/quiz" variant="primary" className="rounded-ds-xl">
+            <Button as="a" href="/placement/run" variant="primary" className="rounded-ds-xl">
               Begin →
             </Button>
             <Button as="a" href="/placement" variant="secondary" className="rounded-ds-xl">


### PR DESCRIPTION
### Motivation
- The "Begin" CTA on the placement start screen pointed to a non-existent route (`/placement/quiz`) instead of the actual runnable placement flow, which would break navigation into the placement flow. 
- Onboarding and other CTAs still referenced an old `band-predictor` target that does not match the available placement pages, so they needed to be normalized to the runnable route.

### Description
- Changed the primary button in `pages/placement/start.tsx` from `href="/placement/quiz"` to `href="/placement/run"` so the Begin button launches the runnable placement flow. 
- Updated onboarding CTAs in `pages/onboarding/welcome/index.tsx` to use `href="/placement/run"` where they previously referenced `/band-predictor`. 
- Scanned related placement entry points and navigation (including `pages/placement/index.tsx`, `components/navigation/ModuleMenu.tsx`, and `components/layouts/ReportsLayout.tsx`) and left existing links that already pointed to valid routes unchanged.

### Testing
- Ran repository searches for placement-related links with `rg` to find stale references and verified no remaining references to `/placement/quiz` or `/band-predictor` after changes, and the searches succeeded. 
- Verified presence of placement pages with a file existence check for `pages/placement/index.tsx`, `pages/placement/run.tsx`, `pages/placement/result.tsx`, and `pages/placement/start.tsx`, and all files were present. 
- Re-ran targeted `rg` queries to confirm updated links (e.g. `href="/placement/run"`) are present and consistent, and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0888d2e048320b4b5bfc90e003fe8)