### PR TITLE
Add route status governance with incomplete placeholders and done-route locks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Route governance: done routes are locked and require explicit owner review.
+/pages/leaderboard/index.tsx @gramorx/core-web
+/pages/account/activity.tsx @gramorx/core-web
+/pages/account/billing-history.tsx @gramorx/core-web
+/pages/settings/security.tsx @gramorx/security
+/pages/dashboard/activity/index.tsx @gramorx/core-web
+/lib/routing/routeStatusManifest.ts @gramorx/core-web

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,5 +29,8 @@ steps:
 - script: npm run ds:guard
   displayName: 'Design system guard'
 
+- script: node scripts/ci/enforce-route-locks.mjs
+  displayName: 'Route lock guard'
+
 - script: npm run build
   displayName: 'Build'

--- a/components/nav/CommandCenter.tsx
+++ b/components/nav/CommandCenter.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { routes } from '@/lib/routes';
+import { isPrimaryNavEligible } from '@/lib/routing/governance';
 
 export type Command = {
   id: string;
@@ -54,7 +55,7 @@ function defaultCommands(): Command[] {
     { id: 'writing', title: 'Writing Tests', href: routes.writingIndex(), group: 'Modules' },
     { id: 'speaking', title: 'Speaking Simulator', href: routes.speakingSimulator(), group: 'Modules' },
     { id: 'checkout-booster', title: 'Upgrade to Booster', href: routes.checkout('booster'), group: 'Actions', kbd: 'Enter' },
-  ];
+  ].filter((item) => !item.href || isPrimaryNavEligible(item.href));
 }
 
 export function CommandCenter({

--- a/components/nav/ModulesMenu.tsx
+++ b/components/nav/ModulesMenu.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 import { routes } from '@/lib/routes';
+import { isPrimaryNavEligible } from '@/lib/routing/governance';
 
 type Item = { label: string; href: string; desc?: string };
 
@@ -76,7 +77,7 @@ export function ModulesMenu() {
             }}
           >
             <div className="w-[320px] max-h-[70vh] overflow-auto rounded-2xl border border-border bg-card p-2 shadow-2xl">
-              {ITEMS.map((it) => (
+              {ITEMS.filter((it) => isPrimaryNavEligible(it.href)).map((it) => (
                 <a
                   key={it.href}
                   href={it.href}

--- a/components/routing/IncompleteRoutePlaceholder.tsx
+++ b/components/routing/IncompleteRoutePlaceholder.tsx
@@ -1,0 +1,53 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+import { Button } from '@/components/design-system/Button';
+import { Card } from '@/components/design-system/Card';
+import { Container } from '@/components/design-system/Container';
+
+type IncompleteRoutePlaceholderProps = {
+  title: string;
+  description: string;
+  ctaLabel: string;
+  ctaHref: string;
+  secondaryCtaLabel?: string;
+  secondaryCtaHref?: string;
+  canonicalUrl?: string;
+};
+
+export function IncompleteRoutePlaceholder({
+  title,
+  description,
+  ctaLabel,
+  ctaHref,
+  secondaryCtaLabel,
+  secondaryCtaHref,
+  canonicalUrl,
+}: IncompleteRoutePlaceholderProps) {
+  return (
+    <>
+      <Head>
+        {canonicalUrl ? <link rel="canonical" href={canonicalUrl} /> : null}
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+      <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
+        <Container>
+          <Card className="max-w-2xl mx-auto space-y-5 p-6 rounded-ds-2xl text-center">
+            <h1 className="font-slab text-h2">{title}</h1>
+            <p className="text-body text-mutedText">{description}</p>
+            <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+              <Button asChild size="lg">
+                <Link href={ctaHref}>{ctaLabel}</Link>
+              </Button>
+              {secondaryCtaLabel && secondaryCtaHref ? (
+                <Button asChild variant="outline" size="lg">
+                  <Link href={secondaryCtaHref}>{secondaryCtaLabel}</Link>
+                </Button>
+              ) : null}
+            </div>
+          </Card>
+        </Container>
+      </section>
+    </>
+  );
+}

--- a/docs/routing-status-policy.md
+++ b/docs/routing-status-policy.md
@@ -1,0 +1,44 @@
+# Routing status policy
+
+This document defines how route readiness is governed across the product.
+
+## Status manifest
+
+Route/component status is tracked in `lib/routing/routeStatusManifest.ts` with these states:
+
+- `done`: live and protected from casual edits.
+- `partial`: live, but still has scoped fallback/copy placeholders.
+- `incomplete`: not launched; must use placeholder experience.
+
+The manifest is the source of truth and includes route path, component path, status summary, CTA metadata, and optional lock metadata.
+
+## Detection process
+
+When scanning for user-visible placeholder strings (for example, “coming soon”), map each affected route/component to one of:
+
+- `done` when the route is functionally complete and placeholder text is only for a minor sub-feature.
+- `partial` when the route is available but can render launch-gating or substantial fallback states.
+- `incomplete` when route-level feature delivery is not complete.
+
+## Rules for `incomplete` routes
+
+`incomplete` routes must follow all of the below:
+
+1. Route through shared placeholder wrapper (`components/routing/IncompleteRoutePlaceholder.tsx`).
+2. Exclude from sitemap via `isSitemapEligible` in `lib/routing/governance.ts`.
+3. Exclude from primary navigation via `isPrimaryNavEligible` in nav filtering.
+4. Include a consistent CTA (waitlist, notify-me equivalent, or fallback path).
+
+## Rules for `done` routes
+
+`done` routes must follow all of the below:
+
+1. Include `lock` annotation in `routeStatusManifest`.
+2. Be listed in `.github/CODEOWNERS` for explicit reviewer ownership.
+3. Be protected by CI (`scripts/ci/enforce-route-locks.mjs`) that fails edits unless `ROUTE_LOCK_OVERRIDE=true` is supplied after owner approval.
+
+## Operational notes
+
+- Navigation filtering is centralized in `lib/navigation/utils.ts`.
+- Utility helpers are in `lib/routing/governance.ts`.
+- New routes should be added to the manifest as part of route creation, not after launch.

--- a/lib/navigation/utils.ts
+++ b/lib/navigation/utils.ts
@@ -3,6 +3,7 @@ import { isFeatureEnabled } from '@/lib/constants/features';
 import { flags } from '@/lib/flags';
 import type { FeatureGate, NavItemConfig, NavigationContext, NavSectionConfig, SubscriptionTier } from './types';
 import { TIER_ORDER } from './types';
+import { isPrimaryNavEligible } from '@/lib/routing/governance';
 
 const tierRank = (tier: SubscriptionTier) => TIER_ORDER.indexOf(tier);
 
@@ -32,7 +33,11 @@ export const isGateSatisfied = (gate: FeatureGate | undefined, ctx: NavigationCo
 };
 
 export const filterNavItems = <T extends NavItemConfig>(items: readonly T[] | T[], ctx: NavigationContext): T[] => {
-  return items.filter((item) => isGateSatisfied(item.featureGate, ctx));
+  return items.filter((item) => {
+    if (!isGateSatisfied(item.featureGate, ctx)) return false;
+    if (!item.href.startsWith('/')) return true;
+    return isPrimaryNavEligible(item.href);
+  });
 };
 
 export const filterNavSections = (sections: readonly NavSectionConfig[] | NavSectionConfig[], ctx: NavigationContext): NavSectionConfig[] => {

--- a/lib/routing/governance.ts
+++ b/lib/routing/governance.ts
@@ -1,0 +1,17 @@
+import { incompleteRouteSet, routeStatusManifest } from '@/lib/routing/routeStatusManifest';
+
+export function isIncompleteRoute(pathname: string): boolean {
+  return incompleteRouteSet.has(pathname);
+}
+
+export function isPrimaryNavEligible(pathname: string): boolean {
+  return !isIncompleteRoute(pathname);
+}
+
+export function isSitemapEligible(pathname: string): boolean {
+  return !isIncompleteRoute(pathname);
+}
+
+export function getRouteStatus(pathname: string) {
+  return routeStatusManifest.find((entry) => entry.route === pathname);
+}

--- a/lib/routing/routeStatusManifest.ts
+++ b/lib/routing/routeStatusManifest.ts
@@ -1,0 +1,99 @@
+export type RouteStatus = 'done' | 'partial' | 'incomplete';
+
+export type RouteStatusEntry = {
+  id: string;
+  route: string;
+  component: string;
+  status: RouteStatus;
+  summary: string;
+  cta?: {
+    label: string;
+    href: string;
+    secondaryLabel?: string;
+    secondaryHref?: string;
+  };
+  lock?: {
+    enabled: true;
+    reason: string;
+  };
+};
+
+export const routeStatusManifest: RouteStatusEntry[] = [
+  {
+    id: 'reading-index',
+    route: '/reading',
+    component: 'pages/reading/index.tsx',
+    status: 'partial',
+    summary: 'Primary reading catalog is available, but writing-only mode still renders a coming-soon gate.',
+    cta: { label: 'Join waitlist', href: '/waitlist' },
+  },
+  {
+    id: 'writing-index',
+    route: '/writing',
+    component: 'pages/writing/index.tsx',
+    status: 'partial',
+    summary: 'Primary writing catalog is available, but reading-only mode still renders a coming-soon gate.',
+    cta: { label: 'Join waitlist', href: '/waitlist' },
+  },
+  {
+    id: 'coach-index',
+    route: '/coach',
+    component: 'pages/coach/index.tsx',
+    status: 'incomplete',
+    summary: 'Coaching is not launched yet and should stay behind a consistent placeholder shell.',
+    cta: {
+      label: 'Join waitlist',
+      href: '/waitlist',
+      secondaryLabel: 'Explore live classes',
+      secondaryHref: '/classes',
+    },
+  },
+  {
+    id: 'leaderboard-index',
+    route: '/leaderboard',
+    component: 'pages/leaderboard/index.tsx',
+    status: 'done',
+    summary: 'Leaderboard is live; seasonal mode copy remains as a minor enhancement item.',
+    lock: { enabled: true, reason: 'Stable acquisition and retention surface with active analytics dependencies.' },
+  },
+  {
+    id: 'account-activity',
+    route: '/account/activity',
+    component: 'pages/account/activity.tsx',
+    status: 'done',
+    summary: 'Activity page is live; filter panel copy indicates a deferred UX enhancement only.',
+    lock: { enabled: true, reason: 'Billing-adjacent activity timeline should not regress without explicit override.' },
+  },
+  {
+    id: 'account-billing-history',
+    route: '/account/billing-history',
+    component: 'pages/account/billing-history.tsx',
+    status: 'done',
+    summary: 'Billing history page is production-ready; load-more subfeature is deferred.',
+    lock: { enabled: true, reason: 'Finance-visible reporting surface requires ownership for edits.' },
+  },
+  {
+    id: 'settings-security',
+    route: '/settings/security',
+    component: 'pages/settings/security.tsx',
+    status: 'done',
+    summary: 'Security settings are usable; MFA management action is still planned.',
+    lock: { enabled: true, reason: 'Security surfaces need explicit review and controlled rollout edits.' },
+  },
+  {
+    id: 'dashboard-activity',
+    route: '/dashboard/activity',
+    component: 'pages/dashboard/activity/index.tsx',
+    status: 'done',
+    summary: 'Dashboard activity page is functional; chart module has coming-soon copy fallback.',
+    lock: { enabled: true, reason: 'Core dashboard route with high user traffic and shared metrics wiring.' },
+  },
+];
+
+export const incompleteRouteSet = new Set(
+  routeStatusManifest.filter((entry) => entry.status === 'incomplete').map((entry) => entry.route),
+);
+
+export const doneLockedComponents = routeStatusManifest
+  .filter((entry) => entry.status === 'done' && entry.lock?.enabled)
+  .map((entry) => entry.component);

--- a/pages/coach/index.tsx
+++ b/pages/coach/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 
+import { IncompleteRoutePlaceholder } from '@/components/routing/IncompleteRoutePlaceholder';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
@@ -42,35 +43,20 @@ function CoachComingSoon() {
     <>
       <Head>
         <title>Coaching coming soon</title>
-        {coachCanonical ? <link rel="canonical" href={coachCanonical} /> : null}
-        <meta name="robots" content="noindex, nofollow" />
         <meta
           name="description"
           content="Personalised coaching sessions are rolling out soon. Explore live classes while we finish the experience."
         />
       </Head>
-      <section className="py-24 bg-lightBg dark:bg-gradient-to-br dark:from-dark/80 dark:to-darker/90">
-        <Container>
-          <Card className="max-w-2xl mx-auto space-y-5 p-6 rounded-ds-2xl text-center">
-            <h1 className="font-slab text-h2">Coaching is almost here</h1>
-            <p className="text-body text-mutedText">
-              We&apos;re putting the final polish on 1:1 coaching so that your essays get thoughtful, human feedback.
-              You&apos;ll see it first in your account once it&apos;s ready.
-            </p>
-            <p className="text-body text-mutedText">
-              In the meantime, keep building momentum with structured classes and practice plans.
-            </p>
-            <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-              <Button asChild size="lg">
-                <Link href="/classes">Explore live classes</Link>
-              </Button>
-              <Button asChild variant="outline" size="lg">
-                <Link href="/study-plan">Open your study plan</Link>
-              </Button>
-            </div>
-          </Card>
-        </Container>
-      </section>
+      <IncompleteRoutePlaceholder
+        title="Coaching is almost here"
+        description="We’re putting the final polish on 1:1 coaching. Join the waitlist to get notified first, or continue with classes while we complete rollout."
+        ctaLabel="Join waitlist"
+        ctaHref="/waitlist"
+        secondaryCtaLabel="Explore live classes"
+        secondaryCtaHref="/classes"
+        canonicalUrl={coachCanonical}
+      />
     </>
   );
 }

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -1,0 +1,45 @@
+import type { GetServerSideProps } from 'next';
+
+import { isSitemapEligible } from '@/lib/routing/governance';
+
+const STATIC_ROUTES = [
+  '/',
+  '/pricing',
+  '/learning',
+  '/mock',
+  '/listening',
+  '/reading',
+  '/writing',
+  '/speaking',
+  '/leaderboard',
+  '/blog',
+  '/faq',
+  '/community',
+  '/waitlist',
+] as const;
+
+const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://gramorx.com').replace(/\/$/, '');
+
+function generateSitemap() {
+  const urls = STATIC_ROUTES.filter((route) => isSitemapEligible(route))
+    .map(
+      (route) => `  <url>\n    <loc>${siteUrl}${route}</loc>\n  </url>`,
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.setHeader('Content-Type', 'text/xml');
+  res.write(generateSitemap());
+  res.end();
+
+  return {
+    props: {},
+  };
+};
+
+export default function SitemapXml() {
+  return null;
+}

--- a/scripts/ci/enforce-route-locks.mjs
+++ b/scripts/ci/enforce-route-locks.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+const lockedFiles = [
+  'pages/leaderboard/index.tsx',
+  'pages/account/activity.tsx',
+  'pages/account/billing-history.tsx',
+  'pages/settings/security.tsx',
+  'pages/dashboard/activity/index.tsx',
+];
+
+if (process.env.ROUTE_LOCK_OVERRIDE === '1' || process.env.ROUTE_LOCK_OVERRIDE === 'true') {
+  console.log('Route lock override detected (ROUTE_LOCK_OVERRIDE). Skipping enforcement.');
+  process.exit(0);
+}
+
+const baseRef = process.env.ROUTE_LOCK_BASE_REF || process.env.SYSTEM_PULLREQUEST_TARGETBRANCH || 'origin/main';
+let changed = '';
+
+try {
+  changed = execSync(`git diff --name-only ${baseRef}...HEAD 2>/dev/null`, { encoding: 'utf8', shell: '/bin/bash' }).trim();
+} catch {
+  changed = execSync('git diff --name-only HEAD~1..HEAD', { encoding: 'utf8' }).trim();
+}
+
+const changedSet = new Set(changed.split('\n').filter(Boolean));
+const touchedLocked = lockedFiles.filter((file) => changedSet.has(file));
+
+if (touchedLocked.length > 0) {
+  console.error('Locked done routes were modified without explicit override.');
+  console.error('Set ROUTE_LOCK_OVERRIDE=true in CI only after codeowner approval.');
+  for (const file of touchedLocked) {
+    console.error(` - ${file}`);
+  }
+  process.exit(1);
+}
+
+console.log('Route lock check passed.');


### PR DESCRIPTION
### Motivation
- Introduce an auditable, in-repo way to map routes/components that show user-visible placeholder text (e.g. “coming soon”) into a single status model (`done|partial|incomplete`) so routing surfaces and SEO/navigation can be governed consistently.
- Enforce different handling for `incomplete` routes (placeholder wrapper, excluded from primary nav and sitemap, consistent CTA) and protect `done` routes from accidental edits with explicit ownership and CI checks.

### Description
- Add a centralized status manifest at `lib/routing/routeStatusManifest.ts` that lists route entries, statuses, CTAs and optional `lock` annotations for `done` routes. 
- Add routing governance helpers in `lib/routing/governance.ts` and wire nav filtering to respect eligibility in `lib/navigation/utils.ts`, plus filter usage in `components/nav/ModulesMenu.tsx` and `components/nav/CommandCenter.tsx`.
- Introduce a shared placeholder component `components/routing/IncompleteRoutePlaceholder.tsx` and route `/coach` through it to standardize incomplete-route UX and CTAs.
- Provide sitemap generation at `pages/sitemap.xml.tsx` that excludes `incomplete` routes, and add CI protection via `scripts/ci/enforce-route-locks.mjs` with pipeline integration in `azure-pipelines.yml`.
- Add `.github/CODEOWNERS` entries for locked `done` routes and the manifest, and document the policy in `docs/routing-status-policy.md`.

### Testing
- Ran the route-lock check with `node scripts/ci/enforce-route-locks.mjs`, which completed and returned a passing result.
- Attempted `npm run lint`, which failed locally because the environment does not have project dependencies installed (`next` binary not found).
- Attempted `npm run dev:3001`, which failed for the same local environment reason (`next` binary not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08f5304e88320a4124106b5f16c9f)