### PR TITLE
Add listening incomplete manifest, route guards, and API 501 telemetry responses

### DIFF
--- a/components/listening/ListeningHero.tsx
+++ b/components/listening/ListeningHero.tsx
@@ -16,9 +16,6 @@ export function ListeningHero() {
         — Academic & General. Start where you are, and level up fast.
       </p>
       <div className="mt-2 flex flex-wrap items-center gap-3">
-        <Link href="/tools/listening/dictation" className="inline-flex">
-          <Button>Try AI Dictation</Button>
-        </Link>
         <Link href="/mock/listening/start" className="inline-flex">
           <Button variant="secondary">Begin a Mock</Button>
         </Link>

--- a/components/listening/NotAvailableYet.tsx
+++ b/components/listening/NotAvailableYet.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+type NotAvailableYetProps = {
+  feature: string;
+};
+
+export default function NotAvailableYet({ feature }: NotAvailableYetProps) {
+  return (
+    <main className="mx-auto flex min-h-[50vh] w-full max-w-2xl flex-col items-center justify-center gap-3 px-6 py-12 text-center">
+      <h1 className="text-2xl font-semibold">Not available yet</h1>
+      <p className="text-sm text-muted-foreground">
+        {feature} is still in development. Please check back after this feature moves out of
+        incomplete status.
+      </p>
+      <Link href="/listening" className="text-sm font-medium text-primary underline-offset-4 hover:underline">
+        Back to Listening hub
+      </Link>
+    </main>
+  );
+}

--- a/config/feature-status.manifest.json
+++ b/config/feature-status.manifest.json
@@ -1,0 +1,46 @@
+{
+  "domains": {
+    "listening": {
+      "status": "incomplete",
+      "placeholders": [
+        { "path": "components/listening/SaveButton.tsx", "status": "incomplete" },
+        { "path": "components/listening/analytics/DrillBreakdown.tsx", "status": "incomplete" },
+        { "path": "components/listening/dictation/DictationEditor.tsx", "status": "incomplete" },
+        { "path": "components/listening/players/AccentSwitcher.tsx", "status": "incomplete" },
+        { "path": "components/listening/quizzes/TimedMiniTest.tsx", "status": "incomplete" },
+        { "path": "components/listening/accent/AccentClip.tsx", "status": "incomplete" },
+        { "path": "lib/ai/listening/dictationAdapter.ts", "status": "incomplete" },
+        { "path": "lib/listening/accentMap.ts", "status": "incomplete" },
+        { "path": "lib/listening/errors.ts", "status": "incomplete" },
+        { "path": "lib/listening/insights.ts", "status": "incomplete" },
+        { "path": "pages/practice/listening/daily.tsx", "status": "incomplete" },
+        { "path": "pages/learn/listening/tips.tsx", "status": "incomplete" },
+        { "path": "pages/learn/listening/coach.tsx", "status": "incomplete" },
+        { "path": "pages/learn/listening/mistakes.tsx", "status": "incomplete" },
+        { "path": "pages/tools/listening/accent-trainer.tsx", "status": "incomplete" },
+        { "path": "pages/tools/listening/dictation.tsx", "status": "incomplete" },
+        { "path": "pages/analytics/listening.tsx", "status": "incomplete" },
+        { "path": "pages/analytics/listening/trajectory.tsx", "status": "incomplete" },
+        { "path": "pages/me/listening/saved.tsx", "status": "incomplete" },
+        { "path": "pages/mock/listening/result.tsx", "status": "incomplete" },
+        { "path": "pages/api/dev/seed/listening-one.ts", "status": "incomplete" },
+        { "path": "pages/api/ai/listening/coach.ts", "status": "incomplete" },
+        { "path": "pages/api/ai/listening/dictation.grade.ts", "status": "incomplete" },
+        { "path": "pages/api/ai/listening/accent.check.ts", "status": "incomplete" },
+        { "path": "pages/api/mock/listening/create-run.ts", "status": "incomplete" },
+        { "path": "pages/api/mock/listening/save-answers.ts", "status": "incomplete" },
+        { "path": "pages/api/mock/listening/play-ping.ts", "status": "incomplete" },
+        { "path": "pages/api/mock/listening/submit-final.ts", "status": "incomplete" },
+        { "path": "pages/api/admin/listening/tips.moderate.ts", "status": "incomplete" },
+        { "path": "pages/api/listening/attempts/export.csv.ts", "status": "incomplete" },
+        { "path": "pages/api/listening/attempts/log.ts", "status": "incomplete" },
+        { "path": "pages/api/listening/mistakes/review.ts", "status": "incomplete" },
+        { "path": "pages/api/listening/practice/toggle.ts", "status": "incomplete" },
+        { "path": "pages/api/listening/tips/submit.ts", "status": "incomplete" },
+        { "path": "pages/api/listening/save.ts", "status": "incomplete" },
+        { "path": "pages/api/listening/mini/grade.ts", "status": "incomplete" },
+        { "path": "scripts/ensure-listening-tree.sh", "status": "incomplete" }
+      ]
+    }
+  }
+}

--- a/docs/listening-implementation-backlog.md
+++ b/docs/listening-implementation-backlog.md
@@ -1,0 +1,129 @@
+# Listening Placeholder Implementation Backlog
+
+Checklist of all files identified via the `"Auto-generated placeholder"` search and the implementation work needed before changing status away from `incomplete`.
+
+## Pages (`pages/`)
+
+- [ ] `pages/practice/listening/daily.tsx`
+  - Steps: build daily practice flow (content feed, streak integration, attempt persistence).
+  - Acceptance: authenticated user can start/complete daily session and see persisted outcome.
+- [ ] `pages/learn/listening/tips.tsx`
+  - Steps: implement tips catalog UI, filters, and CMS/data source wiring.
+  - Acceptance: tips load from source, filters work, and empty/error states are handled.
+- [ ] `pages/learn/listening/coach.tsx`
+  - Steps: implement AI coach session UI, prompt controls, response rendering.
+  - Acceptance: coach returns structured feedback and stores conversation history.
+- [ ] `pages/learn/listening/mistakes.tsx`
+  - Steps: implement mistake review list, remediation actions, and progress tracking.
+  - Acceptance: users can view unresolved mistakes and mark them reviewed.
+- [ ] `pages/tools/listening/accent-trainer.tsx`
+  - Steps: build accent selection/training interface with scoring feedback.
+  - Acceptance: user submits accent attempt and sees deterministic score breakdown.
+- [ ] `pages/tools/listening/dictation.tsx`
+  - Steps: implement dictation player/editor and grading interaction.
+  - Acceptance: user can submit transcript and receive word-level corrections.
+- [ ] `pages/analytics/listening.tsx`
+  - Steps: implement analytics dashboard (trend cards, weak-skill insights).
+  - Acceptance: dashboard loads historical metrics and renders without placeholder content.
+- [ ] `pages/analytics/listening/trajectory.tsx`
+  - Steps: implement trajectory charting and date-range controls.
+  - Acceptance: chart displays historical attempts with selectable time windows.
+- [ ] `pages/me/listening/saved.tsx`
+  - Steps: implement saved resources list, delete actions, pagination.
+  - Acceptance: saved listening resources can be listed and unsaved by user.
+- [ ] `pages/mock/listening/result.tsx`
+  - Steps: implement legacy result surface or redirect to canonical dynamic route.
+  - Acceptance: route no longer placeholder and presents valid result state.
+
+## APIs (`pages/api/`)
+
+- [ ] `pages/api/dev/seed/listening-one.ts`
+  - Steps: add seed payload validation and idempotent seed transaction.
+  - Acceptance: endpoint creates deterministic seed set with audit logs.
+- [ ] `pages/api/ai/listening/coach.ts`
+  - Steps: integrate AI coach runtime, schema-validated inputs/outputs, rate limiting.
+  - Acceptance: returns coach guidance payload and logs token/cost telemetry.
+- [ ] `pages/api/ai/listening/dictation.grade.ts`
+  - Steps: integrate dictation grading engine and error taxonomy.
+  - Acceptance: returns normalized grading JSON with actionable corrections.
+- [ ] `pages/api/ai/listening/accent.check.ts`
+  - Steps: integrate accent analysis provider and confidence thresholds.
+  - Acceptance: response includes accent signals, confidence, and fallback behavior.
+- [ ] `pages/api/mock/listening/create-run.ts`
+  - Steps: create run lifecycle record with auth and test assignment.
+  - Acceptance: returns run identifier and initializes per-section state.
+- [ ] `pages/api/mock/listening/save-answers.ts`
+  - Steps: implement batched answer upsert with optimistic concurrency.
+  - Acceptance: accepted answers persist and return revision metadata.
+- [ ] `pages/api/mock/listening/play-ping.ts`
+  - Steps: implement audio-play telemetry ingestion and anti-spam guard.
+  - Acceptance: valid pings recorded with run/section linkage.
+- [ ] `pages/api/mock/listening/submit-final.ts`
+  - Steps: finalize run, compute scoring, lock run for edits.
+  - Acceptance: final submission returns immutable result summary.
+- [ ] `pages/api/admin/listening/tips.moderate.ts`
+  - Steps: implement moderation queue actions with role-based access control.
+  - Acceptance: only admins can approve/reject and actions are auditable.
+- [ ] `pages/api/listening/attempts/export.csv.ts`
+  - Steps: implement CSV generation pipeline and access checks.
+  - Acceptance: downloads standards-compliant CSV with scoped records.
+- [ ] `pages/api/listening/attempts/log.ts`
+  - Steps: implement attempt event ingestion validation and storage.
+  - Acceptance: event schema enforced and invalid events rejected with 4xx.
+- [ ] `pages/api/listening/mistakes/review.ts`
+  - Steps: implement review mutation endpoint for mistake lifecycle.
+  - Acceptance: review updates persisted and reflected in subsequent fetches.
+- [ ] `pages/api/listening/practice/toggle.ts`
+  - Steps: implement practice preference toggle persistence.
+  - Acceptance: preference toggles survive refresh and return current value.
+- [ ] `pages/api/listening/tips/submit.ts`
+  - Steps: implement tip submission with sanitization/moderation metadata.
+  - Acceptance: submission accepted, stored, and queued for moderation.
+- [ ] `pages/api/listening/save.ts`
+  - Steps: implement saved-resource write path and duplicate protection.
+  - Acceptance: save succeeds once per user/resource and supports idempotency.
+- [ ] `pages/api/listening/mini/grade.ts`
+  - Steps: implement mini-test grading + feedback normalization.
+  - Acceptance: endpoint returns score, band mapping, and rationale fields.
+
+## Components (`components/`)
+
+- [ ] `components/listening/SaveButton.tsx`
+  - Steps: implement authenticated save toggle UI with pending/success states.
+  - Acceptance: button reflects saved state and error rollback behavior.
+- [ ] `components/listening/analytics/DrillBreakdown.tsx`
+  - Steps: implement drill chart/summary widgets from analytics data contracts.
+  - Acceptance: component renders deterministic visual output for fixture data.
+- [ ] `components/listening/dictation/DictationEditor.tsx`
+  - Steps: implement editor interactions, timestamp markers, and validation.
+  - Acceptance: editor supports edit/submit/reset and accessibility keyboard flows.
+- [ ] `components/listening/players/AccentSwitcher.tsx`
+  - Steps: implement accent switching UI + selected state persistence.
+  - Acceptance: selection updates player source and preference is restored.
+- [ ] `components/listening/quizzes/TimedMiniTest.tsx`
+  - Steps: implement timed question workflow and autosubmit on timeout.
+  - Acceptance: timer, submission, and score callbacks behave predictably.
+- [ ] `components/listening/accent/AccentClip.tsx`
+  - Steps: implement clip playback controls and transcript/metadata display.
+  - Acceptance: clip loads playable media with proper loading/error states.
+
+## Libraries (`lib/`)
+
+- [ ] `lib/ai/listening/dictationAdapter.ts`
+  - Steps: implement provider adapter, retries, and schema normalization.
+  - Acceptance: adapter returns stable typed response for supported providers.
+- [ ] `lib/listening/accentMap.ts`
+  - Steps: define canonical accent mapping and utility helpers.
+  - Acceptance: mapping covers required accents and passes type-level checks.
+- [ ] `lib/listening/errors.ts`
+  - Steps: define listening error classes/codes and serializer helpers.
+  - Acceptance: shared errors produce consistent API-safe payloads.
+- [ ] `lib/listening/insights.ts`
+  - Steps: implement insight derivation utilities from attempt metrics.
+  - Acceptance: helper returns repeatable insights for fixed fixtures.
+
+## Tooling
+
+- [ ] `scripts/ensure-listening-tree.sh`
+  - Steps: replace placeholder templates with scaffolds aligned to production conventions.
+  - Acceptance: generator creates non-placeholder starter files and passes shell lint.

--- a/lib/api/respondWithIncomplete.ts
+++ b/lib/api/respondWithIncomplete.ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type IncompleteApiArgs = {
+  req: NextApiRequest;
+  res: NextApiResponse;
+  endpoint: string;
+  code: string;
+};
+
+export function respondWithIncompleteApi({ req, res, endpoint, code }: IncompleteApiArgs) {
+  const telemetry = {
+    tag: 'api_incomplete',
+    domain: 'listening',
+    endpoint,
+    method: req.method ?? 'UNKNOWN',
+    code,
+  };
+
+  console.warn('[telemetry] incomplete_api_called', telemetry);
+
+  res.setHeader('X-GramorX-Telemetry-Tag', telemetry.tag);
+  res.status(501).json({
+    error: 'Not available yet',
+    code,
+    domain: telemetry.domain,
+    endpoint: telemetry.endpoint,
+    telemetryTag: telemetry.tag,
+  });
+}

--- a/pages/analytics/listening.tsx
+++ b/pages/analytics/listening.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/analytics/listening/trajectory.tsx
+++ b/pages/analytics/listening/trajectory.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/api/admin/listening/tips.moderate.ts
+++ b/pages/api/admin/listening/tips.moderate.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/admin/listening/tips.moderate.ts',
+    code: 'LISTENING_INCOMPLETE_ADMIN_LISTENING_TIPS_MODERATE',
+  });
 }

