### PR TITLE
Fix placement score persistence to use supabaseAdmin client export

### DIFF
--- a/pages/api/placement/score.ts
+++ b/pages/api/placement/score.ts
@@ -247,7 +247,12 @@ async function persistResult(result: ScoreResult, req: NextApiRequest) {
   // Try dynamic import so this file works even if supabase isn’t set up yet.
   try {
     const mod = await import('@/lib/supabaseAdmin');
-    const { supaAdmin } = mod as any;
+    const { supabaseAdmin } = mod as any;
+
+    if (!supabaseAdmin) {
+      console.error('placement_results: supabaseAdmin client is undefined');
+      return;
+    }
 
     const userId =
       (req.headers['x-user-id'] as string) ||
@@ -255,7 +260,7 @@ async function persistResult(result: ScoreResult, req: NextApiRequest) {
       null;
 
     // Store as-is; table columns: user_id, accuracy, band, correct, total, by_skill, guidance
-    await supaAdmin.from('placement_results').insert({
+    await supabaseAdmin.from('placement_results').insert({
       user_id: userId,
       accuracy: result.accuracy,
       band: result.band,


### PR DESCRIPTION
### Motivation
- `persistResult()` was importing and using a non-existent `supaAdmin` binding which does not match the actual export in `lib/supabaseAdmin.ts`, risking runtime failures when persisting placement results.

### Description
- Change dynamic import to destructure `supabaseAdmin` and update the insert call to `supabaseAdmin.from('placement_results').insert(...)`, and add a defensive guard that logs a clear error and returns early if `supabaseAdmin` is undefined.

### Testing
- Ran `npx eslint pages/api/placement/score.ts` which failed in this environment due to a local dependency/configuration error (`@eslint/eslintrc` resolution), not due to the code change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08a83da78832082ddaa7657e40639)