### PR TITLE
Create shared module registry and refactor module card consumers

### DIFF
--- a/components/sections/ModulesOverview.tsx
+++ b/components/sections/ModulesOverview.tsx
@@ -3,104 +3,10 @@ import React from 'react';
 import { Container } from '@/components/design-system/Container';
 import { Card } from '@/components/design-system/Card';
 import { Badge } from '@/components/design-system/Badge';
-import Icon, { type IconName } from '@/components/design-system/Icon';
+import Icon from '@/components/design-system/Icon';
+import { getDashboardModuleCards } from '@/lib/modules/registry';
 
-type ModuleCard = {
-  id: string;
-  icon: IconName;
-  title: string;
-  label: string;
-  description: string;
-  bullets: string[];
-  tag?: string;
-};
-
-const modules: ModuleCard[] = [
-  {
-    id: 'listening',
-    icon: 'Headphones',
-    title: 'Listening',
-    label: 'Audio-first drills',
-    description:
-      'Exam-style recordings with question sets that train both speed and accuracy.',
-    bullets: [
-      'Short & full-length recordings',
-      'Question types mirrored from real tests',
-      'Future: accent diversity & playlists',
-    ],
-    tag: 'Core module',
-  },
-  {
-    id: 'reading',
-    icon: 'FileText',
-    title: 'Reading',
-    label: 'Passages & item types',
-    description:
-      'Skim, scan and solve under time pressure — with explanations that don’t waste time.',
-    bullets: [
-      'True/False/Not Given, MCQs, matching',
-      'Guided review of wrong answers',
-      'Future: difficulty ladder per band',
-    ],
-    tag: 'Core module',
-  },
-  {
-    id: 'writing',
-    icon: 'PenSquare',
-    title: 'Writing',
-    label: 'Task 1 & Task 2',
-    description:
-      'Structure, coherence, lexical resource and grammar checked with AI and clear tips.',
-    bullets: [
-      'Band-style rubric breakdown',
-      'Before / After comparisons in AI Lab',
-      'Future: teacher plug-in for manual review',
-    ],
-    tag: 'AI-heavy',
-  },
-  {
-    id: 'speaking',
-    icon: 'Mic2',
-    title: 'Speaking',
-    label: 'Record & review',
-    description:
-      'Prompt packs for Parts 1, 2 and 3 with AI insights on fluency, vocab and pronunciation.',
-    bullets: [
-      'Record directly in browser',
-      'Part-wise scoring hints',
-      'Future: conversation-style dialogues',
-    ],
-    tag: 'AI-heavy',
-  },
-  {
-    id: 'ai-lab',
-    icon: 'Sparkles',
-    title: 'AI Lab',
-    label: 'Your experiment space',
-    description:
-      'Try answers, tweak phrasing, and compare versions side by side before the real exam.',
-    bullets: [
-      'Writing + Speaking pipelines',
-      '“Compare Before / After” mode',
-      'Future: cross-attempt insights',
-    ],
-    tag: 'Always-on coach',
-  },
-  {
-    id: 'analytics',
-    icon: 'PieChart',
-    title: 'Analytics & streaks',
-    label: 'Progress, not vibes',
-    description:
-      'Band trajectory, time on task, accuracy by question type and meaningful streaks.',
-    bullets: [
-      'Band curve across modules',
-      'Time spent vs. results',
-      'Streaks focused on real study, not taps',
-    ],
-    tag: 'For serious prep',
-  },
-];
+const modules = getDashboardModuleCards();
 
 const ModulesOverview: React.FC = () => {
   return (

--- a/lib/modules/registry.ts
+++ b/lib/modules/registry.ts
@@ -1,0 +1,286 @@
+import type * as Lucide from 'lucide-react';
+
+export type ModuleIconName = keyof typeof Lucide;
+
+export const MODULE_CAPABILITIES = [
+  'learning-content',
+  'skill-drills',
+  'full-mocks',
+  'ai-feedback',
+  'progress-analytics',
+  'streaks-gamification',
+] as const;
+
+export type ModuleCapabilityKey = (typeof MODULE_CAPABILITIES)[number];
+
+export type ModuleRegistryEntry = {
+  id: string;
+  label: string;
+  icon: ModuleIconName;
+  baseRoute: `/${string}`;
+  capabilityKey?: ModuleCapabilityKey;
+};
+
+export const moduleRegistry = {
+  learning: {
+    id: 'learning',
+    label: 'Learning Hub',
+    icon: 'BookOpenCheck',
+    baseRoute: '/learning',
+    capabilityKey: 'learning-content',
+  },
+  'skill-practice': {
+    id: 'skill-practice',
+    label: 'Skill Practice Arena',
+    icon: 'Edit3',
+    baseRoute: '/mock',
+    capabilityKey: 'skill-drills',
+  },
+  mock: {
+    id: 'mock',
+    label: 'Full Mock Tests',
+    icon: 'Timer',
+    baseRoute: '/mock',
+    capabilityKey: 'full-mocks',
+  },
+  'ai-lab': {
+    id: 'ai-lab',
+    label: 'AI Lab',
+    icon: 'Sparkles',
+    baseRoute: '/ai',
+    capabilityKey: 'ai-feedback',
+  },
+  analytics: {
+    id: 'analytics',
+    label: 'Progress & Analytics',
+    icon: 'PieChart',
+    baseRoute: '/progress',
+    capabilityKey: 'progress-analytics',
+  },
+  gamification: {
+    id: 'gamification',
+    label: 'Gamification & Streaks',
+    icon: 'Trophy',
+    baseRoute: '/dashboard',
+    capabilityKey: 'streaks-gamification',
+  },
+  listening: {
+    id: 'listening',
+    label: 'Listening',
+    icon: 'Headphones',
+    baseRoute: '/practice/listening',
+  },
+  reading: {
+    id: 'reading',
+    label: 'Reading',
+    icon: 'FileText',
+    baseRoute: '/practice/reading',
+  },
+  writing: {
+    id: 'writing',
+    label: 'Writing',
+    icon: 'PenSquare',
+    baseRoute: '/practice/writing',
+  },
+  speaking: {
+    id: 'speaking',
+    label: 'Speaking',
+    icon: 'Mic2',
+    baseRoute: '/practice/speaking',
+  },
+} as const satisfies Record<string, ModuleRegistryEntry>;
+
+export type ModuleId = keyof typeof moduleRegistry;
+
+const selectModules = <T>(
+  defs: ReadonlyArray<{ id: ModuleId } & T>,
+): Array<
+  {
+    id: ModuleId;
+    title: string;
+    icon: ModuleIconName;
+    href: `/${string}`;
+    capabilityKey?: ModuleCapabilityKey;
+  } & T
+> => {
+  return defs.map(({ id, ...rest }) => {
+    const module = moduleRegistry[id];
+    return {
+      id,
+      title: module.label,
+      icon: module.icon,
+      href: module.baseRoute,
+      capabilityKey: module.capabilityKey,
+      ...rest,
+    };
+  });
+};
+
+export type MarketingModuleCard = {
+  id: ModuleId;
+  title: string;
+  icon: ModuleIconName;
+  href: `/${string}`;
+  status: string;
+  statusTone: 'success' | 'accent' | 'info';
+  description: string;
+  bullets: string[];
+  capabilityKey?: ModuleCapabilityKey;
+};
+
+export const getMarketingModuleCards = (): MarketingModuleCard[] =>
+  selectModules([
+    {
+      id: 'learning',
+      status: 'Live',
+      statusTone: 'success',
+      description:
+        'Concept lessons, strategy guides, and grammar refreshers wired to your target band.',
+      bullets: [
+        'Academic & General Training coverage',
+        'Micro-lessons for all four skills',
+        'AI-personalised paths by band goal',
+      ],
+    },
+    {
+      id: 'skill-practice',
+      status: 'Live',
+      statusTone: 'accent',
+      description:
+        'Focused listening, reading, writing, and speaking practice mapped to real exam sections.',
+      bullets: [
+        'Dedicated hubs for all four skills',
+        'Drills, reviews, and full-section flows',
+        'Daily practice loops with saved progress',
+      ],
+    },
+    {
+      id: 'mock',
+      status: 'Expanded',
+      statusTone: 'success',
+      description:
+        'Complete mock ecosystem with reading, listening, speaking, and writing exam simulations.',
+      bullets: [
+        'Section-based mocks and full exam tracks',
+        'Attempt history, review pages, and results',
+        'Analytics for speed, accuracy, and mastery',
+      ],
+    },
+    {
+      id: 'ai-lab',
+      status: 'Core',
+      statusTone: 'accent',
+      description: 'Where AI Coach, Study Buddy, and Mistakes Book live together.',
+      bullets: [
+        'Task 1 & 2 band feedback',
+        'Speaking insights from audio',
+        'Compare “Before vs After” edits',
+      ],
+    },
+    {
+      id: 'analytics',
+      status: 'Live',
+      statusTone: 'info',
+      description: 'Unified tracking across attempts, streaks, and skill-level improvement signals.',
+      bullets: [
+        'Band trajectory and forecast signals',
+        'Question-type and section diagnostics',
+        'Streak + momentum visibility',
+      ],
+    },
+    {
+      id: 'gamification',
+      status: 'Live',
+      statusTone: 'success',
+      description: 'Daily streaks, weekly challenges, and quiet competition.',
+      bullets: ['Daily streak shields', 'Weekly IELTS challenges', 'Badges for consistency'],
+    },
+  ]);
+
+export type DashboardModuleCard = {
+  id: ModuleId;
+  title: string;
+  icon: ModuleIconName;
+  href: `/${string}`;
+  label: string;
+  description: string;
+  bullets: string[];
+  tag?: string;
+  capabilityKey?: ModuleCapabilityKey;
+};
+
+export const getDashboardModuleCards = (): DashboardModuleCard[] =>
+  selectModules([
+    {
+      id: 'listening',
+      label: 'Audio-first drills',
+      description:
+        'Exam-style recordings with question sets that train both speed and accuracy.',
+      bullets: [
+        'Short & full-length recordings',
+        'Question types mirrored from real tests',
+        'Future: accent diversity & playlists',
+      ],
+      tag: 'Core module',
+    },
+    {
+      id: 'reading',
+      label: 'Passages & item types',
+      description:
+        'Skim, scan and solve under time pressure — with explanations that don’t waste time.',
+      bullets: [
+        'True/False/Not Given, MCQs, matching',
+        'Guided review of wrong answers',
+        'Future: difficulty ladder per band',
+      ],
+      tag: 'Core module',
+    },
+    {
+      id: 'writing',
+      label: 'Task 1 & Task 2',
+      description:
+        'Structure, coherence, lexical resource and grammar checked with AI and clear tips.',
+      bullets: [
+        'Band-style rubric breakdown',
+        'Before / After comparisons in AI Lab',
+        'Future: teacher plug-in for manual review',
+      ],
+      tag: 'AI-heavy',
+    },
+    {
+      id: 'speaking',
+      label: 'Record & review',
+      description:
+        'Prompt packs for Parts 1, 2 and 3 with AI insights on fluency, vocab and pronunciation.',
+      bullets: [
+        'Record directly in browser',
+        'Part-wise scoring hints',
+        'Future: conversation-style dialogues',
+      ],
+      tag: 'AI-heavy',
+    },
+    {
+      id: 'ai-lab',
+      label: 'Your experiment space',
+      description:
+        'Try answers, tweak phrasing, and compare versions side by side before the real exam.',
+      bullets: [
+        'Writing + Speaking pipelines',
+        '“Compare Before / After” mode',
+        'Future: cross-attempt insights',
+      ],
+      tag: 'Always-on coach',
+    },
+    {
+      id: 'analytics',
+      label: 'Progress, not vibes',
+      description:
+        'Band trajectory, time on task, accuracy by question type and meaningful streaks.',
+      bullets: [
+        'Band curve across modules',
+        'Time spent vs. results',
+        'Streaks focused on real study, not taps',
+      ],
+      tag: 'For serious prep',
+    },
+  ]);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,94 +8,10 @@ import { Card } from '@/components/design-system/Card';
 import { Button } from '@/components/design-system/Button';
 import { Badge } from '@/components/design-system/Badge';
 import Icon, { type IconName } from '@/components/design-system/Icon';
+import { getMarketingModuleCards } from '@/lib/modules/registry';
 import { getPlanPricing, getStandardPlanName } from '@/lib/subscription';
 
-const modules = [
-  {
-    id: 'learning',
-    icon: 'BookOpenCheck' as IconName,
-    title: 'Learning Hub',
-    status: 'Live',
-    statusTone: 'success' as const,
-    description: 'Concept lessons, strategy guides, and grammar refreshers wired to your target band.',
-    bullets: [
-      'Academic & General Training coverage',
-      'Micro-lessons for all four skills',
-      'AI-personalised paths by band goal',
-    ],
-    href: '/learning',
-  },
-  {
-    id: 'skill-practice',
-    icon: 'Edit3' as IconName,
-    title: 'Skill Practice Arena',
-    status: 'Live',
-    statusTone: 'accent' as const,
-    description: 'Focused listening, reading, writing, and speaking practice mapped to real exam sections.',
-    bullets: [
-      'Dedicated hubs for all four skills',
-      'Drills, reviews, and full-section flows',
-      'Daily practice loops with saved progress',
-    ],
-    href: '/mock',
-  },
-  {
-    id: 'mock',
-    icon: 'Timer' as IconName,
-    title: 'Full Mock Tests',
-    status: 'Expanded',
-    statusTone: 'success' as const,
-    description: 'Complete mock ecosystem with reading, listening, speaking, and writing exam simulations.',
-    bullets: [
-      'Section-based mocks and full exam tracks',
-      'Attempt history, review pages, and results',
-      'Analytics for speed, accuracy, and mastery',
-    ],
-    href: '/mock',
-  },
-  {
-    id: 'ai-lab',
-    icon: 'Sparkles' as IconName,
-    title: 'AI Lab',
-    status: 'Core',
-    statusTone: 'accent' as const,
-    description: 'Where AI Coach, Study Buddy, and Mistakes Book live together.',
-    bullets: [
-      'Task 1 & 2 band feedback',
-      'Speaking insights from audio',
-      'Compare “Before vs After” edits',
-    ],
-    href: '/ai',
-  },
-  {
-    id: 'analytics',
-    icon: 'PieChart' as IconName,
-    title: 'Progress & Analytics',
-    status: 'Live',
-    statusTone: 'info' as const,
-    description: 'Unified tracking across attempts, streaks, and skill-level improvement signals.',
-    bullets: [
-      'Band trajectory and forecast signals',
-      'Question-type and section diagnostics',
-      'Streak + momentum visibility',
-    ],
-    href: '/progress',
-  },
-  {
-    id: 'gamification',
-    icon: 'Trophy' as IconName,
-    title: 'Gamification & Streaks',
-    status: 'Live',
-    statusTone: 'success' as const,
-    description: 'Daily streaks, weekly challenges, and quiet competition.',
-    bullets: [
-      'Daily streak shields',
-      'Weekly IELTS challenges',
-      'Badges for consistency',
-    ],
-    href: '/dashboard',
-  },
-];
+const modules = getMarketingModuleCards();
 
 const quickLinks = [
   {

--- a/tests/lib/modules-registry.test.ts
+++ b/tests/lib/modules-registry.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  getDashboardModuleCards,
+  getMarketingModuleCards,
+  moduleRegistry,
+} from '../../lib/modules/registry';
+
+const ROOT = process.cwd();
+
+const routeExists = (route: string): boolean => {
+  const clean = route.replace(/\?.*$/, '').replace(/\/$/, '');
+  if (clean === '' || clean === '/') return true;
+
+  const normalized = clean.replace(/^\//, '');
+  const candidates = [
+    path.join(ROOT, 'pages', `${normalized}.tsx`),
+    path.join(ROOT, 'pages', normalized, 'index.tsx'),
+  ];
+
+  return candidates.some((file) => fs.existsSync(file));
+};
+
+const allCards = [...getMarketingModuleCards(), ...getDashboardModuleCards()];
+
+assert.ok(allCards.length > 0, 'Expected module cards to be rendered from registry-backed helpers.');
+
+for (const card of allCards) {
+  const entry = moduleRegistry[card.id];
+  assert.ok(entry, `Module card "${card.id}" is missing from moduleRegistry.`);
+  assert.equal(card.title, entry.label, `Module card "${card.id}" title should come from registry.`);
+  assert.equal(card.icon, entry.icon, `Module card "${card.id}" icon should come from registry.`);
+  assert.equal(card.href, entry.baseRoute, `Module card "${card.id}" href should map to baseRoute.`);
+  assert.equal(routeExists(card.href), true, `Route "${card.href}" for "${card.id}" does not exist in pages/.`);
+}
+
+console.log('module registry cards map cleanly to registry entries and existing routes');


### PR DESCRIPTION
### Motivation

- Centralise canonical module metadata (ids, labels, icons, routes, optional capability keys) to avoid duplicated arrays scattered across pages and components.
- Provide per-view transforms (marketing vs dashboard) so each page can map shared metadata into its UI shape rather than copy-pasting arrays.
- Enforce compile-time safety for module ids and icon names so unknown ids/icons fail to compile and downstream code remains consistent.

### Description

- Added a new registry at `lib/modules/registry.ts` that declares `moduleRegistry` and typed aliases including `ModuleIconName`, `ModuleId`, and `ModuleCapabilityKey` and uses `satisfies Record<string, ModuleRegistryEntry>` for stronger typing.
- Implemented transform helpers `getMarketingModuleCards()` and `getDashboardModuleCards()` plus a `selectModules` mapper so pages consume typed card shapes derived from the registry.
- Refactored `pages/index.tsx` and `components/sections/ModulesOverview.tsx` to call `getMarketingModuleCards()` and `getDashboardModuleCards()` respectively instead of local hardcoded arrays.
- Added `tests/lib/modules-registry.test.ts` which validates that all rendered module cards map to entries in `moduleRegistry` and that their `href` corresponds to an existing `pages/` route.

### Testing

- Ran `git diff --check` which produced no whitespace or diff errors.
- Created and committed the changes and the test file, but executing the new test with `npx tsx tests/lib/modules-registry.test.ts` failed due to the environment being unable to fetch the `tsx` binary from the npm registry (`403 Forbidden`).
- Attempts to run `./node_modules/.bin/tsx` and `npm run test` also failed because the `tsx` binary / node_modules are not installed in this environment. 
- A Playwright screenshot attempt against `http://127.0.0.1:3000` failed with `ERR_EMPTY_RESPONSE` because no local app server was running to validate the rendered UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f5f915948320a63d6877ac71aa95)