### PR TITLE
Make dashboard CTA link directly to /dashboard

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,6 +51,7 @@ type LandingPageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 const LandingPage: React.FC<LandingPageProps> = ({ homeOverview }) => {
   const [showStickyCta, setShowStickyCta] = useState(false);
   const hasPayload = Boolean(homeOverview);
+  const dashboardHref = '/dashboard';
   const modules = homeOverview?.modules ?? [];
   const quickLinks = homeOverview?.quickLinks ?? [];
   const releaseHighlights = homeOverview?.releaseHighlights ?? [];
@@ -124,13 +125,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ homeOverview }) => {
                     <Link href="/signup">Start free practice</Link>
                   </Button>
                   <Button asChild variant="secondary" size="lg" className="rounded-ds-2xl px-6">
-                    <Link
-                      href={
-                        isAuthed
-                          ? dashboardHref
-                          : `/login?next=${encodeURIComponent(dashboardHref)}`
-                      }
-                    >
+                    <Link href={dashboardHref}>
                       View my dashboard
                     </Link>
                   </Button>


### PR DESCRIPTION
### Motivation
- Simplify the landing page CTA so the "View my dashboard" button consistently targets the dashboard route instead of conditionally linking to a login redirect.

### Description
- Add a `dashboardHref` constant and change the `View my dashboard` `Link` to use a static `href={dashboardHref}`, removing the previous `isAuthed` conditional and login `next` redirect.

### Testing
- Ran TypeScript typecheck (`tsc --noEmit`) and lint (`yarn lint`), and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f4dc30f483208308282866b0dd38)