### PR TITLE
Use static login redirect for dashboard CTA on landing page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -124,13 +124,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ homeOverview }) => {
                     <Link href="/signup">Start free practice</Link>
                   </Button>
                   <Button asChild variant="secondary" size="lg" className="rounded-ds-2xl px-6">
-                    <Link
-                      href={
-                        isAuthed
-                          ? dashboardHref
-                          : `/login?next=${encodeURIComponent(dashboardHref)}`
-                      }
-                    >
+                    <Link href="/login?next=%2Fdashboard">
                       View my dashboard
                     </Link>
                   </Button>


### PR DESCRIPTION
### Motivation
- Simplify the "View my dashboard" call-to-action by removing client-side conditional logic and ensuring the link always redirects to the login page with `next=/dashboard`.

### Description
- Replace the dynamic `Link` that depended on `isAuthed` and `dashboardHref` with a static `href="/login?next=%2Fdashboard"` in `pages/index.tsx`.

### Testing
- Ran `next build` to verify compilation and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f4dc30f483208308282866b0dd38)