### PR TITLE
Remove global Quick Access widget and merge links into Need Help panels

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -8,7 +8,6 @@ import dynamic from 'next/dynamic';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import FooterMini from '@/components/navigation/FooterMini';
-import QuickAccessWidget from '@/components/navigation/QuickAccessWidget';
 import HeaderMini from '@/components/navigation/HeaderMini';
 
 const BottomNav = dynamic(
@@ -66,7 +65,6 @@ export default function Layout({ children }: LayoutProps) {
 
       {showBottomNav && <BottomNav />}
 
-      <QuickAccessWidget />
     </>
   );
 }

--- a/components/activity/QuickActions.tsx
+++ b/components/activity/QuickActions.tsx
@@ -100,6 +100,11 @@ export default function QuickActions({ stats, onTaskCreate, onViewAllTasks }: Qu
       ]}
       supportTitle="Need help?"
       supportDescription="Get support from the team if something blocks your progress."
+      supportLinks={[
+        { id: 'daily-task', label: 'Daily task', href: '/dashboard#tasks', ariaLabel: 'Open daily task' },
+        { id: 'retry-mistakes', label: 'Retry mistakes', href: '/mistakes', ariaLabel: 'Retry mistakes' },
+        { id: 'weekly-challenge', label: 'Weekly challenge', href: '/challenge', ariaLabel: 'Join weekly challenge' },
+      ]}
       supportPrimaryCta={{ label: 'Contact support', href: '/help', variant: 'secondary' }}
       supportSecondaryCta={{ label: 'Open AI assistant', href: '/ai', variant: 'ghost' }}
     />

--- a/components/shared/ActionSupportPanel.tsx
+++ b/components/shared/ActionSupportPanel.tsx
@@ -23,6 +23,13 @@ type SupportCta = {
   ariaLabel?: string;
 };
 
+type SupportLink = {
+  id: string;
+  label: string;
+  href: string;
+  ariaLabel?: string;
+};
+
 interface ActionSupportPanelProps {
   title?: string;
   subtitle?: string;
@@ -31,6 +38,7 @@ interface ActionSupportPanelProps {
   supportDescription?: string;
   supportPrimaryCta?: SupportCta;
   supportSecondaryCta?: SupportCta;
+  supportLinks?: SupportLink[];
   className?: string;
   actionsColumns?: 1 | 2 | 3;
 }
@@ -85,6 +93,7 @@ export default function ActionSupportPanel({
   supportDescription,
   supportPrimaryCta,
   supportSecondaryCta,
+  supportLinks = [],
   className,
   actionsColumns = 2,
 }: ActionSupportPanelProps) {
@@ -105,10 +114,28 @@ export default function ActionSupportPanel({
         </div>
       ) : null}
 
-      {(supportPrimaryCta || supportSecondaryCta || supportDescription) && (
+      {(supportPrimaryCta || supportSecondaryCta || supportDescription || supportLinks.length > 0) && (
         <div className={`mt-5 rounded-xl border border-border/70 bg-muted/30 p-4 ${actions.length > 0 ? 'border-t' : ''}`}>
           <h4 className="text-sm font-semibold">{supportTitle}</h4>
           {supportDescription ? <p className="mt-1 text-xs text-muted-foreground">{supportDescription}</p> : null}
+
+          {supportLinks.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {supportLinks.map((link) => (
+                <Button
+                  key={link.id}
+                  variant="outline"
+                  size="sm"
+                  href={link.href}
+                  aria-label={link.ariaLabel}
+                  className="w-full sm:w-auto"
+                >
+                  {link.label}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+
           <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
             {supportPrimaryCta ? (
               <Button

--- a/pages/onboarding/welcome/index.tsx
+++ b/pages/onboarding/welcome/index.tsx
@@ -506,6 +506,11 @@ export default function WelcomePage() {
             actions={[]}
             supportTitle="Need help?"
             supportDescription="Ask the community or talk to our AI assistant."
+            supportLinks={[
+              { id: 'daily-task', label: 'Daily task', href: '/dashboard#tasks', ariaLabel: 'Open daily task' },
+              { id: 'retry-mistakes', label: 'Retry mistakes', href: '/mistakes', ariaLabel: 'Retry mistakes' },
+              { id: 'weekly-challenge', label: 'Weekly challenge', href: '/challenge', ariaLabel: 'Join weekly challenge' },
+            ]}
             supportPrimaryCta={{ label: 'Visit Community', href: '/community', variant: 'secondary' }}
             supportSecondaryCta={{ label: 'Open AI Assistant', href: '/ai', variant: 'ghost' }}
           />


### PR DESCRIPTION
### Motivation
- The floating Quick Access widget was mounted globally and appeared on every page, creating duplication and naming drift with existing "Need help?" panels.
- The goal is to consolidate quick-access links into the shared support UI so support actions and quick links live in one consistent component.

### Description
- Stop rendering the floating widget by removing the `QuickAccessWidget` import and mount in `components/Layout.tsx` so the floating control no longer appears across pages.
- Add a new optional `supportLinks` prop and `SupportLink` type to `components/shared/ActionSupportPanel.tsx` and render those links inside the existing "Need help?" area.
- Wire the quick-link set (`Daily task`, `Retry mistakes`, `Weekly challenge`) into the Need Help sections used by `components/activity/QuickActions.tsx` and `pages/onboarding/welcome/index.tsx` so the links are accessible from those panels.
- Leave the original `components/navigation/QuickAccessWidget.tsx` file in the repo (it is no longer mounted by the main layout).

### Testing
- Attempted to run lint with `npm run lint -- --file components/Layout.tsx --file components/shared/ActionSupportPanel.tsx --file components/activity/QuickActions.tsx --file pages/onboarding/welcome/index.tsx`, which failed in this environment because `next` is not installed (`sh: 1: next: not found`).
- Attempted a Playwright check to load `http://127.0.0.1:3000` and capture a screenshot to validate the floating widget removal, but the request failed because the app server was not running (`ERR_EMPTY_RESPONSE`).
- No other automated tests were run in this environment; code changes are small and limited to rendering and props additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b875a4dcc083288130d4965c364d0f)