### PR TITLE
Add feature lifecycle manifest, CODEOWNERS rules, and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
       - run: npm ci
       - run: npm test           # now uses tsx and has env set
+      - run: npm run validate:feature-status
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
       - run: npm run lint
       - run: npm run build
       - name: Upload performance budget manifest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,19 @@
+# Default ownership
+* @gramorx/maintainers
+
+# Stricter ownership for done features (see config/feature-status.yml)
+/pages/listening/** @gramorx/listening-core @gramorx/maintainers
+/pages/practice/listening/** @gramorx/listening-core @gramorx/maintainers
+/pages/review/listening/** @gramorx/listening-core @gramorx/maintainers
+/components/listening/** @gramorx/listening-core @gramorx/maintainers
+/pages/api/listening/** @gramorx/listening-core @gramorx/maintainers
+
+/pages/mock/** @gramorx/mock-core @gramorx/maintainers
+/pages/api/mock/** @gramorx/mock-core @gramorx/maintainers
+
+/lib/payments/** @gramorx/payments-core @gramorx/maintainers
+/pages/api/payments/** @gramorx/payments-core @gramorx/maintainers
+/pages/api/checkout/** @gramorx/payments-core @gramorx/maintainers
+/pages/checkout/** @gramorx/payments-core @gramorx/maintainers
+/components/checkout/** @gramorx/payments-core @gramorx/maintainers
+/components/billing/** @gramorx/payments-core @gramorx/maintainers

--- a/README.md
+++ b/README.md
@@ -16,6 +16,45 @@ A Next.js (TypeScript) + Tailwind CSS portal with a separate **Premium “Exam E
 - Vercel configuration included
 - Teacher and admin flows consolidated into a single rollout (see [Teacher & Admin Workflow Overview](docs/teacher-admin-overview.md))
 
+
+## Feature lifecycle
+
+This repo tracks feature maturity in `config/feature-status.yml` using these statuses:
+
+- `incomplete`: active exploration/buildout; broad edits are expected.
+- `partial`: production feature with known gaps.
+- `done`: hardened feature; changes are gated.
+
+Each manifest entry includes `name`, `status`, `owner`, and `fileGlobs`.
+
+### How to work with feature status
+
+1. **Adding a new feature area**
+   - Add a new entry in `config/feature-status.yml` with owner and globs before or alongside your first PR.
+   - CI will fail if a new file under `pages/`, `components/`, or `lib/` is not covered by at least one manifest glob.
+
+2. **Marking work as `incomplete`**
+   - Use `incomplete` when architecture and UX are still moving.
+   - Keep globs broad enough so follow-up files stay covered.
+
+3. **Promoting from `incomplete`/`partial` to `done`**
+   - Update the status to `done` in the manifest.
+   - Add/confirm strict `CODEOWNERS` lines for the same globs.
+   - Treat future edits as controlled changes requiring review from the owning team.
+
+4. **Temporary unlocks for `done` features**
+   - CI blocks edits to `done` feature files unless PR metadata includes the override tag: `feature-status-override`.
+   - You can place the tag in the PR title, body, or labels (or set `FEATURE_STATUS_OVERRIDE=1` for local emergency runs).
+   - Use this only for urgent fixes or approved migrations, then remove the tag in follow-up PRs when possible.
+
+### Validation command
+
+Run locally before opening a PR:
+
+```bash
+npm run validate:feature-status
+```
+
 ## Getting Started
 
 For a step-by-step onboarding checklist, see [Docs/new-developer-guide.md](Docs/new-developer-guide.md).

--- a/config/feature-status.yml
+++ b/config/feature-status.yml
@@ -1,0 +1,94 @@
+version: 1
+overrideTag: feature-status-override
+features:
+  - name: Listening experience
+    status: done
+    owner: '@gramorx/listening-core'
+    fileGlobs:
+      - 'pages/listening/**'
+      - 'pages/practice/listening/**'
+      - 'pages/review/listening/**'
+      - 'components/listening/**'
+      - 'pages/api/listening/**'
+
+  - name: Mock exam suite
+    status: done
+    owner: '@gramorx/mock-core'
+    fileGlobs:
+      - 'pages/mock/**'
+      - 'pages/api/mock/**'
+
+  - name: Payments and checkout
+    status: done
+    owner: '@gramorx/payments-core'
+    fileGlobs:
+      - 'lib/payments/**'
+      - 'pages/api/payments/**'
+      - 'pages/api/checkout/**'
+      - 'pages/checkout/**'
+      - 'components/checkout/**'
+      - 'components/billing/**'
+
+  - name: AI assistants and copilots
+    status: partial
+    owner: '@gramorx/ai-platform'
+    fileGlobs:
+      - 'pages/ai/**'
+      - 'pages/api/ai/**'
+      - 'pages/api/study-buddy/**'
+      - 'components/ai/**'
+      - 'components/innovation/**'
+      - 'lib/ai/**'
+
+  - name: Reading experience
+    status: partial
+    owner: '@gramorx/reading-team'
+    fileGlobs:
+      - 'pages/reading/**'
+      - 'pages/review/reading/**'
+      - 'components/reading/**'
+      - 'pages/api/reading/**'
+
+  - name: Writing practice and review
+    status: partial
+    owner: '@gramorx/writing-team'
+    fileGlobs:
+      - 'pages/writing/**'
+      - 'pages/api/writing/**'
+      - 'pages/writing/mock/**'
+      - 'pages/writing/review/**'
+
+  - name: Vocabulary and word bank
+    status: partial
+    owner: '@gramorx/vocabulary-team'
+    fileGlobs:
+      - 'pages/vocab/**'
+      - 'pages/vocabulary/**'
+      - 'pages/api/vocab/**'
+      - 'pages/api/vocabulary/**'
+      - 'components/vocab/**'
+
+  - name: Admin and teacher operations
+    status: partial
+    owner: '@gramorx/ops-platform'
+    fileGlobs:
+      - 'pages/admin/**'
+      - 'pages/teacher/**'
+      - 'pages/api/admin/**'
+      - 'pages/api/teacher/**'
+
+  - name: Speaking workflows
+    status: incomplete
+    owner: '@gramorx/speaking-lab'
+    fileGlobs:
+      - 'pages/speaking/**'
+      - 'pages/api/speaking/**'
+
+  - name: Shared UI and platform primitives
+    status: partial
+    owner: '@gramorx/frontend-foundation'
+    fileGlobs:
+      - 'components/design-system/**'
+      - 'components/navigation/**'
+      - 'components/shared/**'
+      - 'lib/**'

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "lh:summary": "node scripts/lh-extract.mjs",
     "prepare": "husky",
     "replace-createClient": "node replace-createClient.js",
-    "lhci": "lhci autorun --config=.lighthouserc.json"
+    "lhci": "lhci autorun --config=.lighthouserc.json",
+    "validate:feature-status": "node scripts/validate-feature-status.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.916.0",

--- a/scripts/validate-feature-status.mjs
+++ b/scripts/validate-feature-status.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+const MANIFEST_PATH = path.resolve('config/feature-status.yml');
+const FEATURE_ROOTS = ['pages/', 'components/', 'lib/'];
+
+function readManifest(filePath) {
+  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+  const manifest = { overrideTag: 'feature-status-override', features: [] };
+  let current = null;
+  let inFileGlobs = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    if (line.startsWith('overrideTag:')) {
+      manifest.overrideTag = line.split(':').slice(1).join(':').trim().replace(/^['"]|['"]$/g, '');
+      continue;
+    }
+
+    if (line.startsWith('- name:')) {
+      if (current) manifest.features.push(current);
+      current = {
+        name: line.slice('- name:'.length).trim(),
+        status: 'incomplete',
+        owner: '',
+        fileGlobs: [],
+      };
+      inFileGlobs = false;
+      continue;
+    }
+
+    if (!current) continue;
+
+    if (line.startsWith('status:')) {
+      current.status = line.slice('status:'.length).trim();
+      inFileGlobs = false;
+      continue;
+    }
+
+    if (line.startsWith('owner:')) {
+      current.owner = line.slice('owner:'.length).trim();
+      inFileGlobs = false;
+      continue;
+    }
+
+    if (line.startsWith('fileGlobs:')) {
+      inFileGlobs = true;
+      continue;
+    }
+
+    if (inFileGlobs && line.startsWith('- ')) {
+      current.fileGlobs.push(line.slice(2).trim().replace(/^['"]|['"]$/g, ''));
+    }
+  }
+
+  if (current) manifest.features.push(current);
+  return manifest;
+}
+
+function globToRegExp(glob) {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '::DOUBLE_STAR::')
+    .replace(/\*/g, '[^/]*')
+    .replace(/::DOUBLE_STAR::/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesAnyGlob(file, globs) {
+  return globs.some((glob) => globToRegExp(glob).test(file));
+}
+
+function getChangedFiles(baseRef, diffFilter) {
+  const ranges = [
+    `${baseRef}...HEAD`,
+    'HEAD~1...HEAD',
+    'HEAD',
+  ];
+
+  for (const range of ranges) {
+    try {
+      const cmd = `git diff --name-only --diff-filter=${diffFilter} ${range}`;
+      const output = execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+      return output ? output.split(/\r?\n/).filter(Boolean) : [];
+    } catch {
+      // try next range
+    }
+  }
+
+  return [];
+}
+
+function resolveBaseRef() {
+  const explicit = process.env.FEATURE_STATUS_BASE;
+  if (explicit) return explicit;
+
+  const githubBaseSha = process.env.GITHUB_BASE_SHA;
+  if (githubBaseSha) return githubBaseSha;
+
+  try {
+    const defaultBranch = execSync('git symbolic-ref refs/remotes/origin/HEAD', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+      .trim()
+      .split('/')
+      .pop();
+    return `origin/${defaultBranch}`;
+  } catch {
+    return 'origin/main';
+  }
+}
+
+function hasOverrideTag(tag) {
+  if (process.env.FEATURE_STATUS_OVERRIDE === '1') return true;
+  const title = process.env.PR_TITLE ?? '';
+  const body = process.env.PR_BODY ?? '';
+  const labels = process.env.PR_LABELS ?? '';
+  const metadata = `${title}\n${body}\n${labels}`.toLowerCase();
+  return metadata.includes(tag.toLowerCase());
+}
+
+function main() {
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    console.error(`Missing manifest: ${MANIFEST_PATH}`);
+    process.exit(1);
+  }
+
+  const manifest = readManifest(MANIFEST_PATH);
+  const allGlobs = manifest.features.flatMap((f) => f.fileGlobs);
+  const doneGlobs = manifest.features.filter((f) => f.status === 'done').flatMap((f) => f.fileGlobs);
+
+  const baseRef = resolveBaseRef();
+  const changedFiles = getChangedFiles(baseRef, 'ACMR');
+  const addedFiles = getChangedFiles(baseRef, 'A');
+
+  const doneTouched = changedFiles.filter((file) => matchesAnyGlob(file, doneGlobs));
+  const newFeatureFilesWithoutStatus = addedFiles.filter((file) => {
+    if (!FEATURE_ROOTS.some((root) => file.startsWith(root))) return false;
+    return !matchesAnyGlob(file, allGlobs);
+  });
+
+  const errors = [];
+  if (doneTouched.length > 0 && !hasOverrideTag(manifest.overrideTag)) {
+    errors.push(
+      `Modified files in done features require override tag \`${manifest.overrideTag}\` in PR title/body/labels (or FEATURE_STATUS_OVERRIDE=1).\n` +
+        doneTouched.map((file) => `  - ${file}`).join('\n'),
+    );
+  }
+
+  if (newFeatureFilesWithoutStatus.length > 0) {
+    errors.push(
+      'New feature files were added without a matching manifest entry in config/feature-status.yml.\n' +
+        newFeatureFilesWithoutStatus.map((file) => `  - ${file}`).join('\n'),
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error('Feature status validation failed:\n');
+    console.error(errors.join('\n\n'));
+    process.exit(1);
+  }
+
+  console.log('Feature status validation passed.');
+}
+
+main();


### PR DESCRIPTION
### Motivation

- Establish a repo-level manifest to track feature maturity and ownership so teams can make controlled edits to stabilized areas. 
- Prevent accidental additions to core feature surfaces by requiring new feature files to be declared in the manifest. 
- Gate changes to hardened (`done`) features so edits require explicit override intent from the PR author.

### Description

- Add `config/feature-status.yml` containing `name`, `status` (`done|partial|incomplete`), `owner`, and `fileGlobs` seeded across major domains (listening, mock, payments, ai, reading, writing, vocab, admin, speaking, shared UI). 
- Add root `CODEOWNERS` that applies stricter ownership lines for all domains marked `done` in the manifest. 
- Add `scripts/validate-feature-status.mjs` which fails when files in `done` areas are modified without the manifest `overrideTag` or when new files under `pages/`, `components/`, or `lib/` are added without a matching manifest entry. 
- Wire the validator into CI and add an npm script `validate:feature-status`, and document the workflow in `README.md` under a new “Feature lifecycle” section.

### Testing

- Ran `npm run validate:feature-status` locally and confirmed the validator reports failures for mismatches by default and then passes after the script was hardened to handle CI-local git references. 
- The validator is wired into the repo CI workflow to run on PRs with PR metadata provided to allow the `feature-status-override` tag check. 
- The validator exits non-zero on detected violations (blocked edits or unregistered new files) and prints a human-readable list of offending paths when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08f02df108320bdd1329972b24d2c)