--- a/pages/api/ai/listening/accent.check.ts
+++ b/pages/api/ai/listening/accent.check.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/ai/listening/accent.check.ts',
+    code: 'LISTENING_INCOMPLETE_AI_LISTENING_ACCENT_CHECK',
+  });
 }

--- a/pages/api/ai/listening/coach.ts
+++ b/pages/api/ai/listening/coach.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/ai/listening/coach.ts',
+    code: 'LISTENING_INCOMPLETE_AI_LISTENING_COACH',
+  });
 }

--- a/pages/api/ai/listening/dictation.grade.ts
+++ b/pages/api/ai/listening/dictation.grade.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/ai/listening/dictation.grade.ts',
+    code: 'LISTENING_INCOMPLETE_AI_LISTENING_DICTATION_GRADE',
+  });
 }

--- a/pages/api/dev/seed/listening-one.ts
+++ b/pages/api/dev/seed/listening-one.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/dev/seed/listening-one.ts',
+    code: 'LISTENING_INCOMPLETE_DEV_SEED_LISTENING_ONE',
+  });
 }

--- a/pages/api/listening/attempts/export.csv.ts
+++ b/pages/api/listening/attempts/export.csv.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/listening/attempts/export.csv.ts',
+    code: 'LISTENING_INCOMPLETE_LISTENING_ATTEMPTS_EXPORT_CSV',
+  });
 }

