### PR TITLE
Redirect password reset flow to email sign-in

### DIFF
--- a/pages/auth/reset.tsx
+++ b/pages/auth/reset.tsx
@@ -10,9 +10,8 @@ import { Badge } from '@/components/design-system/Badge';
 import { MailIcon, SmsIcon } from '@/components/design-system/icons';
 import { getCurrentSession, isPasswordReused, updatePassword, verifyRecoveryOtp } from '@/lib/auth';
 import { Input } from '@/components/design-system/Input';
-import { LOGIN, FORGOT_PASSWORD } from '@/lib/constants/routes';
+import { FORGOT_PASSWORD, withQuery } from '@/lib/constants/routes';
 import { getSelectedRole, setSelectedRole } from '@/lib/storage';
-import { withQuery } from '@/lib/constants/routes';
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -23,6 +22,11 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 }
 function cls(...xs: Array<string | false | null | undefined>) {
   return xs.filter(Boolean).join(' ');
+}
+
+function buildEmailLoginPath(role: string | null) {
+  const base = '/login/email';
+  return role ? withQuery(base, { role }) : base;
 }
 
 export default function ResetPasswordPage() {
@@ -112,8 +116,8 @@ export default function ResetPasswordPage() {
       const { error } = await updatePassword(password);
       if (error) throw error;
 
-      setOk('Password updated. Redirecting to sign in…');
-      const next = selectedRole ? withQuery(LOGIN, { role: selectedRole }) : LOGIN;
+      setOk('Password updated. Redirecting to email sign in…');
+      const next = buildEmailLoginPath(selectedRole);
       setTimeout(() => router.replace(next), 900);
     } catch (e: any) {
       console.error('Password update error:', e);
@@ -217,10 +221,10 @@ export default function ResetPasswordPage() {
           <div className="text-small text-mutedText">
             Back to{' '}
             <Link
-              href={selectedRole ? withQuery(LOGIN, { role: selectedRole }) : LOGIN}
+              href={buildEmailLoginPath(selectedRole)}
               className="underline"
             >
-              Sign in
+              Email sign in
             </Link>
           </div>
         </form>

--- a/pages/update-password.tsx
+++ b/pages/update-password.tsx
@@ -106,7 +106,7 @@ export default function UpdatePassword() {
       }
 
       setSuccess(true);
-      setTimeout(() => router.push('/login'), 2000);
+      setTimeout(() => router.push('/login/email'), 2000);
     } catch (err: any) {
       setError('Network error: Failed to update password. Please try again.');
       setLoading(false);
@@ -143,7 +143,7 @@ export default function UpdatePassword() {
             <Link href="/forgot-password">Request new link</Link>
           </Button>
           <Button asChild variant="secondary" className="w-full">
-            <Link href="/login">Back to login</Link>
+            <Link href="/login/email">Back to email login</Link>
           </Button>
         </div>
       </AuthLayout>
@@ -209,7 +209,7 @@ export default function UpdatePassword() {
           </Button>
 
           <div className="text-xs text-muted text-center">
-            <Link href="/login" className="underline">Back to login</Link>
+            <Link href="/login/email" className="underline">Back to email login</Link>
           </div>
         </form>
       )}


### PR DESCRIPTION
### Motivation
- Users who reset their password via the emailed link were being taken to the login method selector instead of the direct email/password sign-in page, which is confusing and interrupts the flow.

### Description
- Added a `buildEmailLoginPath` helper in `pages/auth/reset.tsx` and changed the post-update redirect to point to `/login/email`, preserving `role` via `withQuery` when present.
- Updated the reset page copy and the "Back to" link to explicitly say `Email sign in` and link to the email login path in `pages/auth/reset.tsx`.
- Updated `pages/update-password.tsx` so the success redirect and back links go to `/login/email` instead of the login options selector.
- Adjusted imports to use `withQuery` where required to build URLs that keep query params.

### Testing
- Ran `npm run lint` which failed in this environment with `sh: 1: next: not found`, so linting could not complete.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5485c4e88832880d1bb02b4f2a655)