### PR TITLE
Reduce duplicate auth-state requests from route guard

### DIFF
--- a/hooks/useRouteGuard.ts
+++ b/hooks/useRouteGuard.ts
@@ -2,8 +2,9 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
-import { supabase } from '@/lib/supabaseClient'; // Replaced supabaseBrowser
 import { useLocale } from '@/lib/locale';
+import { useUserContext } from '@/context/UserContext';
+import { supabase } from '@/lib/supabaseClient';
 import {
   isGuestOnlyRoute,
   isPublicRoute,
@@ -24,6 +25,7 @@ function safeNext(next?: string | string[] | null) {
 export function useRouteGuard() {
   const router = useRouter();
   const { setLocale } = useLocale();
+  const { user, loading } = useUserContext();
   const pathname = router.pathname;
   const path = router.asPath || pathname;
 
@@ -32,6 +34,7 @@ export function useRouteGuard() {
 
   useEffect(() => {
     if (!router.isReady) return;
+    if (loading) return;
 
     // ⭐ SPECIAL CASE: password reset page – allow without session (the token is in the hash)
     if (pathname === '/update-password') {
@@ -43,14 +46,7 @@ export function useRouteGuard() {
 
     (async () => {
       try {
-        const {
-          data: { session },
-          error,
-        } = await supabase.auth.getSession();
-        if (!mounted) return;
-
-        const authed = !!session && !error;
-        const user = session?.user ?? null;
+        const authed = !!user;
         const role: AppRole | null = getUserRole(user);
 
         // Public routes never redirect (but we can still hydrate locale)
@@ -196,7 +192,7 @@ export function useRouteGuard() {
     return () => {
       mounted = false;
     };
-  }, [router.isReady, router.pathname, router.asPath, path, setLocale]);
+  }, [router.isReady, router.pathname, router.asPath, path, setLocale, user, loading]);
 
   return { isChecking };
 }


### PR DESCRIPTION
### Motivation
- Vercel logs showed bursts of repeated `GET /api/internal/auth/state` calls because the route guard fetched the Supabase session on each run; the goal is to eliminate that redundant polling by reusing already-hydrated app auth state.

### Description
- Updated `hooks/useRouteGuard.ts` to consume `user` and `loading` from `UserContext` instead of calling `supabase.auth.getSession()` directly.
- Added a loading gate (`if (loading) return;`) so the guard waits for context hydration and avoid early extra requests, and included `user` and `loading` in the effect dependencies.
- Kept existing guard behavior intact (locale hydration, guest/public/protected redirects, role checks, and duplicate-redirect protection).
- Change is scoped to `hooks/useRouteGuard.ts` and avoids introducing new dependencies or API surface changes.

### Testing
- Ran `npx eslint hooks/useRouteGuard.ts`, which failed in this environment due to missing local ESLint runtime packages and resolver errors.
- Ran `npm run lint -- --file hooks/useRouteGuard.ts`, which failed because the `next` binary is not available in the execution environment.
- No automated unit or integration tests were executed here; the change was validated by static review of the diff and local code inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b141a00da08320a5aa9f52fd53bd3c)