--- a/pages/api/listening/attempts/log.ts
+++ b/pages/api/listening/attempts/log.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/listening/attempts/log.ts',
+    code: 'LISTENING_INCOMPLETE_LISTENING_ATTEMPTS_LOG',
+  });
 }

--- a/pages/api/listening/mini/grade.ts
+++ b/pages/api/listening/mini/grade.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/listening/mini/grade.ts',
+    code: 'LISTENING_INCOMPLETE_LISTENING_MINI_GRADE',
+  });
 }

--- a/pages/api/listening/mistakes/review.ts
+++ b/pages/api/listening/mistakes/review.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/listening/mistakes/review.ts',
+    code: 'LISTENING_INCOMPLETE_LISTENING_MISTAKES_REVIEW',
+  });
 }

--- a/pages/api/listening/practice/toggle.ts
+++ b/pages/api/listening/practice/toggle.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/listening/practice/toggle.ts',
+    code: 'LISTENING_INCOMPLETE_LISTENING_PRACTICE_TOGGLE',
+  });
 }

--- a/pages/api/listening/save.ts
+++ b/pages/api/listening/save.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/listening/save.ts',
+    code: 'LISTENING_INCOMPLETE_LISTENING_SAVE',
+  });
 }

--- a/pages/api/listening/tips/submit.ts
+++ b/pages/api/listening/tips/submit.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/listening/tips/submit.ts',
+    code: 'LISTENING_INCOMPLETE_LISTENING_TIPS_SUBMIT',
+  });
 }

