### PR TITLE
Unify onboarding notification channel identifiers across frontend/backend

### DIFF
--- a/lib/onboarding/schema.ts
+++ b/lib/onboarding/schema.ts
@@ -3,7 +3,14 @@ import { z } from 'zod';
 const supportedLanguageCodes = ['en', 'ur'] as const;
 const cefrLevels = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const;
 const learningStyles = ['visual', 'auditory', 'reading_writing', 'kinesthetic', 'mixed'] as const;
-const weaknesses = ['listening', 'reading', 'writing', 'speaking', 'grammar', 'vocabulary'] as const;
+const weaknesses = [
+  'listening',
+  'reading',
+  'writing',
+  'speaking',
+  'grammar',
+  'vocabulary',
+] as const;
 
 export const languageOptions = [
   { value: 'en', label: 'English' },
@@ -16,6 +23,12 @@ const CEFRLevelEnum = z.enum(cefrLevels);
 const LearningStyleEnum = z.enum(learningStyles);
 const WeaknessEnum = z.enum(weaknesses);
 export const NotificationChannelEnum = z.enum(['in_app', 'whatsapp', 'email'] as const);
+export type NotificationChannel = z.infer<typeof NotificationChannelEnum>;
+export const NOTIFICATION_CHANNELS_IN_DISPLAY_ORDER: readonly NotificationChannel[] = [
+  'email',
+  'whatsapp',
+  'in_app',
+] as const;
 const PhoneSchema = z.union([z.string().min(6).max(32), z.literal('')]);
 
 export const LanguageBody = z.object({
@@ -95,8 +108,14 @@ export const onboardingStateSchema = z.object({
 export type OnboardingState = z.infer<typeof onboardingStateSchema>;
 
 const StepOneSchema = z.object({ step: z.literal(1), data: z.object({}) });
-const StepTwoSchema = z.object({ step: z.literal(2), data: z.object({ preferredLanguage: LanguageEnum }) });
-const StepThreeSchema = z.object({ step: z.literal(3), data: z.object({ currentLevel: CEFRLevelEnum }) });
+const StepTwoSchema = z.object({
+  step: z.literal(2),
+  data: z.object({ preferredLanguage: LanguageEnum }),
+});
+const StepThreeSchema = z.object({
+  step: z.literal(3),
+  data: z.object({ currentLevel: CEFRLevelEnum }),
+});
 const StepFourSchema = z.object({
   step: z.literal(4),
   data: z.object({
@@ -105,7 +124,10 @@ const StepFourSchema = z.object({
     testDate: z.string().optional().nullable(),
   }),
 });
-const StepFiveSchema = z.object({ step: z.literal(5), data: z.object({ goalBand: z.number().min(4).max(9) }) });
+const StepFiveSchema = z.object({
+  step: z.literal(5),
+  data: z.object({ goalBand: z.number().min(4).max(9) }),
+});
 const StepSixSchema = z.object({
   step: z.literal(6),
   data: z.object({
@@ -120,13 +142,25 @@ const StepSevenSchema = z.object({
     minutesPerDay: z.number().int().min(10).max(360),
   }),
 });
-const StepEightSchema = z.object({ step: z.literal(8), data: z.object({ learningStyle: LearningStyleEnum }) });
-const StepNineSchema = z.object({ step: z.literal(9), data: z.object({ weaknesses: z.array(WeaknessEnum).min(1).max(3) }) });
+const StepEightSchema = z.object({
+  step: z.literal(8),
+  data: z.object({ learningStyle: LearningStyleEnum }),
+});
+const StepNineSchema = z.object({
+  step: z.literal(9),
+  data: z.object({ weaknesses: z.array(WeaknessEnum).min(1).max(3) }),
+});
 const StepTenSchema = z.object({
   step: z.literal(10),
-  data: z.object({ writing: z.number().int().min(1).max(5), speaking: z.number().int().min(1).max(5) }),
+  data: z.object({
+    writing: z.number().int().min(1).max(5),
+    speaking: z.number().int().min(1).max(5),
+  }),
 });
-const StepElevenSchema = z.object({ step: z.literal(11), data: z.object({ response: z.string().min(20), result: DiagnosticResultSchema.optional() }) });
+const StepElevenSchema = z.object({
+  step: z.literal(11),
+  data: z.object({ response: z.string().min(20), result: DiagnosticResultSchema.optional() }),
+});
 const StepTwelveSchema = z.object({
   step: z.literal(12),
   data: z.object({

--- a/pages/api/onboarding/complete.ts
+++ b/pages/api/onboarding/complete.ts
@@ -2,6 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 
+import { NotificationChannelEnum } from '@/lib/onboarding/schema';
 import { getServerClient } from '@/lib/supabaseServer';
 
 const Body = z.object({
@@ -14,10 +15,7 @@ const Body = z.object({
       }),
     ])
     .optional(),
-  channels: z
-    .array(z.enum(['email', 'whatsapp', 'in_app']))
-    .min(1)
-    .optional(),
+  channels: z.array(NotificationChannelEnum).min(1).optional(),
 });
 
 function normalizeBody(req: NextApiRequest): unknown {
@@ -42,10 +40,7 @@ function normalizeBody(req: NextApiRequest): unknown {
   return raw;
 }
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
@@ -53,18 +48,13 @@ export default async function handler(
   const body = normalizeBody(req);
   const parse = Body.safeParse(body);
 
-  let step = 12;
-  let channels: ('email' | 'whatsapp' | 'in_app')[] | undefined;
-
-  if (parse.success) {
-    step = parse.data.step ?? 12;
-    channels = parse.data.channels;
-  } else {
-    console.warn(
-      'onboarding/complete: body validation failed',
-      parse.error.flatten()
-    );
+  if (!parse.success) {
+    console.warn('onboarding/complete: body validation failed', parse.error.flatten());
+    return res.status(400).json({ error: 'Invalid request body' });
   }
+
+  const step = parse.data.step ?? 12;
+  const channels = parse.data.channels;
 
   const supabase = getServerClient(req, res);
   const {
@@ -90,10 +80,7 @@ export default async function handler(
     patch.notification_channels = channels;
   }
 
-  const { error: updateError } = await supabase
-    .from('profiles')
-    .update(patch)
-    .eq('id', user.id);
+  const { error: updateError } = await supabase.from('profiles').update(patch).eq('id', user.id);
 
   if (updateError) {
     console.error('onboarding/complete update error:', updateError);
@@ -102,7 +89,7 @@ export default async function handler(
 
   // 🔁 Sync the onboarding_complete flag to the user's metadata
   const { error: metadataError } = await supabase.auth.updateUser({
-    data: { onboarding_complete: true }
+    data: { onboarding_complete: true },
   });
 
   if (metadataError) {

--- a/pages/onboarding/notifications.tsx
+++ b/pages/onboarding/notifications.tsx
@@ -7,13 +7,12 @@ import { Button } from '@/components/design-system/Button';
 import { Icon } from '@/components/design-system/Icon';
 import { cn } from '@/lib/utils';
 import { supabase } from '@/lib/supabaseClient'; // adjust import to your client
+import {
+  NOTIFICATION_CHANNELS_IN_DISPLAY_ORDER,
+  type NotificationChannel,
+} from '@/lib/onboarding/schema';
 
-type OnboardingStepId =
-  | 'language'
-  | 'target-band'
-  | 'exam-date'
-  | 'study-rhythm'
-  | 'notifications';
+type OnboardingStepId = 'language' | 'target-band' | 'exam-date' | 'study-rhythm' | 'notifications';
 
 const ONBOARDING_STEPS: { id: OnboardingStepId; label: string }[] = [
   { id: 'language', label: 'Language' },
@@ -31,7 +30,7 @@ const STEP_ROUTES: Record<OnboardingStepId, string> = {
   notifications: '/onboarding/notifications',
 };
 
-type ChannelId = 'email' | 'whatsapp' | 'in-app';
+type ChannelId = NotificationChannel;
 
 interface ChannelOption {
   id: ChannelId;
@@ -53,7 +52,7 @@ const CHANNEL_OPTIONS: ChannelOption[] = [
     description: 'Short nudges, streak alerts, and quick links to practice.',
   },
   {
-    id: 'in-app',
+    id: 'in_app',
     label: 'In-app only',
     description: 'Silent mode. See reminders only inside GramorX.',
   },
@@ -63,7 +62,7 @@ const OnboardingNotificationsPage: NextPage = () => {
   const router = useRouter();
 
   const [selectedChannels, setSelectedChannels] = useState<ChannelId[]>([
-    'email',
+    NOTIFICATION_CHANNELS_IN_DISPLAY_ORDER[0],
   ]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -86,14 +85,14 @@ const OnboardingNotificationsPage: NextPage = () => {
 
   const currentIndex = useMemo(
     () => ONBOARDING_STEPS.findIndex((s) => s.id === 'notifications'),
-    []
+    [],
   );
 
   const hasChannel = selectedChannels.length > 0;
 
   function toggleChannel(id: ChannelId) {
     setSelectedChannels((prev) =>
-      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id]
+      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id],
     );
   }
 
@@ -130,7 +129,9 @@ const OnboardingNotificationsPage: NextPage = () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           step: 5,
-          channels: selectedChannels,
+          channels: NOTIFICATION_CHANNELS_IN_DISPLAY_ORDER.filter((channel) =>
+            selectedChannels.includes(channel),
+          ),
         }),
       });
 
@@ -154,9 +155,7 @@ const OnboardingNotificationsPage: NextPage = () => {
     } catch (e: any) {
       // eslint-disable-next-line no-console
       console.error(e);
-      setError(
-        e?.message || 'Could not save your notification settings. Try again.'
-      );
+      setError(e?.message || 'Could not save your notification settings. Try again.');
     } finally {
       setSubmitting(false);
     }
@@ -185,9 +184,8 @@ const OnboardingNotificationsPage: NextPage = () => {
                 How should we keep you on track?
               </h1>
               <p className="mt-2 text-sm text-muted-foreground sm:text-base">
-                Choose where you want to receive study nudges, streak alerts,
-                and mock test reminders. No spam — only what helps your band
-                score.
+                Choose where you want to receive study nudges, streak alerts, and mock test
+                reminders. No spam — only what helps your band score.
               </p>
             </div>
 
@@ -209,9 +207,7 @@ const OnboardingNotificationsPage: NextPage = () => {
             ))}
           </div>
 
-          {error && (
-            <p className="mt-3 text-sm font-medium text-destructive">{error}</p>
-          )}
+          {error && <p className="mt-3 text-sm font-medium text-destructive">{error}</p>}
 
           <p className="mt-4 text-xs text-muted-foreground sm:text-sm">
             You can fine-tune these later from{' '}
@@ -237,11 +233,7 @@ const OnboardingNotificationsPage: NextPage = () => {
                   {nextPath === '/onboarding/study-plan' ? 'your AI study plan' : nextPath}
                 </span>
               </p>
-              <Button
-                size="lg"
-                onClick={handleFinish}
-                disabled={submitting || !hasChannel}
-              >
+              <Button size="lg" onClick={handleFinish} disabled={submitting || !hasChannel}>
                 {submitting ? 'Finishing…' : 'Finish & continue'}
                 <Icon name="arrow-right" className="ml-2 h-4 w-4" />
               </Button>
@@ -276,29 +268,17 @@ const OnboardingProgress: React.FC<OnboardingProgressProps> = ({
             <div
               className={cn(
                 'flex h-7 w-7 items-center justify-center rounded-full border text-xs font-semibold',
-                completed &&
-                  'border-primary bg-primary text-primary-foreground',
-                active &&
-                  !completed &&
-                  'border-primary/80 bg-primary/10 text-primary',
-                !active &&
-                  !completed &&
-                  'border-border bg-muted text-muted-foreground'
+                completed && 'border-primary bg-primary text-primary-foreground',
+                active && !completed && 'border-primary/80 bg-primary/10 text-primary',
+                !active && !completed && 'border-border bg-muted text-muted-foreground',
               )}
             >
-              {completed ? (
-                <Icon name="check" className="h-3.5 w-3.5" />
-              ) : (
-                index + 1
-              )}
+              {completed ? <Icon name="check" className="h-3.5 w-3.5" /> : index + 1}
             </div>
           );
 
           return (
-            <div
-              key={step.id}
-              className="flex flex-1 items-center last:flex-none"
-            >
+            <div key={step.id} className="flex flex-1 items-center last:flex-none">
               {onStepClick ? (
                 <button
                   type="button"
@@ -316,7 +296,7 @@ const OnboardingProgress: React.FC<OnboardingProgressProps> = ({
                   className={cn(
                     'mx-1 h-px flex-1 rounded-full bg-border',
                     completed && 'bg-primary/70',
-                    active && 'bg-primary/50'
+                    active && 'bg-primary/50',
                   )}
                 />
               )}
@@ -340,7 +320,7 @@ const OnboardingProgress: React.FC<OnboardingProgressProps> = ({
               <span
                 className={cn(
                   'flex-1 truncate text-center',
-                  active && 'font-medium text-foreground'
+                  active && 'font-medium text-foreground',
                 )}
               >
                 {step.label}
@@ -359,11 +339,7 @@ interface ChannelCardProps {
   onToggle: () => void;
 }
 
-const ChannelCard: React.FC<ChannelCardProps> = ({
-  option,
-  selected,
-  onToggle,
-}) => {
+const ChannelCard: React.FC<ChannelCardProps> = ({ option, selected, onToggle }) => {
   const { label, description, badge } = option;
 
   return (
@@ -374,7 +350,7 @@ const ChannelCard: React.FC<ChannelCardProps> = ({
         'group flex h-full flex-col justify-between rounded-2xl border p-4 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:p-5',
         selected
           ? 'border-primary bg-primary/10 shadow-md'
-          : 'border-border bg-muted/40 hover:border-primary/60 hover:bg-muted'
+          : 'border-border bg-muted/40 hover:border-primary/60 hover:bg-muted',
       )}
     >
       <div className="mb-2 flex items-start justify-between gap-2">
@@ -385,9 +361,7 @@ const ChannelCard: React.FC<ChannelCardProps> = ({
             </span>
             <span className="text-base font-semibold sm:text-lg">{label}</span>
           </div>
-          <p className="mt-2 text-xs text-muted-foreground sm:text-sm">
-            {description}
-          </p>
+          <p className="mt-2 text-xs text-muted-foreground sm:text-sm">{description}</p>
         </div>
 
         <div
@@ -395,7 +369,7 @@ const ChannelCard: React.FC<ChannelCardProps> = ({
             'flex h-5 w-5 items-center justify-center rounded-full border text-[10px] font-semibold transition-colors',
             selected
               ? 'border-primary bg-primary text-primary-foreground'
-              : 'border-border bg-background text-muted-foreground group-hover:border-primary/70'
+              : 'border-border bg-background text-muted-foreground group-hover:border-primary/70',
           )}
         >
           {selected ? <Icon name="check" className="h-3 w-3" /> : ''}


### PR DESCRIPTION
### Motivation
- Prevent identifier drift between frontend and backend by standardizing notification channel IDs and using a single shared source of truth. 
- Ensure the onboarding completion API receives a deterministic, backend-compatible `channels` payload (exactly `['email','whatsapp','in_app']` when all are selected). 
- Make request validation strict so malformed bodies are rejected instead of partially applied. 

### Description
- Added shared exports in `lib/onboarding/schema.ts`: `NotificationChannel` type and `NOTIFICATION_CHANNELS_IN_DISPLAY_ORDER` constant and kept the existing `NotificationChannelEnum` for validation. 
- Updated `pages/onboarding/notifications.tsx` to import the shared types/constants, switch the frontend ID from `'in-app'` to `'in_app'`, and submit channels in canonical order using `NOTIFICATION_CHANNELS_IN_DISPLAY_ORDER.filter(...)`. 
- Updated `pages/api/onboarding/complete.ts` to use the shared `NotificationChannelEnum` for validation and to return `400` (`res.status(400)`) when the request body fails schema validation instead of silently proceeding. 

### Testing
- Ran `npx prettier --write` on modified files and it completed successfully. 
- Attempted to run `npx eslint` but it failed in this environment due to a missing local eslint dependency/config (`@eslint/eslintrc`), so linting could not be validated here. 
- Performed code searches to verify identifier changes and canonical ordering (`rg`/grep checks returned the updated occurrences).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0889fa87c8320aae52d03cd0b1234)