### PR TITLE
Add computed Home module status mapping and gated CTA routing

### DIFF
--- a/lib/home/moduleStatus.ts
+++ b/lib/home/moduleStatus.ts
@@ -1,0 +1,206 @@
+import { featureFlags, type FeatureToggleKey } from '@/lib/constants/features';
+import { flags, type FeatureFlagKey } from '@/lib/flags';
+import type { IconName } from '@/components/design-system/Icon';
+
+type HomeModuleTone = 'success' | 'accent' | 'info' | 'warning' | 'neutral';
+
+type BaseModule = {
+  id: 'learning' | 'skill-practice' | 'mock' | 'ai-lab' | 'analytics' | 'gamification';
+  icon: IconName;
+  title: string;
+  description: string;
+  bullets: string[];
+  href: string;
+};
+
+export type HomeModuleCard = BaseModule & {
+  isEnabled: boolean;
+  statusLabel: string;
+  statusTone: HomeModuleTone;
+  reason: string | null;
+  ctaHref: string;
+};
+
+export type ComputeHomeModuleCardsOptions = {
+  featureToggleSnapshot?: Partial<Record<FeatureToggleKey, boolean>>;
+  flagEnabled?: (key: FeatureFlagKey) => boolean;
+};
+
+const BASE_MODULES: BaseModule[] = [
+  {
+    id: 'learning',
+    icon: 'BookOpenCheck',
+    title: 'Learning Hub',
+    description: 'Concept lessons, strategy guides, and grammar refreshers wired to your target band.',
+    bullets: [
+      'Academic & General Training coverage',
+      'Micro-lessons for all four skills',
+      'AI-personalised paths by band goal',
+    ],
+    href: '/learning',
+  },
+  {
+    id: 'skill-practice',
+    icon: 'Edit3',
+    title: 'Skill Practice Arena',
+    description: 'Focused listening, reading, writing, and speaking practice mapped to real exam sections.',
+    bullets: [
+      'Dedicated hubs for all four skills',
+      'Drills, reviews, and full-section flows',
+      'Daily practice loops with saved progress',
+    ],
+    href: '/mock',
+  },
+  {
+    id: 'mock',
+    icon: 'Timer',
+    title: 'Full Mock Tests',
+    description: 'Complete mock ecosystem with reading, listening, speaking, and writing exam simulations.',
+    bullets: [
+      'Section-based mocks and full exam tracks',
+      'Attempt history, review pages, and results',
+      'Analytics for speed, accuracy, and mastery',
+    ],
+    href: '/mock',
+  },
+  {
+    id: 'ai-lab',
+    icon: 'Sparkles',
+    title: 'AI Lab',
+    description: 'Where AI Coach, Study Buddy, and Mistakes Book live together.',
+    bullets: [
+      'Task 1 & 2 band feedback',
+      'Speaking insights from audio',
+      'Compare “Before vs After” edits',
+    ],
+    href: '/ai',
+  },
+  {
+    id: 'analytics',
+    icon: 'PieChart',
+    title: 'Progress & Analytics',
+    description: 'Unified tracking across attempts, streaks, and skill-level improvement signals.',
+    bullets: [
+      'Band trajectory and forecast signals',
+      'Question-type and section diagnostics',
+      'Streak + momentum visibility',
+    ],
+    href: '/progress',
+  },
+  {
+    id: 'gamification',
+    icon: 'Trophy',
+    title: 'Gamification & Streaks',
+    description: 'Daily streaks, weekly challenges, and quiet competition.',
+    bullets: ['Daily streak shields', 'Weekly IELTS challenges', 'Badges for consistency'],
+    href: '/dashboard',
+  },
+];
+
+export function computeHomeModuleCards(options: ComputeHomeModuleCardsOptions = {}): HomeModuleCard[] {
+  const toggles: Record<FeatureToggleKey, boolean> = {
+    ...featureFlags,
+    ...(options.featureToggleSnapshot ?? {}),
+  };
+  const flagEnabled = options.flagEnabled ?? ((key: FeatureFlagKey) => flags.enabled(key));
+
+  const aiLabEnabled =
+    toggles.aiCoach || toggles.studyBuddy || toggles.mistakesBook || flagEnabled('coach');
+  const weeklyChallengeEnabled = toggles.weeklyChallenge || flagEnabled('challenge');
+
+  return BASE_MODULES.map((module): HomeModuleCard => {
+    if (module.id === 'ai-lab') {
+      if (aiLabEnabled) {
+        return {
+          ...module,
+          isEnabled: true,
+          statusLabel: 'Core',
+          statusTone: 'accent',
+          reason: null,
+          ctaHref: module.href,
+        };
+      }
+      return {
+        ...module,
+        isEnabled: false,
+        statusLabel: 'Gated',
+        statusTone: 'warning',
+        reason: 'AI Lab requires an active AI feature flag or plan access.',
+        ctaHref: '/pricing',
+      };
+    }
+
+    if (module.id === 'analytics') {
+      if (toggles.bandPredictor) {
+        return {
+          ...module,
+          isEnabled: true,
+          statusLabel: 'Live',
+          statusTone: 'info',
+          reason: null,
+          ctaHref: module.href,
+        };
+      }
+      return {
+        ...module,
+        isEnabled: true,
+        statusLabel: 'Limited',
+        statusTone: 'neutral',
+        reason: 'Band predictor insights are currently turned off for this environment.',
+        ctaHref: module.href,
+      };
+    }
+
+    if (module.id === 'gamification') {
+      if (weeklyChallengeEnabled) {
+        return {
+          ...module,
+          isEnabled: true,
+          statusLabel: 'Live',
+          statusTone: 'success',
+          reason: null,
+          ctaHref: module.href,
+        };
+      }
+      return {
+        ...module,
+        isEnabled: false,
+        statusLabel: 'Onboarding',
+        statusTone: 'neutral',
+        reason: 'Complete setup to unlock weekly challenges and leaderboard competitions.',
+        ctaHref: '/profile/setup',
+      };
+    }
+
+    if (module.id === 'mock') {
+      return {
+        ...module,
+        isEnabled: true,
+        statusLabel: 'Expanded',
+        statusTone: 'success',
+        reason: null,
+        ctaHref: module.href,
+      };
+    }
+
+    if (module.id === 'skill-practice') {
+      return {
+        ...module,
+        isEnabled: true,
+        statusLabel: 'Live',
+        statusTone: 'accent',
+        reason: null,
+        ctaHref: module.href,
+      };
+    }
+
+    return {
+      ...module,
+      isEnabled: true,
+      statusLabel: 'Live',
+      statusTone: 'success',
+      reason: null,
+      ctaHref: module.href,
+    };
+  });
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,94 +8,10 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import Icon, { type IconName } from '@/components/design-system/Icon';
+import { computeHomeModuleCards } from '@/lib/home/moduleStatus';
 import { getPlanPricing, getStandardPlanName } from '@/lib/subscription';
 
-const modules = [
-  {
-    id: 'learning',
-    icon: 'BookOpenCheck' as IconName,
-    title: 'Learning Hub',
-    status: 'Live',
-    statusTone: 'success' as const,
-    description: 'Concept lessons, strategy guides, and grammar refreshers wired to your target band.',
-    bullets: [
-      'Academic & General Training coverage',
-      'Micro-lessons for all four skills',
-      'AI-personalised paths by band goal',
-    ],
-    href: '/learning',
-  },
-  {
-    id: 'skill-practice',
-    icon: 'Edit3' as IconName,
-    title: 'Skill Practice Arena',
-    status: 'Live',
-    statusTone: 'accent' as const,
-    description: 'Focused listening, reading, writing, and speaking practice mapped to real exam sections.',
-    bullets: [
-      'Dedicated hubs for all four skills',
-      'Drills, reviews, and full-section flows',
-      'Daily practice loops with saved progress',
-    ],
-    href: '/mock',
-  },
-  {
-    id: 'mock',
-    icon: 'Timer' as IconName,
-    title: 'Full Mock Tests',
-    status: 'Expanded',
-    statusTone: 'success' as const,
-    description: 'Complete mock ecosystem with reading, listening, speaking, and writing exam simulations.',
-    bullets: [
-      'Section-based mocks and full exam tracks',
-      'Attempt history, review pages, and results',
-      'Analytics for speed, accuracy, and mastery',
-    ],
-    href: '/mock',
-  },
-  {
-    id: 'ai-lab',
-    icon: 'Sparkles' as IconName,
-    title: 'AI Lab',
-    status: 'Core',
-    statusTone: 'accent' as const,
-    description: 'Where AI Coach, Study Buddy, and Mistakes Book live together.',
-    bullets: [
-      'Task 1 & 2 band feedback',
-      'Speaking insights from audio',
-      'Compare “Before vs After” edits',
-    ],
-    href: '/ai',
-  },
-  {
-    id: 'analytics',
-    icon: 'PieChart' as IconName,
-    title: 'Progress & Analytics',
-    status: 'Live',
-    statusTone: 'info' as const,
-    description: 'Unified tracking across attempts, streaks, and skill-level improvement signals.',
-    bullets: [
-      'Band trajectory and forecast signals',
-      'Question-type and section diagnostics',
-      'Streak + momentum visibility',
-    ],
-    href: '/progress',
-  },
-  {
-    id: 'gamification',
-    icon: 'Trophy' as IconName,
-    title: 'Gamification & Streaks',
-    status: 'Live',
-    statusTone: 'success' as const,
-    description: 'Daily streaks, weekly challenges, and quiet competition.',
-    bullets: [
-      'Daily streak shields',
-      'Weekly IELTS challenges',
-      'Badges for consistency',
-    ],
-    href: '/dashboard',
-  },
-];
+const modules = computeHomeModuleCards();
 
 const quickLinks = [
   {
@@ -525,15 +441,9 @@ const LandingPage: React.FC = () => {
                       </div>
                       <Badge
                         size="xs"
-                        variant={
-                          mod.statusTone === 'success'
-                            ? 'success'
-                            : mod.statusTone === 'accent'
-                            ? 'accent'
-                            : 'neutral'
-                        }
+                        variant={mod.statusTone}
                       >
-                        {mod.status}
+                        {mod.statusLabel}
                       </Badge>
                     </div>
 
@@ -549,6 +459,10 @@ const LandingPage: React.FC = () => {
                     </ul>
                   </div>
 
+                  {mod.reason ? (
+                    <p className="pt-3 text-xs text-muted-foreground">{mod.reason}</p>
+                  ) : null}
+
                   <div className="pt-4">
                     <Button
                       asChild
@@ -556,7 +470,7 @@ const LandingPage: React.FC = () => {
                       variant="secondary"
                       className="w-full rounded-ds-xl"
                     >
-                      <Link href={mod.href}>Open {mod.title}</Link>
+                      <Link href={mod.ctaHref}>{mod.isEnabled ? `Open ${mod.title}` : `Unlock ${mod.title}`}</Link>
                     </Button>
                   </div>
                 </Card>

--- a/tests/lib/home-module-status.test.ts
+++ b/tests/lib/home-module-status.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeHomeModuleCards } from '@/lib/home/moduleStatus';
+
+const getModule = (id: string, cards = computeHomeModuleCards()) => cards.find((card) => card.id === id);
+
+describe('computeHomeModuleCards', () => {
+  it('gates AI Lab and redirects to pricing when AI toggles are disabled', () => {
+    const cards = computeHomeModuleCards({
+      featureToggleSnapshot: {
+        aiCoach: false,
+        studyBuddy: false,
+        mistakesBook: false,
+      },
+      flagEnabled: () => false,
+    });
+
+    const aiLab = getModule('ai-lab', cards);
+    expect(aiLab).toBeDefined();
+    expect(aiLab?.isEnabled).toBe(false);
+    expect(aiLab?.statusLabel).toBe('Gated');
+    expect(aiLab?.statusTone).toBe('warning');
+    expect(aiLab?.ctaHref).toBe('/pricing');
+    expect(aiLab?.reason).toContain('AI Lab requires');
+  });
+
+  it('enables AI Lab when a backing AI toggle is enabled', () => {
+    const cards = computeHomeModuleCards({
+      featureToggleSnapshot: {
+        aiCoach: true,
+        studyBuddy: false,
+        mistakesBook: false,
+      },
+      flagEnabled: () => false,
+    });
+
+    const aiLab = getModule('ai-lab', cards);
+    expect(aiLab?.isEnabled).toBe(true);
+    expect(aiLab?.statusLabel).toBe('Core');
+    expect(aiLab?.ctaHref).toBe('/ai');
+    expect(aiLab?.reason).toBeNull();
+  });
+
+  it('marks analytics as limited when predictor is disabled', () => {
+    const cards = computeHomeModuleCards({
+      featureToggleSnapshot: {
+        bandPredictor: false,
+      },
+      flagEnabled: () => false,
+    });
+
+    const analytics = getModule('analytics', cards);
+    expect(analytics?.isEnabled).toBe(true);
+    expect(analytics?.statusLabel).toBe('Limited');
+    expect(analytics?.statusTone).toBe('neutral');
+    expect(analytics?.reason).toContain('Band predictor');
+    expect(analytics?.ctaHref).toBe('/progress');
+  });
+
+  it('routes gamification to onboarding when challenge access is unavailable', () => {
+    const cards = computeHomeModuleCards({
+      featureToggleSnapshot: {
+        weeklyChallenge: false,
+      },
+      flagEnabled: () => false,
+    });
+
+    const gamification = getModule('gamification', cards);
+    expect(gamification?.isEnabled).toBe(false);
+    expect(gamification?.statusLabel).toBe('Onboarding');
+    expect(gamification?.ctaHref).toBe('/profile/setup');
+  });
+});


### PR DESCRIPTION
### Motivation
- Centralise Home module availability logic so UI reflects actual feature flags and server flags instead of hardcoded values.
- Provide explicit computed fields (`isEnabled`, `statusLabel`, `statusTone`, `reason`, `ctaHref`) so CTA routing and badges can change when flags or toggles change.

### Description
- Added `computeHomeModuleCards` in `lib/home/moduleStatus.ts` which derives module state from `featureFlags` and `flags.enabled(...)` and returns `HomeModuleCard[]` with computed fields. 
- Updated `pages/index.tsx` to consume `computeHomeModuleCards()` and render badge text/tone from `statusLabel`/`statusTone`, show `reason` when present, and use `ctaHref` with conditional copy (`Open` vs `Unlock`).
- Adjusted CTA routing for gated/limited modules so users are routed to `/pricing` or `/profile/setup` as appropriate instead of dead-end links.
- Added unit tests at `tests/lib/home-module-status.test.ts` that cover AI Lab gating, AI-enabled path, analytics limited mode, and gamification onboarding routing.

### Testing
- Added unit tests in `tests/lib/home-module-status.test.ts` and attempted to run them with `npx vitest run tests/lib/home-module-status.test.ts`, which failed due to an environment/npm access error (403) preventing package resolution. 
- Attempted `./node_modules/.bin/vitest run tests/lib/home-module-status.test.ts`, which failed because `node_modules` are not present in the container. 
- Tried a Playwright screenshot of the page at `http://127.0.0.1:3001` to validate UI changes, which failed due to no local dev server responding (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f5f6d47c8320ac91fba5a5c60df7)