--- a/pages/api/mock/listening/create-run.ts
+++ b/pages/api/mock/listening/create-run.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/mock/listening/create-run.ts',
+    code: 'LISTENING_INCOMPLETE_MOCK_LISTENING_CREATE_RUN',
+  });
 }

--- a/pages/api/mock/listening/play-ping.ts
+++ b/pages/api/mock/listening/play-ping.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/mock/listening/play-ping.ts',
+    code: 'LISTENING_INCOMPLETE_MOCK_LISTENING_PLAY_PING',
+  });
 }

--- a/pages/api/mock/listening/save-answers.ts
+++ b/pages/api/mock/listening/save-answers.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/mock/listening/save-answers.ts',
+    code: 'LISTENING_INCOMPLETE_MOCK_LISTENING_SAVE_ANSWERS',
+  });
 }

--- a/pages/api/mock/listening/submit-final.ts
+++ b/pages/api/mock/listening/submit-final.ts
@@ -1,5 +1,11 @@
-// Auto-generated placeholder API — replace with real implementation.
 import type { NextApiRequest, NextApiResponse } from 'next';
-export default function handler(_req: NextApiRequest, res: NextApiResponse) {
-  res.status(501).json({ error: 'Not implemented' });
+import { respondWithIncompleteApi } from '@/lib/api/respondWithIncomplete';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  return respondWithIncompleteApi({
+    req,
+    res,
+    endpoint: '/mock/listening/submit-final.ts',
+    code: 'LISTENING_INCOMPLETE_MOCK_LISTENING_SUBMIT_FINAL',
+  });
 }

