### PR TITLE
Guard partial payment providers in production

### DIFF
--- a/components/billing/UpgradeDialog.tsx
+++ b/components/billing/UpgradeDialog.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Button } from '@/components/design-system/Button';
 import { Modal } from '@/components/design-system/Modal';
 import { PLAN_LABEL, startCheckout } from '@/lib/payments/index';
+import { isProviderSelectableInUi } from '@/lib/payments/providerManifest';
 import { track } from '@/lib/analytics/track';
 import { evaluateQuota, nextPlanForQuota, type QuotaKey } from '@/lib/plan/quotas';
 import type { PaymentMethod, PlanKey } from '@/types/payments';
@@ -33,6 +34,10 @@ export function UpgradeDialog({
 }: UpgradeDialogProps) {
   const [loading, setLoading] = React.useState<PaymentMethod | null>(null);
   const [error, setError] = React.useState<string | null>(null);
+  const selectableMethods = React.useMemo<PaymentMethod[]>(() => {
+    const filtered = methods.filter((method) => isProviderSelectableInUi(method));
+    return filtered.length > 0 ? filtered : ['stripe'];
+  }, [methods]);
 
   const evaluation = React.useMemo(() => evaluateQuota(plan, quota.key, quota.used), [plan, quota.key, quota.used]);
   const suggestedPlanId = React.useMemo(() => nextPlanForQuota(plan, quota.key), [plan, quota.key]);
@@ -119,7 +124,7 @@ export function UpgradeDialog({
 
         {canUpgrade ? (
           <div className="grid gap-3 md:grid-cols-3">
-            {methods.map((method) => (
+            {selectableMethods.map((method) => (
               <Button
                 key={method}
                 variant="solid"

--- a/components/checkout/PaymentOptions.tsx
+++ b/components/checkout/PaymentOptions.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Card } from '@/components/design-system/Card';
+import { isProviderSelectableInUi } from '@/lib/payments/providerManifest';
 
 export type PaymentMethod = 'jazzcash' | 'easypaisa' | 'safepay' | 'card';
 
@@ -23,12 +24,19 @@ const OPTIONS: Array<{
 ];
 
 export const PaymentOptions: React.FC<Props> = ({ selected, onChange, className }) => {
+  const visibleOptions = React.useMemo(() => {
+    return OPTIONS.filter((option) => {
+      const provider = option.value === 'card' ? 'stripe' : option.value;
+      return isProviderSelectableInUi(provider);
+    });
+  }, []);
+
   return (
     <fieldset className={className}>
       <legend className="sr-only">Choose a payment method</legend>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        {OPTIONS.map((opt) => {
+        {visibleOptions.map((opt) => {
           const id = `pay-${opt.value}`;
           const active = selected === opt.value;
           return (
@@ -39,7 +47,11 @@ export const PaymentOptions: React.FC<Props> = ({ selected, onChange, className 
                 name="payment"
                 value={opt.value}
                 checked={active}
-                onChange={() => onChange(opt.value)}
+                onChange={() => {
+                  const provider = opt.value === 'card' ? 'stripe' : opt.value;
+                  if (!isProviderSelectableInUi(provider)) return;
+                  onChange(opt.value);
+                }}
                 className="peer sr-only"
               />
               <Card

--- a/components/payments/CheckoutForm.tsx
+++ b/components/payments/CheckoutForm.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { startCheckout } from '@/lib/payments/index';
+import { isProviderSelectableInUi } from '@/lib/payments/providerManifest';
 import type { PlanKey, Cycle, PaymentMethod } from '@/types/payments';
 
 export type CheckoutFormProps = {
@@ -25,11 +26,20 @@ export default function CheckoutForm({
   const [loading, setLoading] = React.useState<PaymentMethod | null>(null);
   const [err, setErr] = React.useState<string | null>(null);
 
+  const selectableMethods = React.useMemo<PaymentMethod[]>(() => {
+    const filtered = methods.filter((method) => isProviderSelectableInUi(method));
+    return filtered.length > 0 ? filtered : ['stripe'];
+  }, [methods]);
+
   const start = React.useCallback(async (method: PaymentMethod) => {
     setErr(null);
     setLoading(method);
 
     try {
+      if (!isProviderSelectableInUi(method)) {
+        throw new Error(`${method} is unavailable in production.`);
+      }
+
       const result = await startCheckout(method, { plan, referralCode, billingCycle, promoCode });
       if (!result.ok) {
         const message = result.error || `Failed to start ${method} checkout`;
@@ -64,7 +74,7 @@ export default function CheckoutForm({
 
   return (
     <div className={`grid gap-4 md:grid-cols-3 ${className}`}>
-      {methods.includes('stripe') && (
+      {selectableMethods.includes('stripe') && (
         <div className="rounded-xl border border-border p-4">
           <h3 className="mb-1 text-h4 font-medium">Pay by Card</h3>
           <p className="mb-4 text-small text-muted-foreground">Visa, MasterCard</p>
@@ -79,7 +89,7 @@ export default function CheckoutForm({
         </div>
       )}
 
-      {methods.includes('easypaisa') && (
+      {selectableMethods.includes('easypaisa') && (
         <div className="rounded-xl border border-border p-4">
           <h3 className="mb-1 text-h4 font-medium">Easypaisa</h3>
           <p className="mb-4 text-small text-muted-foreground">Pakistan local payments</p>
@@ -94,7 +104,7 @@ export default function CheckoutForm({
         </div>
       )}
 
-      {methods.includes('jazzcash') && (
+      {selectableMethods.includes('jazzcash') && (
         <div className="rounded-xl border border-border p-4">
           <h3 className="mb-1 text-h4 font-medium">JazzCash</h3>
           <p className="mb-4 text-small text-muted-foreground">Pakistan local payments</p>
@@ -109,7 +119,7 @@ export default function CheckoutForm({
         </div>
       )}
 
-      {methods.includes('safepay') && (
+      {selectableMethods.includes('safepay') && (
         <div className="rounded-xl border border-border p-4">
           <h3 className="mb-1 text-h4 font-medium">Safepay</h3>
           <p className="mb-4 text-small text-muted-foreground">Pakistan local payments</p>
@@ -124,7 +134,7 @@ export default function CheckoutForm({
         </div>
       )}
 
-      {methods.includes('crypto') && (
+      {selectableMethods.includes('crypto') && (
         <div className="rounded-xl border border-border p-4 md:col-span-3 lg:col-span-1">
           <h3 className="mb-1 text-h4 font-medium">Pay with Crypto</h3>
           <p className="mb-4 text-small text-muted-foreground">Bitcoin, Ethereum, USDT (manual confirmation)</p>

--- a/components/payments/PlanPicker.tsx
+++ b/components/payments/PlanPicker.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 import { startCheckout as startCheckoutRequest } from '@/lib/payments/index';
+import { isProviderSelectableInUi } from '@/lib/payments/providerManifest';
 import type { Cycle, PaymentMethod, PlanKey } from '@/types/payments';
 
 export type Plan = Readonly<{
@@ -77,8 +78,9 @@ export default function PlanPicker({
 
   const availableMethods = React.useMemo<PaymentMethod[]>(() => {
     if (onSelect) return [];
-    if (methods && methods.length > 0) return methods;
-    return ['stripe'];
+    const requested = methods && methods.length > 0 ? methods : ['stripe'];
+    const selectable = requested.filter((method) => isProviderSelectableInUi(method));
+    return selectable.length > 0 ? selectable : ['stripe'];
   }, [methods, onSelect]);
 
   const [selectedMethod, setSelectedMethod] = React.useState<PaymentMethod>(() => availableMethods[0] ?? 'stripe');

--- a/lib/payments/gateway.ts
+++ b/lib/payments/gateway.ts
@@ -5,6 +5,7 @@ import { type Cycle, type PlanKey } from '@/lib/pricing';
 import { initiateEasypaisa } from '@/lib/payments/easypaisa';
 import { initiateJazzCash } from '@/lib/payments/jazzcash';
 import { initiateSafepay } from '@/lib/payments/safepay';
+import { assertProviderCanCreateIntent } from '@/lib/payments/providerManifest';
 
 const CRYPTO_CHECKOUT_PATH = '/checkout/crypto';
 
@@ -135,6 +136,8 @@ function createCryptoCheckout(input: CreateGatewayIntentInput): GatewayIntent {
 }
 
 export async function createGatewayIntent(input: CreateGatewayIntentInput): Promise<GatewayIntent> {
+  assertProviderCanCreateIntent(input.provider);
+
   if (input.provider === 'stripe') {
     return createStripeCheckout(input);
   }

--- a/lib/payments/providerManifest.ts
+++ b/lib/payments/providerManifest.ts
@@ -1,0 +1,98 @@
+import type { PaymentProvider } from '@/lib/payments/gateway';
+
+export type ProviderRolloutStatus = 'ga' | 'partial' | 'disabled';
+
+export type ProviderCapabilities = Readonly<{
+  supportsLiveInit: boolean;
+  supportsWebhookVerification: boolean;
+}>;
+
+export type ProviderManifestEntry = Readonly<{
+  status: ProviderRolloutStatus;
+  modulePath: string;
+  capabilities: ProviderCapabilities;
+}>;
+
+/**
+ * Feature-status manifest for payment providers.
+ */
+export const PAYMENT_PROVIDER_MANIFEST: Record<PaymentProvider, ProviderManifestEntry> = {
+  stripe: {
+    status: 'ga',
+    modulePath: 'lib/payments/stripe.ts',
+    capabilities: {
+      supportsLiveInit: true,
+      supportsWebhookVerification: true,
+    },
+  },
+  easypaisa: {
+    status: 'partial',
+    modulePath: 'lib/payments/easypaisa.ts',
+    capabilities: {
+      supportsLiveInit: false,
+      supportsWebhookVerification: false,
+    },
+  },
+  jazzcash: {
+    status: 'partial',
+    modulePath: 'lib/payments/jazzcash.ts',
+    capabilities: {
+      supportsLiveInit: false,
+      supportsWebhookVerification: false,
+    },
+  },
+  safepay: {
+    status: 'ga',
+    modulePath: 'lib/payments/safepay.ts',
+    capabilities: {
+      supportsLiveInit: true,
+      supportsWebhookVerification: true,
+    },
+  },
+  crypto: {
+    status: 'ga',
+    modulePath: 'lib/payments/gateway.ts',
+    capabilities: {
+      supportsLiveInit: true,
+      supportsWebhookVerification: true,
+    },
+  },
+};
+
+export function isDevPaymentsEnabled(value: string | undefined = process.env.NEXT_PUBLIC_DEV_PAYMENTS): boolean {
+  return value === '1';
+}
+
+export function isProviderSelectableInUi(provider: PaymentProvider): boolean {
+  const entry = PAYMENT_PROVIDER_MANIFEST[provider];
+  if (!entry) return false;
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  if (!isProduction) return true;
+
+  if (entry.status !== 'partial') return true;
+  return isDevPaymentsEnabled();
+}
+
+export function assertProviderCanCreateIntent(provider: PaymentProvider): void {
+  const entry = PAYMENT_PROVIDER_MANIFEST[provider];
+  if (!entry) {
+    throw new Error(`Unsupported provider: ${provider}`);
+  }
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  const devPayments = isDevPaymentsEnabled();
+
+  if (isProduction && entry.status === 'partial' && !devPayments) {
+    throw new Error(`${provider} is partial and unavailable in production`);
+  }
+
+  if (isProduction && !devPayments) {
+    if (!entry.capabilities.supportsLiveInit) {
+      throw new Error(`${provider} does not support live init in production`);
+    }
+    if (!entry.capabilities.supportsWebhookVerification) {
+      throw new Error(`${provider} does not support webhook verification in production`);
+    }
+  }
+}

--- a/tests/lib/payments/gateway.test.ts
+++ b/tests/lib/payments/gateway.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/payments/easypaisa', () => ({
+  initiateEasypaisa: vi.fn(async () => ({
+    url: 'https://example.test/easypaisa',
+    sessionId: 'ep_session',
+  })),
+}));
+
+vi.mock('@/lib/payments/jazzcash', () => ({
+  initiateJazzCash: vi.fn(async () => ({
+    url: 'https://example.test/jazzcash',
+    sessionId: 'jc_session',
+  })),
+}));
+
+vi.mock('@/lib/payments/safepay', () => ({
+  initiateSafepay: vi.fn(async () => ({
+    url: 'https://example.test/safepay',
+    sessionId: 'sp_session',
+  })),
+}));
+
+import { createGatewayIntent } from '@/lib/payments/gateway';
+
+const baseInput = {
+  plan: 'starter' as const,
+  cycle: 'monthly' as const,
+  origin: 'https://app.test',
+  userId: 'user_1',
+  amountCents: 900,
+  intentId: 'intent_1',
+  currency: 'PKR' as const,
+};
+
+describe('createGatewayIntent integration checks', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalDevPayments = process.env.NEXT_PUBLIC_DEV_PAYMENTS;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    process.env.NEXT_PUBLIC_DEV_PAYMENTS = originalDevPayments;
+  });
+
+  it('blocks partial providers in production', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_DEV_PAYMENTS = '0';
+
+    await expect(
+      createGatewayIntent({
+        ...baseInput,
+        provider: 'easypaisa',
+      }),
+    ).rejects.toThrow('partial and unavailable in production');
+  });
+
+  it('allows partial provider dev fallback only when NEXT_PUBLIC_DEV_PAYMENTS=1', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_DEV_PAYMENTS = '0';
+
+    await expect(
+      createGatewayIntent({
+        ...baseInput,
+        provider: 'jazzcash',
+      }),
+    ).rejects.toThrow('partial and unavailable in production');
+
+    process.env.NEXT_PUBLIC_DEV_PAYMENTS = '1';
+
+    await expect(
+      createGatewayIntent({
+        ...baseInput,
+        provider: 'jazzcash',
+      }),
+    ).resolves.toMatchObject({
+      provider: 'jazzcash',
+      url: 'https://example.test/jazzcash',
+      sessionId: 'jc_session',
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Mark local Pakistani providers as not generally available and prevent accidental live use in production by gating them behind a rollout manifest and a dev-payments flag. 
- Ensure gateway intent creation only proceeds for providers that have required runtime capabilities (live init, webhook verification) to avoid unsupported flows in prod.

### Description

- Added a provider feature-status manifest at `lib/payments/providerManifest.ts` that lists each `PaymentProvider`, sets `easypaisa` and `jazzcash` to `partial`, and introduces capability flags `supportsLiveInit` and `supportsWebhookVerification` along with helpers `isProviderSelectableInUi` and `assertProviderCanCreateIntent`.
- Enforced provider checks in the gateway by calling `assertProviderCanCreateIntent(...)` from `lib/payments/gateway.ts` before any provider-specific initialization runs.
- Updated UI to hide/disable unavailable providers by using `isProviderSelectableInUi` in `components/payments/PlanPicker.tsx`, `components/payments/CheckoutForm.tsx`, `components/billing/UpgradeDialog.tsx` and `components/checkout/PaymentOptions.tsx` so users cannot choose `partial` providers in production unless dev payments mode is enabled.
- Added integration-style tests in `tests/lib/payments/gateway.test.ts` that mock provider initiation functions and verify blocking of `partial` providers in production and the `NEXT_PUBLIC_DEV_PAYMENTS` dev-fallback behavior.

### Testing

- Added `tests/lib/payments/gateway.test.ts` (Vitest) covering: blocking `partial` providers in production, and allowing dev fallback only when `NEXT_PUBLIC_DEV_PAYMENTS=1`.
- Attempted to run `npx vitest run tests/lib/payments/gateway.test.ts` but the run failed due to registry / environment restrictions (npm 403), so the test could not be executed here.
- Attempted project test run via `npm run test:phase3` but the `vitest` binary was not available in this execution environment, so automated test execution could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08f231a848320afe185801119ace3)