### PR TITLE
Sanitize and normalize auth `next` redirects to avoid encoded Welcome 404

### DIFF
--- a/components/auth/AuthOptions.tsx
+++ b/components/auth/AuthOptions.tsx
@@ -16,6 +16,7 @@ import {
 import { SectionLabel } from '@/components/design-system/SectionLabel';
 import { supabase } from '@/lib/supabaseClient';
 import { destinationByRole } from '@/lib/routeAccess';
+import { sanitizeInternalNextPath } from '@/lib/authNextPath';
 
 type AuthMode = 'login' | 'signup';
 type OAuthProvider = 'apple' | 'google' | 'facebook';
@@ -32,8 +33,7 @@ export default function AuthOptions({ mode }: AuthOptionsProps) {
   const [selectedRole, setSelectedRole] = useState<string | null>(null);
 
   const ref = mode === 'signup' && typeof router.query.ref === 'string' ? router.query.ref : '';
-  const rawNext = typeof router.query.next === 'string' ? router.query.next : '';
-  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '';
+  const next = sanitizeInternalNextPath(router.query.next) ?? '';
   const actionVerb = mode === 'login' ? 'Sign in' : 'Sign up';
   const sharedQS = useMemo(() => {
     const qp = new URLSearchParams();

--- a/lib/authNextPath.ts
+++ b/lib/authNextPath.ts
@@ -1,0 +1,39 @@
+const CANONICAL_CASE_PATHS = new Map<string, string>([
+  ['/welcome', '/welcome'],
+  ['/onboarding/welcome', '/onboarding/welcome'],
+  ['/dashboard', '/dashboard'],
+  ['/login', '/login'],
+  ['/signup', '/signup'],
+]);
+
+function decodePossiblyEncodedPath(raw: string): string {
+  let value = raw.trim();
+  for (let i = 0; i < 2; i += 1) {
+    if (!value.includes('%')) break;
+    try {
+      const decoded = decodeURIComponent(value);
+      if (decoded === value) break;
+      value = decoded;
+    } catch {
+      break;
+    }
+  }
+  return value;
+}
+
+export function sanitizeInternalNextPath(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+
+  const decoded = decodePossiblyEncodedPath(raw);
+  if (!decoded.startsWith('/') || decoded.startsWith('//')) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(decoded, 'http://localhost');
+  } catch {
+    return null;
+  }
+
+  const pathname = CANONICAL_CASE_PATHS.get(parsed.pathname.toLowerCase()) ?? parsed.pathname;
+  return `${pathname}${parsed.search}${parsed.hash}`;
+}

--- a/pages/auth/confirm.tsx
+++ b/pages/auth/confirm.tsx
@@ -13,6 +13,7 @@ import {
   verifyOtpWithTokenHash,
 } from '@/lib/auth';
 import { LOGIN, withQuery } from '@/lib/constants/routes';
+import { sanitizeInternalNextPath } from '@/lib/authNextPath';
 
 function resolveDestination(role: string, onboardingDone: boolean, redirectAfter: string | null) {
   if (redirectAfter) return redirectAfter;
@@ -43,7 +44,7 @@ export default function AuthConfirmPage() {
       const tokenHash = typeof token_hash === 'string' ? token_hash : null;
       const otpType = typeof type === 'string' ? type : 'signup';
       const verificationCode = typeof code === 'string' ? code : null;
-      const redirectAfter = typeof next === 'string' && next.startsWith('/') ? next : null;
+      const redirectAfter = sanitizeInternalNextPath(next);
 
       if (!tokenHash && !verificationCode) {
         setStatus('error');

--- a/pages/auth/verify.tsx
+++ b/pages/auth/verify.tsx
@@ -16,6 +16,7 @@ import {
   setClientSession,
 } from '@/lib/auth';
 import { LOGIN, ONBOARDING, VERIFY_EMAIL } from '@/lib/constants/routes';
+import { sanitizeInternalNextPath } from '@/lib/authNextPath';
 import { withQuery } from '@/lib/constants/routes';
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
@@ -29,7 +30,7 @@ export default function VerifyPage() {
   const email = typeof query.email === 'string' ? query.email : null;
   const ref = typeof query.ref === 'string' ? query.ref : '';
   const role = typeof query.role === 'string' ? query.role : '';
-  const nextParam = typeof query.next === 'string' ? query.next : '';
+  const nextParam = sanitizeInternalNextPath(query.next) ?? '';
 
   // DEFAULT POST-VERIFY LANDING → ONBOARDING
   const welcomeHref = React.useMemo(() => {
@@ -40,7 +41,7 @@ export default function VerifyPage() {
   }, [ref, role]);
 
   const redirectHref = React.useMemo(() => {
-    if (nextParam && nextParam.startsWith('/')) {
+    if (nextParam) {
       return nextParam;
     }
     return welcomeHref;

--- a/pages/login/email.tsx
+++ b/pages/login/email.tsx
@@ -11,6 +11,7 @@ import { Alert } from '@/components/design-system/Alert';
 import { destinationByRole } from '@/lib/routeAccess';
 import { isValidEmail } from '@/utils/validation';
 import useEmailLoginMFA from '@/hooks/useEmailLoginMFA';
+import { sanitizeInternalNextPath } from '@/lib/authNextPath';
 import { useUserContext } from '@/context/UserContext';
 import {
   getCurrentUser,
@@ -49,10 +50,9 @@ export default function LoginWithEmail() {
 
 
   const resolveTarget = React.useCallback((currentUser: { id?: string } | null) => {
-    const rawNext = typeof router.query.next === 'string' ? router.query.next : '';
-    const safeNext = rawNext && rawNext.startsWith('/') && rawNext !== '/login' ? rawNext : null;
+    const safeNext = sanitizeInternalNextPath(router.query.next);
     const fallback = currentUser ? destinationByRole(currentUser as any) : '/dashboard';
-    return safeNext ?? fallback;
+    return safeNext && safeNext !== '/login' ? safeNext : fallback;
   }, [router.query.next]);
 
   const navigateAfterAuth = React.useCallback(async (currentUser: { id?: string } | null) => {

--- a/pages/signup/email.tsx
+++ b/pages/signup/email.tsx
@@ -13,13 +13,13 @@ import { isValidEmail } from '@/utils/validation';
 import { ONBOARDING, LOGIN, SIGNUP, TERMS, PRIVACY } from '@/lib/constants/routes';
 import { withQuery } from '@/lib/constants/routes';
 import { buildPkcePair, resendSignupEmail, sendVerificationCode, submitPkceSignup } from '@/lib/auth';
+import { sanitizeInternalNextPath } from '@/lib/authNextPath';
 
 export default function SignUpWithEmail() {
   const router = useRouter();
   const role = typeof router.query?.role === 'string' ? (router.query.role as string) : '';
   const ref = typeof router.query?.ref === 'string' ? (router.query.ref as string) : '';
-  const rawNext = typeof router.query?.next === 'string' ? (router.query.next as string) : '';
-  const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '';
+  const next = sanitizeInternalNextPath(router.query?.next) ?? '';
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/pages/signup/verify.tsx
+++ b/pages/signup/verify.tsx
@@ -17,6 +17,7 @@ import {
   sendVerificationCode,
   verifyEmailOtp,
 } from '@/lib/auth';
+import { sanitizeInternalNextPath } from '@/lib/authNextPath';
 
 export default function VerifyEmailPage() {
   const router = useRouter();
@@ -24,8 +25,7 @@ export default function VerifyEmailPage() {
   const email = typeof router.query.email === 'string' ? router.query.email : '';
   const role = typeof router.query.role === 'string' ? router.query.role : '';
   const ref = typeof router.query.ref === 'string' ? router.query.ref : '';
-  const rawNext = typeof router.query.next === 'string' ? router.query.next : '';
-  const nextParam = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '';
+  const nextParam = sanitizeInternalNextPath(router.query.next) ?? '';
 
   const next = useMemo(() => {
     if (nextParam) return nextParam;

--- a/tests/lib/authNextPath.test.ts
+++ b/tests/lib/authNextPath.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeInternalNextPath } from '@/lib/authNextPath';
+
+describe('sanitizeInternalNextPath', () => {
+  it('accepts normal internal paths', () => {
+    expect(sanitizeInternalNextPath('/dashboard?tab=overview')).toBe('/dashboard?tab=overview');
+  });
+
+  it('rejects external and protocol-relative paths', () => {
+    expect(sanitizeInternalNextPath('https://evil.com')).toBeNull();
+    expect(sanitizeInternalNextPath('//evil.com')).toBeNull();
+  });
+
+  it('decodes encoded next values and normalizes known route casing', () => {
+    expect(sanitizeInternalNextPath('/Welcome%3Frole=Student')).toBe('/welcome?role=Student');
+    expect(sanitizeInternalNextPath('%2FWelcome%3Frole%3DStudent')).toBe('/welcome?role=Student');
+  });
+});


### PR DESCRIPTION
### Motivation
- Users arriving from verification/OAuth flows could carry an encoded and/or wrong-cased `next` value like `/Welcome%3Frole=Student` which was treated literally and caused a 404 when redirected to.
- The goal is to robustly validate and normalize internal `next` paths before performing client-side redirects so onboarding/login flows land on the correct pages.

### Description
- Added a shared helper `sanitizeInternalNextPath` (`lib/authNextPath.ts`) that safely decodes up to two layers of percent-encoding, rejects external or protocol-relative URLs, and canonicalizes known auth destinations (e.g. `/welcome`, `/onboarding/welcome`) to their canonical casing.
- Wired `sanitizeInternalNextPath` into all auth entry points that consume `next`: OAuth/signup options (`components/auth/AuthOptions.tsx`), signup email (`pages/signup/email.tsx`), signup verify (`pages/signup/verify.tsx`), auth verify (`pages/auth/verify.tsx`), auth confirm (`pages/auth/confirm.tsx`), and login email (`pages/login/email.tsx`) so redirects use the sanitized path.
- Added a unit test file `tests/lib/authNextPath.test.ts` covering normal internal paths, rejecting external/protocol-relative paths, and the specific encoded/cased failing case (`/Welcome%3Frole=Student`).

### Testing
- Added unit tests `tests/lib/authNextPath.test.ts` that exercise decoding, normalization and rejection rules, but running `vitest` in this environment failed because the `vitest` binary is not available (test run aborted).
- Attempted to run `next lint` for the changed files but the `next` binary was not available in the container so linting could not be executed.
- All code changes and tests were committed; automated test and lint runs should succeed in CI where project dependencies (`vitest`, `next`) are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8746a58608328bb9ebfa73fc41745)