--- a/pages/learn/listening/coach.tsx
+++ b/pages/learn/listening/coach.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/learn/listening/mistakes.tsx
+++ b/pages/learn/listening/mistakes.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/learn/listening/tips.tsx
+++ b/pages/learn/listening/tips.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/me/listening/saved.tsx
+++ b/pages/me/listening/saved.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/mock/listening/index.tsx
+++ b/pages/mock/listening/index.tsx
@@ -39,13 +39,6 @@ const quickListeningActions = [
     href: '/mock/listening/history',
     icon: 'BarChart3' as const,
   },
-  {
-    id: 'analytics',
-    label: 'Open Listening analytics',
-    description: 'Spot weak sections and question types.',
-    href: '/analytics/listening',
-    icon: 'PieChart' as const,
-  },
 ];
 
 // -----------------------------------------------------------------------------

--- a/pages/mock/listening/result.tsx
+++ b/pages/mock/listening/result.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/practice/listening/daily.tsx
+++ b/pages/practice/listening/daily.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/tools/listening/accent-trainer.tsx
+++ b/pages/tools/listening/accent-trainer.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}

--- a/pages/tools/listening/dictation.tsx
+++ b/pages/tools/listening/dictation.tsx
@@ -1,2 +1,5 @@
-// Auto-generated placeholder page — replace with real implementation.
-export default function Page(){ return <main />; }
+import NotAvailableYet from '@/components/listening/NotAvailableYet';
+
+export default function Page() {
+  return <NotAvailableYet feature="Listening module" />;
+}


### PR DESCRIPTION
### Motivation
- Establish a single source-of-truth for the Listening feature rollout status so incomplete/placeholder files are tracked programmatically.
- Prevent users from reaching incomplete UI surfaces by presenting a controlled “Not available yet” state and hiding links until implementations are ready.
- Make incomplete API endpoints explicit and machine-detectable by returning structured 501 responses with telemetry tags.
- Provide a concise backlog mapping each placeholder to implementation steps and acceptance criteria to drive follow-up work.

### Description
- Added `config/feature-status.manifest.json` which registers all discovered listening placeholder files under the `listening` domain with `status: "incomplete"`.
- Replaced many placeholder route pages with a shared guard UI implemented in `components/listening/NotAvailableYet.tsx` so routes render a controlled “Not available yet” state.
- Removed/hid direct navigation links to incomplete routes (examples: removed dictation CTA in `ListeningHero` and analytics quick action in the mock index).
- Replaced placeholder API stubs under `pages/api/...` with explicit 501 responses via a shared helper `lib/api/respondWithIncomplete.ts` that emits a machine-readable error code and a telemetry header.
- Added `docs/listening-implementation-backlog.md` as a checklist mapping each placeholder file to implementation steps and acceptance criteria.

### Testing
- Ran `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('config/feature-status.manifest.json','utf8')); console.log('manifest ok')"` which succeeded and validated the manifest JSON.
- Ran `npx eslint ...` across changed files which failed in this environment due to missing local ESLint dependency resolution (`@eslint/eslintrc`), so linting could not be fully validated here.
- Attempted `npm run dev:3001` to smoke-test the app but the `next` binary is not available in this environment so a local runtime smoke test could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08f191dc483209890ef200baaf2f4)